### PR TITLE
first pass at cleaning up attributes

### DIFF
--- a/Octokit.Tests.Conventions/ClientRouteTests.cs
+++ b/Octokit.Tests.Conventions/ClientRouteTests.cs
@@ -81,7 +81,6 @@ namespace Octokit.Tests.Conventions
                 .Assembly
                 .ExportedTypes
                 .Where(TypeExtensions.IsClientClass)
-                .Where(t => t != typeof(StatisticsClient)) // This convention doesn't apply to this one type.
                 .Where(t => t != typeof(GitHubClient))
                 .Select(type => new[] { type });
         }

--- a/Octokit/Clients/AssigneesClient.cs
+++ b/Octokit/Clients/AssigneesClient.cs
@@ -24,7 +24,7 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/assignees")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/assignees")]
         public Task<IReadOnlyList<User>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -49,7 +49,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">The options to change API's response.</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/assignees")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/assignees")]
         public Task<IReadOnlyList<User>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -82,7 +82,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="assignee">Username of the prospective assignee</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/assignees/{username}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/assignees/{username}")]
         public async Task<bool> CheckAssignee(string owner, string name, string assignee)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -108,7 +108,7 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <param name="assignees">List of names of assignees to add</param>
         /// <returns></returns>
-        [ManualRoute("POST", "/repos/{owner}/{name}/issues/{number}/assignees")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/issues/{number}/assignees")]
         public Task<Issue> AddAssignees(string owner, string name, int number, AssigneesUpdate assignees)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -126,7 +126,7 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <param name="assignees">List of assignees to remove</param>
         /// <returns></returns>
-        [ManualRoute("DELETE", "/repos/{owner}/{name}/issues/{number}/assignees")]
+        [ManualRoute("DELETE", "/repos/{owner}/{repo}/issues/{number}/assignees")]
         public Task<Issue> RemoveAssignees(string owner, string name, int number, AssigneesUpdate assignees)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/AuthorizationsClient.cs
+++ b/Octokit/Clients/AuthorizationsClient.cs
@@ -345,7 +345,7 @@ namespace Octokit
         /// <param name="clientId">Client Id of the OAuth application for the token</param>
         /// <param name="accessToken">The OAuth token to check</param>
         /// <returns>The valid <see cref="ApplicationAuthorization"/>.</returns>
-        [ManualRoute("POST", "/applications/{id}/token")]
+        [ManualRoute("POST", "/applications/{client_id}/token")]
         public Task<ApplicationAuthorization> CheckApplicationAuthentication(string clientId, string accessToken)
         {
             Ensure.ArgumentNotNullOrEmptyString(clientId, nameof(clientId));
@@ -370,7 +370,7 @@ namespace Octokit
         /// <param name="clientId">ClientID of the OAuth application for the token</param>
         /// <param name="accessToken">The OAuth token to reset</param>
         /// <returns>The valid <see cref="ApplicationAuthorization"/> with a new OAuth token</returns>
-        [ManualRoute("PATCH", "/applications/{id}/token")]
+        [ManualRoute("PATCH", "/applications/{client_id}/token")]
         public Task<ApplicationAuthorization> ResetApplicationAuthentication(string clientId, string accessToken)
         {
             Ensure.ArgumentNotNullOrEmptyString(clientId, nameof(clientId));
@@ -395,7 +395,7 @@ namespace Octokit
         /// <param name="clientId">ClientID of the OAuth application for the token</param>
         /// <param name="accessToken">The OAuth token to revoke</param>
         /// <returns>A <see cref="Task"/> for the request's execution.</returns>
-        [ManualRoute("DELETE", "/applications/{id}/token")]
+        [ManualRoute("DELETE", "/applications/{client_id}/token")]
         public Task RevokeApplicationAuthentication(string clientId, string accessToken)
         {
             Ensure.ArgumentNotNullOrEmptyString(clientId, nameof(clientId));

--- a/Octokit/Clients/BlobsClient.cs
+++ b/Octokit/Clients/BlobsClient.cs
@@ -28,7 +28,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The SHA of the blob</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/git/blobs/{file_sha}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/git/blobs/{file_sha}")]
         public Task<Blob> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -63,7 +63,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newBlob">The new Blob</param>
-        [ManualRoute("POST", "/repos/{owner}/{name}/git/blobs")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/git/blobs")]
         public Task<BlobReference> Create(string owner, string name, NewBlob newBlob)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/CheckRunsClient.cs
+++ b/Octokit/Clients/CheckRunsClient.cs
@@ -31,7 +31,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="newCheckRun">Details of the Check Run to create</param>
         [Preview("antiope")]
-        [ManualRoute("POST", "/repos/{owner}/{name}/check-runs")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/check-runs")]
         public Task<CheckRun> Create(string owner, string name, NewCheckRun newCheckRun)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -69,7 +69,7 @@ namespace Octokit
         /// <param name="checkRunId">The Id of the check run</param>
         /// <param name="checkRunUpdate">The updates to the check run</param>
         [Preview("antiope")]
-        [ManualRoute("PATCH", "/repos/{owner}/{name}/check-runs/{check_run_id}")]
+        [ManualRoute("PATCH", "/repos/{owner}/{repo}/check-runs/{check_run_id}")]
         public Task<CheckRun> Update(string owner, string name, long checkRunId, CheckRunUpdate checkRunUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -106,7 +106,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The commit reference (can be a SHA, branch name, or a tag name)</param>
-        [ManualRoute("GET", "repos/{owner}/{name}/commits/{sha}/check-runs")]
+        [ManualRoute("GET", "/repos/{owner}/{name}/commits/{commit_sha}/check-runs")]
         public Task<CheckRunsResponse> GetAllForReference(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -124,7 +124,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The commit reference (can be a SHA, branch name, or a tag name)</param>
-        [ManualRoute("GET", "/repositories/{id}/commits/{sha}/check-runs")]
+        [ManualRoute("GET", "/repositories/{id}/commits/{commit_sha}/check-runs")]
         public Task<CheckRunsResponse> GetAllForReference(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
@@ -142,7 +142,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The commit reference (can be a SHA, branch name, or a tag name)</param>
         /// <param name="checkRunRequest">Details to filter the request, such as by check name</param>
-        [ManualRoute("GET", "repos/{owner}/{name}/commits/{sha}/check-runs")]
+        [ManualRoute("GET", "/repos/{owner}/{name}/commits/{commit_sha}/check-runs")]
         public Task<CheckRunsResponse> GetAllForReference(string owner, string name, string reference, CheckRunRequest checkRunRequest)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -162,7 +162,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The commit reference (can be a SHA, branch name, or a tag name)</param>
         /// <param name="checkRunRequest">Details to filter the request, such as by check name</param>
-        [ManualRoute("GET", "/repositories/{id}/commits/{sha}/check-runs")]
+        [ManualRoute("GET", "/repositories/{id}/commits/{commit_sha}/check-runs")]
         public Task<CheckRunsResponse> GetAllForReference(long repositoryId, string reference, CheckRunRequest checkRunRequest)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
@@ -183,7 +183,7 @@ namespace Octokit
         /// <param name="checkRunRequest">Details to filter the request, such as by check name</param>
         /// <param name="options">Options to change the API response</param>
         [Preview("antiope")]
-        [ManualRoute("GET", "repos/{owner}/{name}/commits/{sha}/check-runs")]
+        [ManualRoute("GET", "/repos/{owner}/{name}/commits/{commit_sha}/check-runs")]
         public async Task<CheckRunsResponse> GetAllForReference(string owner, string name, string reference, CheckRunRequest checkRunRequest, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -210,7 +210,7 @@ namespace Octokit
         /// <param name="checkRunRequest">Details to filter the request, such as by check name</param>
         /// <param name="options">Options to change the API response</param>
         [Preview("antiope")]
-        [ManualRoute("GET", "/repositories/{id}/commits/{sha}/check-runs")]
+        [ManualRoute("GET", "/repositories/{id}/commits/{commit_sha}/check-runs")]
         public async Task<CheckRunsResponse> GetAllForReference(long repositoryId, string reference, CheckRunRequest checkRunRequest, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
@@ -233,7 +233,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="checkSuiteId">The Id of the check suite</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/check-suite/{check_suite_id}/check-runs")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/check-suite/{check_suite_id}/check-runs")]
         public Task<CheckRunsResponse> GetAllForCheckSuite(string owner, string name, long checkSuiteId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -266,7 +266,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="checkSuiteId">The Id of the check suite</param>
         /// <param name="checkRunRequest">Details to filter the request, such as by check name</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/check-suite/{check_suite_id}/check-runs")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/check-suite/{check_suite_id}/check-runs")]
         public Task<CheckRunsResponse> GetAllForCheckSuite(string owner, string name, long checkSuiteId, CheckRunRequest checkRunRequest)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -305,7 +305,7 @@ namespace Octokit
         /// <param name="checkRunRequest">Details to filter the request, such as by check name</param>
         /// <param name="options">Options to change the API response</param>
         [Preview("antiope")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/check-suite/{check_suite_id}/check-runs")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/check-suite/{check_suite_id}/check-runs")]
         public async Task<CheckRunsResponse> GetAllForCheckSuite(string owner, string name, long checkSuiteId, CheckRunRequest checkRunRequest, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -354,7 +354,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="checkRunId">The Id of the check run</param>
         [Preview("antiope")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/check-runs/{check_run_id}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/check-runs/{check_run_id}")]
         public Task<CheckRun> Get(string owner, string name, long checkRunId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -387,7 +387,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="checkRunId">The Id of the check run</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/check-runs/{check_run_id}/annotations")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/check-runs/{check_run_id}/annotations")]
         public Task<IReadOnlyList<CheckRunAnnotation>> GetAllAnnotations(string owner, string name, long checkRunId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -422,7 +422,7 @@ namespace Octokit
         /// <param name="checkRunId">The Id of the check run</param>
         /// <param name="options">Options to change the API response</param>
         [Preview("antiope")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/check-runs/{check_run_id}/annotations")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/check-runs/{check_run_id}/annotations")]
         public Task<IReadOnlyList<CheckRunAnnotation>> GetAllAnnotations(string owner, string name, long checkRunId, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/CheckSuitesClient.cs
+++ b/Octokit/Clients/CheckSuitesClient.cs
@@ -31,7 +31,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="checkSuiteId">The Id of the check suite</param>
         [Preview("antiope")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/check-suites/{id}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/check-suites/{id}")]
         public Task<CheckSuite> Get(string owner, string name, long checkSuiteId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -64,7 +64,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name or tag name) to list check suites for</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/commits/{ref}/check-suites")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/commits/{ref}/check-suites")]
         public Task<CheckSuitesResponse> GetAllForReference(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -100,7 +100,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name or tag name) to list check suites for</param>
         /// <param name="request">Details to filter the request, such as by App Id or Check Name</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/commits/{ref}/check-suites")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/commits/{ref}/check-suites")]
         public Task<CheckSuitesResponse> GetAllForReference(string owner, string name, string reference, CheckSuiteRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -141,7 +141,7 @@ namespace Octokit
         /// <param name="request">Details to filter the request, such as by App Id or Check Name</param>
         /// <param name="options">Options to change the API response</param>
         [Preview("antiope")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/commits/{ref}/check-suites")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/commits/{ref}/check-suites")]
         public async Task<CheckSuitesResponse> GetAllForReference(string owner, string name, string reference, CheckSuiteRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -192,7 +192,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="preferences">The check suite preferences</param>
         [Preview("antiope")]
-        [ManualRoute("PATCH", "/repos/{owner}/{name}/check-suites/preferences")]
+        [ManualRoute("PATCH", "/repos/{owner}/{repo}/check-suites/preferences")]
         public Task<CheckSuitePreferencesResponse> UpdatePreferences(string owner, string name, CheckSuitePreferences preferences)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -229,7 +229,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="newCheckSuite">Details of the Check Suite to create</param>
         [Preview("antiope")]
-        [ManualRoute("POST", "/repos/{owner}/{name}/check-suites")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/check-suites")]
         public Task<CheckSuite> Create(string owner, string name, NewCheckSuite newCheckSuite)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -266,7 +266,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="checkSuiteId">The Id of the check suite</param>
         [Preview("antiope")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/check-suites/{2}/rerequest")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/check-suites/{2}/rerequest")]
         public async Task<bool> Rerequest(string owner, string name, long checkSuiteId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/CommitCommentReactionsClient.cs
+++ b/Octokit/Clients/CommitCommentReactionsClient.cs
@@ -26,7 +26,7 @@ namespace Octokit
         /// <param name="reaction">The reaction to create</param>
         /// <returns></returns>
         [Preview("squirrel-girl")]
-        [ManualRoute("POST", "/repos/{owner}/{name}/comments/{comment_id}/reactions")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/comments/{comment_id}/reactions")]
         public Task<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -61,7 +61,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <returns></returns>
-        [ManualRoute("GET", "/repos/{owner}/{name}/comments/{comment_id}/reactions")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/comments/{comment_id}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number)
         {
             return GetAll(owner, name, number, ApiOptions.None);
@@ -77,7 +77,7 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
         [Preview("squirrel-girl")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/comments/{comment_id}/reactions")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/comments/{comment_id}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/CommitStatusClient.cs
+++ b/Octokit/Clients/CommitStatusClient.cs
@@ -29,7 +29,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/commits/{sha}/statuses")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/commits/{ref}/statuses")]
         public Task<IReadOnlyList<CommitStatus>> GetAll(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -48,7 +48,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        [ManualRoute("GET", "/repositories/{id}/commits/{sha}/statuses")]
+        [ManualRoute("GET", "/repositories/{id}/commits/{ref}/statuses")]
         public Task<IReadOnlyList<CommitStatus>> GetAll(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
@@ -64,10 +64,10 @@ namespace Octokit
         /// https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>        
+        /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="options">Options for changing the API response</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/commits/{sha}/statuses")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/commits/{ref}/statuses")]
         public Task<IReadOnlyList<CommitStatus>> GetAll(string owner, string name, string reference, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -88,7 +88,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="options">Options for changing the API response</param>
-        [ManualRoute("GET", "/repositories/{id}/commits/{sha}/statuses")]
+        [ManualRoute("GET", "/repositories/{id}/commits/{ref}/statuses")]
         public Task<IReadOnlyList<CommitStatus>> GetAll(long repositoryId, string reference, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
@@ -107,7 +107,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/commits/{sha}/status")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/commits/{ref}/status")]
         public Task<CombinedCommitStatus> GetCombined(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -126,7 +126,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        [ManualRoute("GET", "/repositories/{id}/commits/{sha}/status")]
+        [ManualRoute("GET", "/repositories/{id}/commits/{ref}/status")]
         public Task<CombinedCommitStatus> GetCombined(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
@@ -144,7 +144,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="newCommitStatus">The commit status to create</param>
-        [ManualRoute("POST", "/repos/{owner}/{name}/statuses/{sha}")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/statuses/{ref}")]
         public Task<CommitStatus> Create(string owner, string name, string reference, NewCommitStatus newCommitStatus)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -164,7 +164,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="newCommitStatus">The commit status to create</param>
-        [ManualRoute("POST", "/repositories/{id}/statuses/{sha}")]
+        [ManualRoute("POST", "/repositories/{id}/statuses/{ref}")]
         public Task<CommitStatus> Create(long repositoryId, string reference, NewCommitStatus newCommitStatus)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));

--- a/Octokit/Clients/CommitsClient.cs
+++ b/Octokit/Clients/CommitsClient.cs
@@ -28,7 +28,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">Tha sha reference of the commit</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/git/commits/{commit_sha}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/git/commits/{commit_sha}")]
         public Task<Commit> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -63,7 +63,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="commit">The commit to create</param>
-        [ManualRoute("POST", "/repos/{owner}/{name}/git/commits")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/git/commits")]
         public Task<Commit> Create(string owner, string name, NewCommit commit)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/DeploymentStatusClient.cs
+++ b/Octokit/Clients/DeploymentStatusClient.cs
@@ -27,7 +27,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/deployments/{deployment_id}/statuses")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/deployments/{deployment_id}/statuses")]
         public Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, int deploymentId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -64,7 +64,7 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         [Preview("ant-man")]
         [Preview("flash")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/deployments/{deployment_id}/statuses")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/deployments/{deployment_id}/statuses")]
         public Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, int deploymentId, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -113,7 +113,7 @@ namespace Octokit
         /// <param name="newDeploymentStatus">The new deployment status to create.</param>
         [Preview("ant-man")]
         [Preview("flash")]
-        [ManualRoute("POST", "/repos/{owner}/{name}/deployments/{deployment_id}/statuses")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/deployments/{deployment_id}/statuses")]
         public Task<DeploymentStatus> Create(string owner, string name, int deploymentId, NewDeploymentStatus newDeploymentStatus)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/DeploymentsClient.cs
+++ b/Octokit/Clients/DeploymentsClient.cs
@@ -31,7 +31,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/deployments")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/deployments")]
         public Task<IReadOnlyList<Deployment>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -65,7 +65,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         [Preview("ant-man")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/deployments")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/deployments")]
         public Task<IReadOnlyList<Deployment>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -106,7 +106,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="newDeployment">A <see cref="NewDeployment"/> instance describing the new deployment to create</param>
         [Preview("ant-man")]
-        [ManualRoute("POST", "/repos/{owner}/{name}/deployments")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/deployments")]
         public Task<Deployment> Create(string owner, string name, NewDeployment newDeployment)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/EventsClient.cs
+++ b/Octokit/Clients/EventsClient.cs
@@ -56,7 +56,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/events")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/events")]
         public Task<IReadOnlyList<Activity>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -87,7 +87,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/events")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/events")]
         public Task<IReadOnlyList<Activity>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -121,7 +121,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/issues/events")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/issues/events")]
         public Task<IReadOnlyList<IssueEvent>> GetAllIssuesForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -152,7 +152,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/issues/events")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/issues/events")]
         public Task<IReadOnlyList<IssueEvent>> GetAllIssuesForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/FollowersClient.cs
+++ b/Octokit/Clients/FollowersClient.cs
@@ -57,7 +57,7 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/users/followers/#list-followers-of-a-user">API documentation</a> for more information.
         /// </remarks>
         /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s that follow the passed user.</returns>
-        [ManualRoute("GET", "/user/{username}/followers")]
+        [ManualRoute("GET", "/users/{username}/followers")]
         public Task<IReadOnlyList<User>> GetAll(string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
@@ -74,7 +74,7 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/users/followers/#list-followers-of-a-user">API documentation</a> for more information.
         /// </remarks>
         /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s that follow the passed user.</returns>
-        [ManualRoute("GET", "/user/{username}/followers")]
+        [ManualRoute("GET", "/users/{username}/followers")]
         public Task<IReadOnlyList<User>> GetAll(string login, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
@@ -179,7 +179,7 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/users/followers/#check-if-one-user-follows-another">API documentation</a> for more information.
         /// </remarks>
         /// <returns>A <c>bool</c> representing the success of the operation.</returns>
-        [ManualRoute("GET", "/users/{login}/following/{username}")]
+        [ManualRoute("GET", "/users/{username}/following/{target_user}")]
         public async Task<bool> IsFollowing(string login, string following)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));

--- a/Octokit/Clients/GistsClient.cs
+++ b/Octokit/Clients/GistsClient.cs
@@ -49,8 +49,8 @@ namespace Octokit
         {
             Ensure.ArgumentNotNull(newGist, nameof(newGist));
 
-            //Required to create anonymous object to match signature of files hash.  
-            // Allowing the serializer to handle Dictionary<string,NewGistFile> 
+            //Required to create anonymous object to match signature of files hash.
+            // Allowing the serializer to handle Dictionary<string,NewGistFile>
             // will fail to match.
             var filesAsJsonObject = new JsonObject();
             foreach (var kvp in newGist.Files)
@@ -97,7 +97,7 @@ namespace Octokit
         }
 
         /// <summary>
-        /// List the authenticated user’s gists or if called anonymously, 
+        /// List the authenticated user’s gists or if called anonymously,
         /// this will return all public gists
         /// </summary>
         /// <remarks>
@@ -110,7 +110,7 @@ namespace Octokit
         }
 
         /// <summary>
-        /// List the authenticated user’s gists or if called anonymously, 
+        /// List the authenticated user’s gists or if called anonymously,
         /// this will return all public gists
         /// </summary>
         /// <remarks>
@@ -126,7 +126,7 @@ namespace Octokit
         }
 
         /// <summary>
-        /// List the authenticated user’s gists or if called anonymously, 
+        /// List the authenticated user’s gists or if called anonymously,
         /// this will return all public gists
         /// </summary>
         /// <remarks>
@@ -140,7 +140,7 @@ namespace Octokit
         }
 
         /// <summary>
-        /// List the authenticated user’s gists or if called anonymously, 
+        /// List the authenticated user’s gists or if called anonymously,
         /// this will return all public gists
         /// </summary>
         /// <remarks>
@@ -278,7 +278,7 @@ namespace Octokit
         /// http://developer.github.com/v3/gists/#list-gists
         /// </remarks>
         /// <param name="user">The user</param>
-        [ManualRoute("GET", "/users/{user}/gists")]
+        [ManualRoute("GET", "/users/{username}/gists")]
         public Task<IReadOnlyList<Gist>> GetAllForUser(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -294,7 +294,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="user">The user</param>
         /// <param name="options">Options for changing the API response</param>
-        [ManualRoute("GET", "/users/{user}/gists")]
+        [ManualRoute("GET", "/users/{username}/gists")]
         public Task<IReadOnlyList<Gist>> GetAllForUser(string user, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -311,7 +311,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="user">The user</param>
         /// <param name="since">Only gists updated at or after this time are returned</param>
-        [ManualRoute("GET", "/users/{user}/gists")]
+        [ManualRoute("GET", "/users/{username}/gists")]
         public Task<IReadOnlyList<Gist>> GetAllForUser(string user, DateTimeOffset since)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -328,7 +328,7 @@ namespace Octokit
         /// <param name="user">The user</param>
         /// <param name="since">Only gists updated at or after this time are returned</param>
         /// <param name="options">Options for changing the API response</param>
-        [ManualRoute("GET", "/users/{user}/gists")]
+        [ManualRoute("GET", "/users/{username}/gists")]
         public Task<IReadOnlyList<Gist>> GetAllForUser(string user, DateTimeOffset since, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));

--- a/Octokit/Clients/GitHubAppsClient.cs
+++ b/Octokit/Clients/GitHubAppsClient.cs
@@ -94,7 +94,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/apps/#get-a-single-installation</remarks>
         /// <param name="installationId">The Id of the GitHub App Installation</param>
         [Preview("machine-man")]
-        [ManualRoute("GET", "/app/installations/{id}")]
+        [ManualRoute("GET", "/app/installations/{installation_id}")]
         public Task<Installation> GetInstallationForCurrent(long installationId)
         {
             return ApiConnection.Get<Installation>(ApiUrls.Installation(installationId), null, AcceptHeaders.GitHubAppsPreview);
@@ -142,7 +142,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="installationId">The Id of the GitHub App Installation</param>
         [Preview("machine-man")]
-        [ManualRoute("GET", "/app/installations/{id}/access_tokens")]
+        [ManualRoute("GET", "/app/installations/{installation_id}/access_tokens")]
         public Task<AccessToken> CreateInstallationToken(long installationId)
         {
             return ApiConnection.Post<AccessToken>(ApiUrls.AccessTokens(installationId), string.Empty, AcceptHeaders.GitHubAppsPreview);
@@ -169,7 +169,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repo</param>
         /// <param name="repo">The name of the repo</param>
         [Preview("machine-man")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/installation")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/installation")]
         public Task<Installation> GetRepositoryInstallationForCurrent(string owner, string repo)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -196,7 +196,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/apps/#find-user-installation</remarks>
         /// <param name="user">The name of the user</param>
         [Preview("machine-man")]
-        [ManualRoute("GET", "/users/{user}/installation")]
+        [ManualRoute("GET", "/users/{username}/installation")]
         public Task<Installation> GetUserInstallationForCurrent(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));

--- a/Octokit/Clients/IssueCommentReactionsClient.cs
+++ b/Octokit/Clients/IssueCommentReactionsClient.cs
@@ -25,7 +25,7 @@ namespace Octokit
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
         [Preview("squirrel-girl")]
-        [ManualRoute("POST", "/repos/{owner}/{name}/issues/comments/{number}/reactions")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/issues/comments/{number}/reactions")]
         public Task<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -58,7 +58,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
-        [ManualRoute("POST", "/repos/{owner}/{name}/issues/comments/{number}/reactions")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/issues/comments/{number}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number)
         {
             return GetAll(owner, name, number, ApiOptions.None);
@@ -73,7 +73,7 @@ namespace Octokit
         /// <param name="number">The comment id</param>
         /// <param name="options">Options for changing the API response</param>
         [Preview("squirrel-girl")]
-        [ManualRoute("POST", "/repos/{owner}/{name}/issues/comments/{number}/reactions")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/issues/comments/{number}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/IssueCommentsClient.cs
+++ b/Octokit/Clients/IssueCommentsClient.cs
@@ -27,7 +27,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="id">The issue comment id</param>
         [Preview("squirrel-girl")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/issues/comments/{comment_id}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/issues/comments/{comment_id}")]
         public Task<IssueComment> Get(string owner, string name, int id)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -55,7 +55,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/issues/comments")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/issues/comments")]
         public Task<IReadOnlyList<IssueComment>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -82,7 +82,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/issues/comments")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/issues/comments")]
         public Task<IReadOnlyList<IssueComment>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -113,7 +113,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/issues/comments")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/issues/comments")]
         public Task<IReadOnlyList<IssueComment>> GetAllForRepository(string owner, string name, IssueCommentRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -146,7 +146,7 @@ namespace Octokit
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
         [Preview("squirrel-girl")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/issues/comments")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/issues/comments")]
         public Task<IReadOnlyList<IssueComment>> GetAllForRepository(string owner, string name, IssueCommentRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -181,7 +181,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number]/comments")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{number]/comments")]
         public Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -210,7 +210,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number]/comments")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{number]/comments")]
         public Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -243,7 +243,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number]/comments")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{number]/comments")]
         public Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int number, IssueCommentRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -278,7 +278,7 @@ namespace Octokit
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
         [Preview("squirrel-girl")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number]/comments")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{number]/comments")]
         public Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int number, IssueCommentRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -315,7 +315,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="newComment">The new comment to add to the issue</param>
-        [ManualRoute("POST", "/repos/{owner}/{name}/issues/{number]/comments")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/issues/{number]/comments")]
         public Task<IssueComment> Create(string owner, string name, int number, string newComment)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -348,7 +348,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="id">The comment id</param>
         /// <param name="commentUpdate">The modified comment</param>
-        [ManualRoute("PATCH", "/repos/{owner}/{name}/issues/comments/{id}")]
+        [ManualRoute("PATCH", "/repos/{owner}/{repo}/issues/comments/{id}")]
         public Task<IssueComment> Update(string owner, string name, int id, string commentUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -380,7 +380,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="id">The comment id</param>
-        [ManualRoute("DELETE", "/repos/{owner}/{name}/issues/comments/{id}")]
+        [ManualRoute("DELETE", "/repos/{owner}/{repo}/issues/comments/{id}")]
         public Task Delete(string owner, string name, int id)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/IssueReactionsClient.cs
+++ b/Octokit/Clients/IssueReactionsClient.cs
@@ -23,7 +23,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number}/reactions")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{number}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number)
         {
             return GetAll(owner, name, number, ApiOptions.None);
@@ -38,7 +38,7 @@ namespace Octokit
         /// <param name="number">The issue id</param>
         /// <param name="options">Options for changing the API response</param>
         [Preview("squirrel-girl")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number}/reactions")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{number}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -85,7 +85,7 @@ namespace Octokit
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create</param>
         [Preview("squirrel-girl")]
-        [ManualRoute("POST", "/repos/{owner}/{name}/issues/{number}/reactions")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/issues/{number}/reactions")]
         public Task<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/IssueTimelineClient.cs
+++ b/Octokit/Clients/IssueTimelineClient.cs
@@ -24,7 +24,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="repo">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number}/timeline")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{number}/timeline")]
         public Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(string owner, string repo, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -45,7 +45,7 @@ namespace Octokit
         /// <param name="options">Options for changing the API repsonse</param>
         [Preview("mockingbird")]
         [Preview("starfox")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number}/timeline")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{number}/timeline")]
         public Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(string owner, string repo, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/IssuesClient.cs
+++ b/Octokit/Clients/IssuesClient.cs
@@ -67,7 +67,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         [Preview("squirrel-girl")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{number}")]
         public Task<Issue> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -298,7 +298,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/issues")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/issues")]
         public Task<IReadOnlyList<Issue>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -329,7 +329,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/issues")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/issues")]
         public Task<IReadOnlyList<Issue>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -364,7 +364,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/issues")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/issues")]
         public Task<IReadOnlyList<Issue>> GetAllForRepository(string owner, string name, RepositoryIssueRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -401,7 +401,7 @@ namespace Octokit
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
         [Preview("squirrel-girl")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/issues")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/issues")]
         public Task<IReadOnlyList<Issue>> GetAllForRepository(string owner, string name, RepositoryIssueRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -439,7 +439,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newIssue">A <see cref="NewIssue"/> instance describing the new issue to create</param>
-        [ManualRoute("POST", "/repos/{owner}/{name}/issues")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/issues")]
         public Task<Issue> Create(string owner, string name, NewIssue newIssue)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -473,7 +473,7 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        [ManualRoute("PATCH", "/repos/{owner}/{name}/issues/{number}")]
+        [ManualRoute("PATCH", "/repos/{owner}/{repo}/issues/{number}")]
         public Task<Issue> Update(string owner, string name, int number, IssueUpdate issueUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -507,7 +507,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        [ManualRoute("PUT", "/repos/{owner}/{name}/issues/{number}/lock")]
+        [ManualRoute("PUT", "/repos/{owner}/{repo}/issues/{number}/lock")]
         public Task Lock(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -535,7 +535,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        [ManualRoute("DELETE", "/repos/{owner}/{name}/issues/{number}/lock")]
+        [ManualRoute("DELETE", "/repos/{owner}/{repo}/issues/{number}/lock")]
         public Task Unlock(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/IssuesEventsClient.cs
+++ b/Octokit/Clients/IssuesEventsClient.cs
@@ -24,7 +24,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number}/events")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{number}/events")]
         public Task<IReadOnlyList<IssueEvent>> GetAllForIssue(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -58,7 +58,7 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
         [Preview("starfox")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number}/events")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{number}/events")]
         public Task<IReadOnlyList<IssueEvent>> GetAllForIssue(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -100,7 +100,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/issues/events")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/issues/events")]
         public Task<IReadOnlyList<IssueEvent>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -132,7 +132,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         [Preview("starfox")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/issues/events")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/issues/events")]
         public Task<IReadOnlyList<IssueEvent>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -175,7 +175,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="eventId">The event id</param>
         [Preview("starfox")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/issues/events/{event_id}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/issues/events/{event_id}")]
         public Task<IssueEvent> Get(string owner, string name, long eventId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/IssuesLabelsClient.cs
+++ b/Octokit/Clients/IssuesLabelsClient.cs
@@ -25,7 +25,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number}/labels")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{number}/labels")]
         public Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -58,7 +58,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number}/labels")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{number}/labels")]
         public Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -93,7 +93,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/labels")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/labels")]
         public Task<IReadOnlyList<Label>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -124,7 +124,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/labels")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/labels")]
         public Task<IReadOnlyList<Label>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -159,7 +159,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the milestone</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/milestones/{number}/labels")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/milestones/{number}/labels")]
         public Task<IReadOnlyList<Label>> GetAllForMilestone(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -192,7 +192,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the milestone</param>
         /// <param name="options">Options for changing the API response</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/milestones/{number}/labels")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/milestones/{number}/labels")]
         public Task<IReadOnlyList<Label>> GetAllForMilestone(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -228,7 +228,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/labels/{name}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/labels/{name}")]
         public Task<Label> Get(string owner, string name, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -263,7 +263,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        [ManualRoute("DELETE", "/repos/{owner}/{name}/labels/{name}")]
+        [ManualRoute("DELETE", "/repos/{owner}/{repo}/labels/{name}")]
         public Task Delete(string owner, string name, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -298,7 +298,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newLabel">The data for the label to be created</param>
-        [ManualRoute("POST", "/repos/{owner}/{name}/labels")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/labels")]
         public Task<Label> Create(string owner, string name, NewLabel newLabel)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -334,7 +334,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="labelName">The name of the label</param>
         /// <param name="labelUpdate">The data for the label to be updated</param>
-        [ManualRoute("PATCH", "/repos/{owner}/{name}/labels/{name}")]
+        [ManualRoute("PATCH", "/repos/{owner}/{repo}/labels/{name}")]
         public Task<Label> Update(string owner, string name, string labelName, LabelUpdate labelUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -377,7 +377,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to add</param>
-        [ManualRoute("POST", "/repos/{owner}/{name}/issues/{number}/labels")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/issues/{number}/labels")]
         public Task<IReadOnlyList<Label>> AddToIssue(string owner, string name, int number, string[] labels)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -414,7 +414,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labelName">The name of the label to remove</param>
-        [ManualRoute("DELETE", "/repos/{owner}/{name}/issues/{number}/labels")]
+        [ManualRoute("DELETE", "/repos/{owner}/{repo}/issues/{number}/labels")]
         public Task<IReadOnlyList<Label>> RemoveFromIssue(string owner, string name, int number, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -451,7 +451,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to set</param>
-        [ManualRoute("PUT", "/repos/{owner}/{name}/issues/{number}/labels")]
+        [ManualRoute("PUT", "/repos/{owner}/{repo}/issues/{number}/labels")]
         public Task<IReadOnlyList<Label>> ReplaceAllForIssue(string owner, string name, int number, string[] labels)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -487,7 +487,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
-        [ManualRoute("DELETE", "/repos/{owner}/{name}/issues/{number}/labels")]
+        [ManualRoute("DELETE", "/repos/{owner}/{repo}/issues/{number}/labels")]
         public Task RemoveAllFromIssue(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/MergingClient.cs
+++ b/Octokit/Clients/MergingClient.cs
@@ -28,7 +28,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="merge">The merge to create</param>
         /// <returns></returns>
-        [ManualRoute("POST", "repos/{owner}/{name}/merges")]
+        [ManualRoute("POST", "/repos/{owner}/{name}/merges")]
         public Task<Merge> Create(string owner, string name, NewMerge merge)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -47,7 +47,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="merge">The merge to create</param>
         /// <returns></returns>
-        [ManualRoute("POST", "repositories/{id}/merges")]
+        [ManualRoute("POST", "/repositories/{id}/merges")]
         public Task<Merge> Create(long repositoryId, NewMerge merge)
         {
             Ensure.ArgumentNotNull(merge, nameof(merge));

--- a/Octokit/Clients/MilestonesClient.cs
+++ b/Octokit/Clients/MilestonesClient.cs
@@ -26,7 +26,7 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/milestones/#get-a-single-milestone
         /// </remarks>
         /// <returns></returns>
-        [ManualRoute("GET", "/repos/{owner}/{name}/milestones/{number}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/milestones/{number}")]
         public Task<Milestone> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -57,7 +57,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <returns></returns>
-        [ManualRoute("GET", "/repos/{owner}/{name}/milestones")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/milestones")]
         public Task<IReadOnlyList<Milestone>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -90,7 +90,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
-        [ManualRoute("GET", "/repos/{owner}/{name}/milestones")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/milestones")]
         public Task<IReadOnlyList<Milestone>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -127,7 +127,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of Milestones returned</param>
         /// <returns></returns>
-        [ManualRoute("GET", "/repos/{owner}/{name}/milestones")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/milestones")]
         public Task<IReadOnlyList<Milestone>> GetAllForRepository(string owner, string name, MilestoneRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -165,7 +165,7 @@ namespace Octokit
         /// <param name="request">Used to filter and sort the list of Milestones returned</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
-        [ManualRoute("GET", "/repos/{owner}/{name}/milestones")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/milestones")]
         public Task<IReadOnlyList<Milestone>> GetAllForRepository(string owner, string name, MilestoneRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -206,7 +206,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="newMilestone">A <see cref="NewMilestone"/> instance describing the new Milestone to create</param>
         /// <returns></returns>
-        [ManualRoute("POST", "/repos/{owner}/{name}/milestones")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/milestones")]
         public Task<Milestone> Create(string owner, string name, NewMilestone newMilestone)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -243,7 +243,7 @@ namespace Octokit
         /// <param name="milestoneUpdate">An <see cref="MilestoneUpdate"/> instance describing the changes to make to the Milestone
         /// </param>
         /// <returns></returns>
-        [ManualRoute("PATCH", "/repos/{owner}/{name}/milestones/{number}")]
+        [ManualRoute("PATCH", "/repos/{owner}/{repo}/milestones/{number}")]
         public Task<Milestone> Update(string owner, string name, int number, MilestoneUpdate milestoneUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -280,7 +280,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The milestone number</param>
         /// <returns></returns>
-        [ManualRoute("DELETE", "/repos/{owner}/{name}/milestones/{number}")]
+        [ManualRoute("DELETE", "/repos/{owner}/{repo}/milestones/{number}")]
         public Task Delete(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/MiscellaneousClient.cs
+++ b/Octokit/Clients/MiscellaneousClient.cs
@@ -72,7 +72,7 @@ namespace Octokit
         /// </summary>
         /// <param name="templateName"></param>
         /// <returns>A template and its source</returns>
-        [ManualRoute("GET", "/gitignore/templates/{template_name}")]
+        [ManualRoute("GET", "/gitignore/templates/{name}")]
         public Task<GitIgnoreTemplate> GetGitIgnoreTemplate(string templateName)
         {
             Ensure.ArgumentNotNullOrEmptyString(templateName, nameof(templateName));

--- a/Octokit/Clients/OrganizationMembersClient.cs
+++ b/Octokit/Clients/OrganizationMembersClient.cs
@@ -81,7 +81,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="org">The login for the organization</param>
         /// <returns>The users</returns>
-        [ManualRoute("GET", "orgs/{org}/members")]
+        [ManualRoute("GET", "/orgs/{org}/members")]
         public Task<IReadOnlyList<User>> GetAll(string org)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -110,7 +110,7 @@ namespace Octokit
         /// <param name="org">The login for the organization</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>The users</returns>
-        [ManualRoute("GET", "orgs/{org}/members")]
+        [ManualRoute("GET", "/orgs/{org}/members")]
         public Task<IReadOnlyList<User>> GetAll(string org, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -140,7 +140,7 @@ namespace Octokit
         /// <param name="org">The login for the organization</param>
         /// <param name="filter">The filter to use when getting the users, <see cref="OrganizationMembersFilter"/></param>
         /// <returns>The users</returns>
-        [ManualRoute("GET", "orgs/{org}/members")]
+        [ManualRoute("GET", "/orgs/{org}/members")]
         public Task<IReadOnlyList<User>> GetAll(string org, OrganizationMembersFilter filter)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -170,7 +170,7 @@ namespace Octokit
         /// <param name="filter">The filter to use when getting the users, <see cref="OrganizationMembersFilter"/></param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>The users</returns>
-        [ManualRoute("GET", "orgs/{org}/members")]
+        [ManualRoute("GET", "/orgs/{org}/members")]
         public Task<IReadOnlyList<User>> GetAll(string org, OrganizationMembersFilter filter, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -200,7 +200,7 @@ namespace Octokit
         /// <param name="org">The login for the organization</param>
         /// <param name="role">The role filter to use when getting the users, <see cref="OrganizationMembersRole"/></param>
         /// <returns>The users</returns>
-        [ManualRoute("GET", "orgs/{org}/members?role={1}")]
+        [ManualRoute("GET", "/orgs/{org}/members?role={1}")]
         public Task<IReadOnlyList<User>> GetAll(string org, OrganizationMembersRole role)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -230,7 +230,7 @@ namespace Octokit
         /// <param name="role">The role filter to use when getting the users, <see cref="OrganizationMembersRole"/></param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>The users</returns>
-        [ManualRoute("GET", "orgs/{org}/members?role={1}")]
+        [ManualRoute("GET", "/orgs/{org}/members?role={1}")]
         public Task<IReadOnlyList<User>> GetAll(string org, OrganizationMembersRole role, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -261,7 +261,7 @@ namespace Octokit
         /// <param name="filter">The filter to use when getting the users, <see cref="OrganizationMembersFilter"/></param>
         /// <param name="role">The role filter to use when getting the users, <see cref="OrganizationMembersRole"/></param>
         /// <returns>The users</returns>
-        [ManualRoute("GET", "orgs/{org}/members?filter={1}&role={2}")]
+        [ManualRoute("GET", "/orgs/{org}/members?filter={1}&role={2}")]
         public Task<IReadOnlyList<User>> GetAll(string org, OrganizationMembersFilter filter, OrganizationMembersRole role)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -292,7 +292,7 @@ namespace Octokit
         /// <param name="role">The role filter to use when getting the users, <see cref="OrganizationMembersRole"/></param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>The users</returns>
-        [ManualRoute("GET", "orgs/{org}/members?filter={1}&role={2}")]
+        [ManualRoute("GET", "/orgs/{org}/members?filter={1}&role={2}")]
         public Task<IReadOnlyList<User>> GetAll(string org, OrganizationMembersFilter filter, OrganizationMembersRole role, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -307,7 +307,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/orgs/members/#public-members-list</remarks>
         /// <param name="org">The login for the organization</param>
         /// <returns></returns>
-        [ManualRoute("GET", "orgs/{org}/public_members")]
+        [ManualRoute("GET", "/orgs/{org}/public_members")]
         public Task<IReadOnlyList<User>> GetAllPublic(string org)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -322,7 +322,7 @@ namespace Octokit
         /// <param name="org">The login for the organization</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
-        [ManualRoute("GET", "orgs/{org}/public_members")]
+        [ManualRoute("GET", "/orgs/{org}/public_members")]
         public Task<IReadOnlyList<User>> GetAllPublic(string org, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -341,7 +341,7 @@ namespace Octokit
         /// <param name="org">The login for the organization</param>
         /// <param name="user">The login for the user</param>
         /// <returns></returns>
-        [ManualRoute("GET", "orgs/{org}/members/{username}")]
+        [ManualRoute("GET", "/orgs/{org}/members/{username}")]
         public async Task<bool> CheckMember(string org, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -375,7 +375,7 @@ namespace Octokit
         /// <param name="org">The login for the organization</param>
         /// <param name="user">The login for the user</param>
         /// <returns></returns>
-        [ManualRoute("GET", "orgs/{org}/public_members/{username}")]
+        [ManualRoute("GET", "/orgs/{org}/public_members/{username}")]
         public async Task<bool> CheckMemberPublic(string org, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -404,7 +404,7 @@ namespace Octokit
         /// <param name="org">The login for the organization</param>
         /// <param name="user">The login for the user</param>
         /// <returns></returns>
-        [ManualRoute("DELETE", "orgs/{org}/members/{username}")]
+        [ManualRoute("DELETE", "/orgs/{org}/members/{username}")]
         public Task Delete(string org, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -418,13 +418,13 @@ namespace Octokit
         /// </summary>
         /// <remarks>
         /// This method requires authentication.
-        /// See the <a href="http://developer.github.com/v3/orgs/members/#publicize-a-users-membership">API documentation</a> 
+        /// See the <a href="http://developer.github.com/v3/orgs/members/#publicize-a-users-membership">API documentation</a>
         /// for more information.
         /// </remarks>
         /// <param name="org">The login for the organization</param>
         /// <param name="user">The login for the user</param>
         /// <returns></returns>
-        [ManualRoute("PUT", "orgs/{org}/public_members/{username}")]
+        [ManualRoute("PUT", "/orgs/{org}/public_members/{username}")]
         public async Task<bool> Publicize(string org, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -457,7 +457,7 @@ namespace Octokit
         /// <param name="org">The login for the organization</param>
         /// <param name="user">The login for the user</param>
         /// <returns></returns>
-        [ManualRoute("DELETE", "orgs/{org}/public_members/{username}")]
+        [ManualRoute("DELETE", "/orgs/{org}/public_members/{username}")]
         public Task Conceal(string org, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -478,7 +478,7 @@ namespace Octokit
         /// <param name="org">The login for the organization</param>
         /// <param name="user">The login for the user</param>
         /// <returns></returns>
-        [ManualRoute("GET", "orgs/{org}/memberships/{username}")]
+        [ManualRoute("GET", "/orgs/{org}/memberships/{username}")]
         public Task<OrganizationMembership> GetOrganizationMembership(string org, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -488,7 +488,7 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Add a user to the organization or update the user's role withing the organization. 
+        /// Add a user to the organization or update the user's role withing the organization.
         /// </summary>
         /// <remarks>
         /// This method requires authentication.
@@ -501,7 +501,7 @@ namespace Octokit
         /// <param name="addOrUpdateRequest">An <see cref="OrganizationMembershipUpdate"/> instance describing the
         /// changes to make to the user's organization membership</param>
         /// <returns></returns>
-        [ManualRoute("PUT", "orgs/{org}/memberships/{username}")]
+        [ManualRoute("PUT", "/orgs/{org}/memberships/{username}")]
         public Task<OrganizationMembership> AddOrUpdateOrganizationMembership(string org, string user, OrganizationMembershipUpdate addOrUpdateRequest)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -523,7 +523,7 @@ namespace Octokit
         /// <param name="org">The login for the organization</param>
         /// <param name="user">The login for the user</param>
         /// <returns></returns>
-        [ManualRoute("DELETE", "orgs/{org}/memberships/{username}")]
+        [ManualRoute("DELETE", "/orgs/{org}/memberships/{username}")]
         public Task RemoveOrganizationMembership(string org, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -541,7 +541,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="org">The login for the organization</param>
         /// <returns></returns>
-        [ManualRoute("GET", "orgs/{org}/invitations")]
+        [ManualRoute("GET", "/orgs/{org}/invitations")]
         public Task<IReadOnlyList<OrganizationMembershipInvitation>> GetAllPendingInvitations(string org)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -559,7 +559,7 @@ namespace Octokit
         /// <param name="org">The login for the organization</param>
         /// <param name="options">Options to change API behaviour</param>
         /// <returns></returns>
-        [ManualRoute("GET", "orgs/{org}/invitations")]
+        [ManualRoute("GET", "/orgs/{org}/invitations")]
         public Task<IReadOnlyList<OrganizationMembershipInvitation>> GetAllPendingInvitations(string org, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));

--- a/Octokit/Clients/ProjectColumnsClient.cs
+++ b/Octokit/Clients/ProjectColumnsClient.cs
@@ -24,7 +24,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/projects/columns/#list-project-columns">API documentation</a> for more information.
         /// </remarks>
         /// <param name="projectId">The Id of the project</param>
-        [ManualRoute("GET", "projects/{project_id}/columns")]
+        [ManualRoute("GET", "/projects/{project_id}/columns")]
         public Task<IReadOnlyList<ProjectColumn>> GetAll(int projectId)
         {
             return GetAll(projectId, ApiOptions.None);
@@ -39,7 +39,7 @@ namespace Octokit
         /// <param name="projectId">The Id of the project</param>
         /// <param name="options">Options for changing the API response</param>
         [Preview("inertia")]
-        [ManualRoute("GET", "projects/{project_id}/columns")]
+        [ManualRoute("GET", "/projects/{project_id}/columns")]
         public Task<IReadOnlyList<ProjectColumn>> GetAll(int projectId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -55,7 +55,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The id of the column</param>
         [Preview("inertia")]
-        [ManualRoute("GET", "projects/columns/{column_id}")]
+        [ManualRoute("GET", "/projects/columns/{column_id}")]
         public Task<ProjectColumn> Get(int id)
         {
             return ApiConnection.Get<ProjectColumn>(ApiUrls.ProjectColumn(id), null, AcceptHeaders.ProjectsApiPreview);
@@ -70,7 +70,7 @@ namespace Octokit
         /// <param name="projectId">The Id of the project</param>
         /// <param name="newProjectColumn">The column to create</param>
         [Preview("inertia")]
-        [ManualRoute("POST", "projects/{project_id}/columns")]
+        [ManualRoute("POST", "/projects/{project_id}/columns")]
         public Task<ProjectColumn> Create(int projectId, NewProjectColumn newProjectColumn)
         {
             Ensure.ArgumentNotNull(newProjectColumn, nameof(newProjectColumn));
@@ -87,7 +87,7 @@ namespace Octokit
         /// <param name="id">The id of the column</param>
         /// <param name="projectColumnUpdate">New values to update the column with</param>
         [Preview("inertia")]
-        [ManualRoute("PATCH", "projects/columns/{column_id}")]
+        [ManualRoute("PATCH", "/projects/columns/{column_id}")]
         public Task<ProjectColumn> Update(int id, ProjectColumnUpdate projectColumnUpdate)
         {
             Ensure.ArgumentNotNull(projectColumnUpdate, nameof(projectColumnUpdate));
@@ -103,7 +103,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The id of the column</param>
         [Preview("inertia")]
-        [ManualRoute("DELETE", "projects/columns/{column_id}")]
+        [ManualRoute("DELETE", "/projects/columns/{column_id}")]
         public async Task<bool> Delete(int id)
         {
             var endpoint = ApiUrls.ProjectColumn(id);
@@ -127,7 +127,7 @@ namespace Octokit
         /// <param name="id">The id of the column</param>
         /// <param name="position">The position to move the column</param>
         [Preview("inertia")]
-        [ManualRoute("POST", "projects/columns/{column_id}/moves")]
+        [ManualRoute("POST", "/projects/columns/{column_id}/moves")]
         public async Task<bool> Move(int id, ProjectColumnMove position)
         {
             Ensure.ArgumentNotNull(position, nameof(position));

--- a/Octokit/Clients/ProjectsClient.cs
+++ b/Octokit/Clients/ProjectsClient.cs
@@ -28,7 +28,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/projects")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/projects")]
         public Task<IReadOnlyList<Project>> GetAllForRepository(string owner, string name)
         {
             return GetAllForRepository(owner, name, ApiOptions.None);
@@ -44,7 +44,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         [Preview("inertia")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/projects")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/projects")]
         public Task<IReadOnlyList<Project>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -63,7 +63,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter the list of projects returned</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/projects")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/projects")]
         public Task<IReadOnlyList<Project>> GetAllForRepository(string owner, string name, ProjectRequest request)
         {
             return GetAllForRepository(owner, name, request, ApiOptions.None);
@@ -80,7 +80,7 @@ namespace Octokit
         /// <param name="request">Used to filter the list of projects returned</param>
         /// <param name="options">Options for changing the API response</param>
         [Preview("inertia")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/projects")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/projects")]
         public Task<IReadOnlyList<Project>> GetAllForRepository(string owner, string name, ProjectRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/PullRequestReviewCommentReactionsClient.cs
+++ b/Octokit/Clients/PullRequestReviewCommentReactionsClient.cs
@@ -23,7 +23,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/comments/{comment_id}/reactions")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number)
         {
             return GetAll(owner, name, number, ApiOptions.None);
@@ -38,7 +38,7 @@ namespace Octokit
         /// <param name="number">The comment id</param>
         /// <param name="options">Options for changing the API response</param>
         [Preview("squirrel-girl")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/comments/{comment_id}/reactions")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -85,7 +85,7 @@ namespace Octokit
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
         [Preview("squirrel-girl")]
-        [ManualRoute("POST", "/repos/{owner}/{name}/pulls/comments/{comment_id}/reactions")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions")]
         public Task<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/PullRequestReviewCommentsClient.cs
+++ b/Octokit/Clients/PullRequestReviewCommentsClient.cs
@@ -24,7 +24,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/{number}/comments")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/pulls/{pull_number}/comments")]
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -53,7 +53,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/{number}/comments")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/pulls/{pull_number}/comments")]
         [Preview("squirrel-girl")]
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAll(string owner, string name, int number, ApiOptions options)
         {
@@ -85,7 +85,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/comments")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/pulls/comments")]
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -112,7 +112,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/comments")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/pulls/comments")]
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -143,7 +143,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/comments")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/pulls/comments")]
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(string owner, string name, PullRequestReviewCommentRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -176,7 +176,7 @@ namespace Octokit
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
         [Preview("squirrel-girl")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/comments")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/pulls/comments")]
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(string owner, string name, PullRequestReviewCommentRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -212,7 +212,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request review comment number</param>
         [Preview("squirrel-girl")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/comments/{number}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/pulls/comments/{comment_id}")]
         public Task<PullRequestReviewComment> GetComment(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -241,7 +241,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The Pull Request number</param>
         /// <param name="comment">The comment</param>
-        [ManualRoute("POST", "/repos/{owner}/{name}/pulls/{number}/comments")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/pulls/{pull_number}/comments")]
         public async Task<PullRequestReviewComment> Create(string owner, string name, int number, PullRequestReviewCommentCreate comment)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -290,7 +290,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="comment">The comment</param>
-        [ManualRoute("POST", "/repos/{owner}/{name}/pulls/{number}/comment")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/pulls/{pull_number}/comment")]
         public async Task<PullRequestReviewComment> CreateReply(string owner, string name, int number, PullRequestReviewCommentReplyCreate comment)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -339,7 +339,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request review comment number</param>
         /// <param name="comment">The edited comment</param>
-        [ManualRoute("PATCH", "/repos/{owner}/{name}/pulls/comment/{number}")]
+        [ManualRoute("PATCH", "/repos/{owner}/{repo}/pulls/comments/{comment_id}")]
         public Task<PullRequestReviewComment> Edit(string owner, string name, int number, PullRequestReviewCommentEdit comment)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -371,7 +371,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        [ManualRoute("DELETE", "/repos/{owner}/{name}/pulls/comment/{number}")]
+        [ManualRoute("DELETE", "/repos/{owner}/{repo}/pulls/comments/{comment_id}")]
         public Task Delete(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/PullRequestReviewRequestsClient.cs
+++ b/Octokit/Clients/PullRequestReviewRequestsClient.cs
@@ -24,7 +24,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/{number}/requested_reviewers")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers")]
         public Task<RequestedReviews> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -53,7 +53,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The Pull Request number</param>
         /// <param name="users">List of logins of user will be requested for review</param>
-        [ManualRoute("POST", "/repos/{owner}/{name}/pulls/{number}/requested_reviewers")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers")]
         public Task<PullRequest> Create(string owner, string name, int number, PullRequestReviewRequest users)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -88,7 +88,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request review comment number</param>
         /// <param name="users">List of logins of users that will be not longer requested for review</param>
-        [ManualRoute("DELETE", "/repos/{owner}/{name}/pulls/{number}/requested_reviewers")]
+        [ManualRoute("DELETE", "/repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers")]
         public Task Delete(string owner, string name, int number, PullRequestReviewRequest users)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/PullRequestReviewsClient.cs
+++ b/Octokit/Clients/PullRequestReviewsClient.cs
@@ -23,7 +23,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/{number}/reviews")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/pulls/{pull_number}/reviews")]
         public Task<IReadOnlyList<PullRequestReview>> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -52,7 +52,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/{number}/reviews")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/pulls/{pull_number}/reviews")]
         public Task<IReadOnlyList<PullRequestReview>> GetAll(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -87,7 +87,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/{number}/reviews/{review_id}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}")]
         public Task<PullRequestReview> Get(string owner, string name, int number, long reviewId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -119,7 +119,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The Pull Request number</param>
         /// <param name="review">The review</param>
-        [ManualRoute("POST", "/repos/{owner}/{name}/pulls/{number}/reviews")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/pulls/{pull_number}/reviews")]
         public Task<PullRequestReview> Create(string owner, string name, int number, PullRequestReviewCreate review)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -154,7 +154,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
-        [ManualRoute("DELETE", "/repos/{owner}/{name}/pulls/{number}/reviews/{review_id}")]
+        [ManualRoute("DELETE", "/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}")]
         public Task Delete(string owner, string name, int number, long reviewId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -187,7 +187,7 @@ namespace Octokit
         /// <param name="number">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <param name="dismissMessage">The message indicating why the review was dismissed</param>
-        [ManualRoute("PUT", "/repos/{owner}/{name}/pulls/{number}/reviews/{review_id}/dismissals")]
+        [ManualRoute("PUT", "/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals")]
         public Task<PullRequestReview> Dismiss(string owner, string name, int number, long reviewId, PullRequestReviewDismiss dismissMessage)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -224,7 +224,7 @@ namespace Octokit
         /// <param name="number">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <param name="submitMessage">The message and event being submitted for the review</param>
-        [ManualRoute("POST", "/repos/{owner}/{name}/pulls/{number}/reviews/{review_id}/events")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/events")]
         public Task<PullRequestReview> Submit(string owner, string name, int number, long reviewId, PullRequestReviewSubmit submitMessage)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -260,7 +260,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/{number}/reviews/{review_id}/comments")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments")]
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllComments(string owner, string name, int number, long reviewId)
         {
             return GetAllComments(owner, name, number, reviewId, ApiOptions.None);
@@ -288,7 +288,7 @@ namespace Octokit
         /// <param name="number">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <param name="options">Options for changing the API response</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/{number}/reviews/{review_id}/comments")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments")]
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllComments(string owner, string name, int number, long reviewId, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/PullRequestsClient.cs
+++ b/Octokit/Clients/PullRequestsClient.cs
@@ -42,7 +42,7 @@ namespace Octokit
         /// http://developer.github.com/v3/pulls/#get-a-single-pull-request
         /// </remarks>
         [Preview("shadow-cat")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/{number}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/pulls/{pull_number}")]
         public Task<PullRequest> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -72,7 +72,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/pulls")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/pulls")]
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -103,7 +103,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/pulls")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/pulls")]
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -138,7 +138,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/pulls")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/pulls")]
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name, PullRequestRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -175,7 +175,7 @@ namespace Octokit
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
         /// <param name="options">Options for changing the API response</param>
         [Preview("shadow-cat")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/pulls")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/pulls")]
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name, PullRequestRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -215,7 +215,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
         [Preview("shadow-cat")]
-        [ManualRoute("POST", "/repos/{owner}/{name}/pulls")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/pulls")]
         public Task<PullRequest> Create(string owner, string name, NewPullRequest newPullRequest)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -250,7 +250,7 @@ namespace Octokit
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
         [Preview("shadow-cat")]
-        [ManualRoute("PATCH", "/repos/{owner}/{name}/pulls/{number}")]
+        [ManualRoute("PATCH", "/repos/{owner}/{repo}/pulls/{pull_number}")]
         public Task<PullRequest> Update(string owner, string name, int number, PullRequestUpdate pullRequestUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -285,7 +285,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
-        [ManualRoute("PUT", "/repos/{owner}/{name}/pulls/{number}/merge")]
+        [ManualRoute("PUT", "/repos/{owner}/{repo}/pulls/{pull_number}/merge")]
         public async Task<PullRequestMerge> Merge(string owner, string name, int number, MergePullRequest mergePullRequest)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -353,7 +353,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/{number}/merge")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/pulls/{pull_number}/merge")]
         public async Task<bool> Merged(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -399,7 +399,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/{number}/commits")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/pulls/{pull_number}/commits")]
         public Task<IReadOnlyList<PullRequestCommit>> Commits(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -427,7 +427,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/{number}/files")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/pulls/{pull_number}/files")]
         public Task<IReadOnlyList<PullRequestFile>> Files(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/ReactionsClient.cs
+++ b/Octokit/Clients/ReactionsClient.cs
@@ -57,7 +57,7 @@ namespace Octokit
         /// <param name="number">The reaction id</param>
         /// <returns></returns>
         [Preview("squirrel-girl")]
-        [ManualRoute("DELETE", "/reactions/{number}")]
+        [ManualRoute("DELETE", "/reactions/{reaction_id}")]
         public Task Delete(int number)
         {
             return ApiConnection.Delete(ApiUrls.Reactions(number), new object(), AcceptHeaders.ReactionsPreview);

--- a/Octokit/Clients/ReferencesClient.cs
+++ b/Octokit/Clients/ReferencesClient.cs
@@ -35,7 +35,7 @@ namespace Octokit
         /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
         /// "heads/master" or "tags/release-1")
         /// </remarks>
-        [ManualRoute("GET", "/repos/{owner}/{name}/git/refs/{ref}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/git/refs/{ref}")]
         public Task<Reference> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -86,7 +86,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <returns></returns>
-        [ManualRoute("GET", "/repos/{owner}/{name}/git/refs")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/git/refs")]
         public Task<IReadOnlyList<Reference>> GetAll(string owner, string name)
         {
             return GetAll(owner, name, ApiOptions.None);
@@ -102,7 +102,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
-        [ManualRoute("GET", "/repos/{owner}/{name}/git/refs")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/git/refs")]
         public Task<IReadOnlyList<Reference>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -153,7 +153,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="subNamespace">The sub-namespace to get references for</param>
         /// <returns></returns>
-        [ManualRoute("GET", "/repos/{owner}/{name}/git/refs/{ref}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/git/refs/{ref}")]
         public Task<IReadOnlyList<Reference>> GetAllForSubNamespace(string owner, string name, string subNamespace)
         {
             return GetAllForSubNamespace(owner, name, subNamespace, ApiOptions.None);
@@ -175,7 +175,7 @@ namespace Octokit
         /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
         /// "heads/master" or "tags/release-1")
         /// </remarks>
-        [ManualRoute("GET", "/repos/{owner}/{name}/git/refs/{ref}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/git/refs/{ref}")]
         public Task<IReadOnlyList<Reference>> GetAllForSubNamespace(string owner, string name, string subNamespace, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -245,7 +245,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference to create</param>
         /// <returns></returns>
-        [ManualRoute("POST", "/repos/{owner}/{name}/git/refs")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/git/refs")]
         public Task<Reference> Create(string owner, string name, NewReference reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -288,7 +288,7 @@ namespace Octokit
         /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
         /// "heads/master" or "tags/release-1")
         /// </remarks>
-        [ManualRoute("PATCH", "/repos/{owner}/{name}/git/refs/{ref}")]
+        [ManualRoute("PATCH", "/repos/{owner}/{repo}/git/refs/{ref}")]
         public Task<Reference> Update(string owner, string name, string reference, ReferenceUpdate referenceUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -348,7 +348,7 @@ namespace Octokit
         /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
         /// "heads/master" or "tags/release-1")
         /// </remarks>
-        [ManualRoute("PATCH", "/repos/{owner}/{name}/git/refs/{ref}")]
+        [ManualRoute("PATCH", "/repos/{owner}/{repo}/git/refs/{ref}")]
         public Task Delete(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/ReleasesClient.cs
+++ b/Octokit/Clients/ReleasesClient.cs
@@ -28,7 +28,7 @@ namespace Octokit
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [ManualRoute("GET", "/repos/{owner}/{name}/releases")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/releases")]
         public Task<IReadOnlyList<Release>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -61,7 +61,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [ManualRoute("GET", "/repos/{owner}/{name}/releases")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/releases")]
         public Task<IReadOnlyList<Release>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -100,7 +100,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="id">The id of the release</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [ManualRoute("GET", "/repos/{owner}/{name}/releases/{id}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/releases/{release_id}")]
         public Task<Release> Get(string owner, string name, int id)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -120,7 +120,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="tag">The tag of the release</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [ManualRoute("GET", "/repos/{owner}/{name}/releases/tags/{tag}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/releases/tags/{tag}")]
         public Task<Release> Get(string owner, string name, string tag)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -174,7 +174,7 @@ namespace Octokit
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [ManualRoute("GET", "/repos/{owner}/{name}/releases/latest")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/releases/latest")]
         public Task<Release> GetLatest(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -209,7 +209,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="data">A description of the release to create</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [ManualRoute("POST", "/repos/{owner}/{name}/releases")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/releases")]
         public Task<Release> Create(string owner, string name, NewRelease data)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -249,7 +249,7 @@ namespace Octokit
         /// <param name="id">The id of the release</param>
         /// <param name="data">A description of the release to edit</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [ManualRoute("PATCH", "/repos/{owner}/{name}/releases/{id}")]
+        [ManualRoute("PATCH", "/repos/{owner}/{repo}/releases/{release_id}")]
         public Task<Release> Edit(string owner, string name, int id, ReleaseUpdate data)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -289,7 +289,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="id">The id of the release to delete</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [ManualRoute("DELETE", "/repos/{owner}/{name}/releases/{id}")]
+        [ManualRoute("DELETE", "/repos/{owner}/{repo}/releases/{release_id}")]
         public Task Delete(string owner, string name, int id)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -325,7 +325,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="id">The id of the <see cref="Release"/>.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [ManualRoute("GET", "/repos/{owner}/{name}/releases/{id}/assets")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/releases/{release_id}/assets")]
         public Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(string owner, string name, int id)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -360,7 +360,7 @@ namespace Octokit
         /// <param name="id">The id of the <see cref="Release"/>.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [ManualRoute("GET", "/repos/{owner}/{name}/releases/{id}/assets")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/releases/{release_id}/assets")]
         public Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(string owner, string name, int id, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -433,7 +433,7 @@ namespace Octokit
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
         /// <param name="assetId">The id of the <see cref="ReleaseAsset"/></param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/releases/assets/{asset_id}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/releases/assets/{asset_id}")]
         public Task<ReleaseAsset> GetAsset(string owner, string name, int assetId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -468,7 +468,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="assetId">The id of the <see cref="ReleaseAsset"/></param>
         /// <param name="data">Description of the asset with its amended data</param>
-        [ManualRoute("PATCH", "/repos/{owner}/{name}/releases/assets/{asset_id}")]
+        [ManualRoute("PATCH", "/repos/{owner}/{repo}/releases/assets/{asset_id}")]
         public Task<ReleaseAsset> EditAsset(string owner, string name, int assetId, ReleaseAssetUpdate data)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -506,7 +506,7 @@ namespace Octokit
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
         /// <param name="id">The id of the <see cref="ReleaseAsset"/>.</param>
-        [ManualRoute("DELETE", "/repos/{owner}/{name}/releases/assets/{asset_id}")]
+        [ManualRoute("DELETE", "/repos/{owner}/{repo}/releases/assets/{asset_id}")]
         public Task DeleteAsset(string owner, string name, int id)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/RepoCollaboratorsClient.cs
+++ b/Octokit/Clients/RepoCollaboratorsClient.cs
@@ -29,7 +29,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [ManualRoute("GET", "/repos/{owner}/{name}/collaborators")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/collaborators")]
         public Task<IReadOnlyList<User>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -62,7 +62,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [ManualRoute("GET", "/repos/{owner}/{name}/collaborators")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/collaborators")]
         public Task<IReadOnlyList<User>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -99,7 +99,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to request and filter a list of repository collaborators</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [ManualRoute("GET", "/repos/{owner}/{name}/collaborators")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/collaborators")]
         public Task<IReadOnlyList<User>> GetAll(string owner, string name, RepositoryCollaboratorListRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -137,7 +137,7 @@ namespace Octokit
         /// <param name="request">Used to request and filter a list of repository collaborators</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [ManualRoute("GET", "/repos/{owner}/{name}/collaborators")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/collaborators")]
         public Task<IReadOnlyList<User>> GetAll(string owner, string name, RepositoryCollaboratorListRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -178,7 +178,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="user">Username of the prospective collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [ManualRoute("GET", "/repos/{owner}/{name}/collaborators/{username}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/collaborators/{username}")]
         public async Task<bool> IsCollaborator(string owner, string name, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -231,7 +231,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="user">Username of the collaborator to check permission for</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [ManualRoute("GET", "/repos/{owner}/{name}/collaborators/{username}/permission")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/collaborators/{username}/permission")]
         public Task<CollaboratorPermission> ReviewPermission(string owner, string name, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -270,7 +270,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="user">Username of the new collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [ManualRoute("PUT", "/repos/{owner}/{name}/collaborators/{username}")]
+        [ManualRoute("PUT", "/repos/{owner}/{repo}/collaborators/{username}")]
         public Task Add(string owner, string name, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -291,7 +291,7 @@ namespace Octokit
         /// <param name="user">Username of the new collaborator</param>
         /// <param name="permission">The permission to set. Only valid on organization-owned repositories.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [ManualRoute("PUT", "/repos/{owner}/{name}/collaborators/{username}")]
+        [ManualRoute("PUT", "/repos/{owner}/{repo}/collaborators/{username}")]
         public async Task<bool> Add(string owner, string name, string user, CollaboratorRequest permission)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -362,7 +362,7 @@ namespace Octokit
         /// <param name="name">The name of the repository.</param>
         /// <param name="user">The name of the user to invite.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [ManualRoute("PUT", "/repos/{owner}/{name}/collaborators/{username}")]
+        [ManualRoute("PUT", "/repos/{owner}/{repo}/collaborators/{username}")]
         public Task<RepositoryInvitation> Invite(string owner, string name, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -384,7 +384,7 @@ namespace Octokit
         /// <param name="user">The name of the user to invite.</param>
         /// <param name="permission">The permission to set. Only valid on organization-owned repositories.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [ManualRoute("PUT", "/repos/{owner}/{name}/collaborators/{username}")]
+        [ManualRoute("PUT", "/repos/{owner}/{repo}/collaborators/{username}")]
         public Task<RepositoryInvitation> Invite(string owner, string name, string user, CollaboratorRequest permission)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -441,7 +441,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="user">Username of the deleted collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [ManualRoute("DELETE", "/repos/{owner}/{name}/collaborators/{username}")]
+        [ManualRoute("DELETE", "/repos/{owner}/{repo}/collaborators/{username}")]
         public Task Delete(string owner, string name, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -143,7 +143,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [ManualRoute("DELETE", "/repos/{owner}/{name}")]
+        [ManualRoute("DELETE", "/repos/{owner}/{repo}")]
         public Task Delete(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -177,7 +177,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="repositoryTransfer">Repository transfer information</param>
         /// <returns>A <see cref="Repository"/></returns>
-        [ManualRoute("POST", "/repos/{owner}/{name}/transfer")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/transfer")]
         public Task<Repository> Transfer(string owner, string name, RepositoryTransfer repositoryTransfer)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -211,7 +211,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="update">New values to update the repository with</param>
         /// <returns>The updated <see cref="T:Octokit.Repository"/></returns>
-        [ManualRoute("PATCH", "/repos/{owner}/{name}")]
+        [ManualRoute("PATCH", "/repos/{owner}/{repo}")]
         public Task<Repository> Edit(string owner, string name, RepositoryUpdate update)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -246,7 +246,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="Repository"/></returns>
-        [ManualRoute("GET", "/repos/{owner}/{name}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}")]
         public Task<Repository> Get(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -576,7 +576,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <returns>All contributors of the repository.</returns>
-        [ManualRoute("GET", "/repos/{owner}/{name}/contributors")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/contributors")]
         public Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -609,7 +609,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All contributors of the repository.</returns>
-        [ManualRoute("GET", "/repos/{owner}/{name}/contributors")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/contributors")]
         public Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -646,7 +646,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="includeAnonymous">True if anonymous contributors should be included in result; Otherwise false</param>
         /// <returns>All contributors of the repository.</returns>
-        [ManualRoute("GET", "/repos/{owner}/{name}/contributors")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/contributors")]
         public Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(string owner, string name, bool includeAnonymous)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -681,7 +681,7 @@ namespace Octokit
         /// <param name="includeAnonymous">True if anonymous contributors should be included in result; Otherwise false</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All contributors of the repository.</returns>
-        [ManualRoute("GET", "/repos/{owner}/{name}/contributors")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/contributors")]
         public Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(string owner, string name, bool includeAnonymous, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -726,7 +726,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <returns>All languages used in the repository and the number of bytes of each language.</returns>
-        [ManualRoute("GET", "/repos/{owner}/{name}/languages")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/languages")]
         public async Task<IReadOnlyList<RepositoryLanguage>> GetAllLanguages(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -768,7 +768,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <returns>All <see cref="T:Octokit.Team"/>s associated with the repository</returns>
-        [ManualRoute("GET", "/repos/{owner}/{name}/teams")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/teams")]
         public Task<IReadOnlyList<Team>> GetAllTeams(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -801,7 +801,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All <see cref="T:Octokit.Team"/>s associated with the repository</returns>
-        [ManualRoute("GET", "/repos/{owner}/{name}/teams")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/teams")]
         public Task<IReadOnlyList<Team>> GetAllTeams(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -837,7 +837,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <returns>All of the repositories tags.</returns>
-        [ManualRoute("GET", "/repos/{owner}/{name}/tags")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/tags")]
         public Task<IReadOnlyList<RepositoryTag>> GetAllTags(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -870,7 +870,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All of the repositories tags.</returns>
-        [ManualRoute("GET", "/repos/{owner}/{name}/tags")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/tags")]
         public Task<IReadOnlyList<RepositoryTag>> GetAllTags(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -906,7 +906,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <returns>Returns the contents of the repository's license file, if one is detected.</returns>
-        [ManualRoute("GET", "/repos/{owner}/{name}/license")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/license")]
         public Task<RepositoryContentLicense> GetLicenseContents(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/RepositoryBranchesClient.cs
+++ b/Octokit/Clients/RepositoryBranchesClient.cs
@@ -32,7 +32,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/branches")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/branches")]
         public Task<IReadOnlyList<Branch>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -65,7 +65,7 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         [Preview("luke-cage")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/branches")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/branches")]
         public Task<IReadOnlyList<Branch>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -102,7 +102,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         [Preview("luke-cage")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/branches/{branch}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/branches/{branch}")]
         public Task<Branch> Get(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -139,7 +139,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         [Preview("luke-cage")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/branches/{branch}/protection")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/branches/{branch}/protection")]
         public Task<BranchProtectionSettings> GetBranchProtection(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -177,7 +177,7 @@ namespace Octokit
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">Branch protection settings</param>
         [Preview("luke-cage")]
-        [ManualRoute("PUT", "/repos/{owner}/{name}/branches/{branch}/protection")]
+        [ManualRoute("PUT", "/repos/{owner}/{repo}/branches/{branch}/protection")]
         public Task<BranchProtectionSettings> UpdateBranchProtection(string owner, string name, string branch, BranchProtectionSettingsUpdate update)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -217,7 +217,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         [Preview("luke-cage")]
-        [ManualRoute("DELETE", "/repos/{owner}/{name}/branches/{branch}/protection")]
+        [ManualRoute("DELETE", "/repos/{owner}/{repo}/branches/{branch}/protection")]
         public async Task<bool> DeleteBranchProtection(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -272,7 +272,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         [Preview("luke-cage")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/branches/{branch}/protection/required_status_checks")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks")]
         public Task<BranchProtectionRequiredStatusChecks> GetRequiredStatusChecks(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -310,7 +310,7 @@ namespace Octokit
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">Required status checks</param>
         [Preview("luke-cage")]
-        [ManualRoute("PATCH", "/repos/{owner}/{name}/branches/{branch}/protection/required_status_checks")]
+        [ManualRoute("PATCH", "/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks")]
         public Task<BranchProtectionRequiredStatusChecks> UpdateRequiredStatusChecks(string owner, string name, string branch, BranchProtectionRequiredStatusChecksUpdate update)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -350,7 +350,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         [Preview("luke-cage")]
-        [ManualRoute("DELETE", "/repos/{owner}/{name}/branches/{branch}/protection/required_status_checks")]
+        [ManualRoute("DELETE", "/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks")]
         public async Task<bool> DeleteRequiredStatusChecks(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -407,7 +407,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         [Preview("luke-cage")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/branches/{branch}/protection/required_status_checks/contexts")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts")]
         public Task<IReadOnlyList<string>> GetAllRequiredStatusChecksContexts(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -445,7 +445,7 @@ namespace Octokit
         /// <param name="branch">The name of the branch</param>
         /// <param name="contexts">The contexts to replace</param>
         [Preview("luke-cage")]
-        [ManualRoute("PUT", "/repos/{owner}/{name}/branches/{branch}/protection/required_status_checks/contexts")]
+        [ManualRoute("PUT", "/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts")]
         public Task<IReadOnlyList<string>> UpdateRequiredStatusChecksContexts(string owner, string name, string branch, IReadOnlyList<string> contexts)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -486,7 +486,7 @@ namespace Octokit
         /// <param name="branch">The name of the branch</param>
         /// <param name="contexts">The contexts to add</param>
         [Preview("luke-cage")]
-        [ManualRoute("POST", "/repos/{owner}/{name}/branches/{branch}/protection/required_status_checks/contexts")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts")]
         public Task<IReadOnlyList<string>> AddRequiredStatusChecksContexts(string owner, string name, string branch, IReadOnlyList<string> contexts)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -527,7 +527,7 @@ namespace Octokit
         /// <param name="branch">The name of the branch</param>
         /// <param name="contexts">The contexts to remove</param>
         [Preview("luke-cage")]
-        [ManualRoute("DELETE", "/repos/{owner}/{name}/branches/{branch}/protection/required_status_checks/contexts")]
+        [ManualRoute("DELETE", "/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts")]
         public Task<IReadOnlyList<string>> DeleteRequiredStatusChecksContexts(string owner, string name, string branch, IReadOnlyList<string> contexts)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -567,7 +567,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         [Preview("luke-cage")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/branches/{branch}/protection/required_pull_request_reviews")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews")]
         public Task<BranchProtectionRequiredReviews> GetReviewEnforcement(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -605,7 +605,7 @@ namespace Octokit
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">The required pull request review settings</param>
         [Preview("luke-cage")]
-        [ManualRoute("PATCH", "/repos/{owner}/{name}/branches/{branch}/protection/required_pull_request_reviews")]
+        [ManualRoute("PATCH", "/repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews")]
         public Task<BranchProtectionRequiredReviews> UpdateReviewEnforcement(string owner, string name, string branch, BranchProtectionRequiredReviewsUpdate update)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -645,7 +645,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         [Preview("luke-cage")]
-        [ManualRoute("DELETE", "/repos/{owner}/{name}/branches/{branch}/protection/required_pull_request_reviews")]
+        [ManualRoute("DELETE", "/repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews")]
         public async Task<bool> RemoveReviewEnforcement(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -702,7 +702,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         [Preview("luke-cage")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/branches/{branch}/protection/enforce_admins")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins")]
         public Task<EnforceAdmins> GetAdminEnforcement(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -739,7 +739,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         [Preview("luke-cage")]
-        [ManualRoute("POST", "/repos/{owner}/{name}/branches/{branch}/protection/enforce_admins")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins")]
         public Task<EnforceAdmins> AddAdminEnforcement(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -776,7 +776,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         [Preview("luke-cage")]
-        [ManualRoute("DELETE", "/repos/{owner}/{name}/branches/{branch}/protection/enforce_admins")]
+        [ManualRoute("DELETE", "/repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins")]
         public async Task<bool> RemoveAdminEnforcement(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -833,7 +833,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         [Preview("luke-cage")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/branches/{branch}/protection/restrictions")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions")]
         public Task<BranchProtectionPushRestrictions> GetProtectedBranchRestrictions(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -870,7 +870,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         [Preview("luke-cage")]
-        [ManualRoute("DELETE", "/repos/{owner}/{name}/branches/{branch}/protection/restrictions")]
+        [ManualRoute("DELETE", "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions")]
         public async Task<bool> DeleteProtectedBranchRestrictions(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -927,7 +927,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         [Preview("luke-cage")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/branches/{branch}/protection/restrictions/teams")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams")]
         public Task<IReadOnlyList<Team>> GetAllProtectedBranchTeamRestrictions(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -965,7 +965,7 @@ namespace Octokit
         /// <param name="branch">The name of the branch</param>
         /// <param name="teams">List of teams with push access</param>
         [Preview("luke-cage")]
-        [ManualRoute("PUT", "/repos/{owner}/{name}/branches/{branch}/protection/restrictions/teams")]
+        [ManualRoute("PUT", "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams")]
         public Task<IReadOnlyList<Team>> UpdateProtectedBranchTeamRestrictions(string owner, string name, string branch, BranchProtectionTeamCollection teams)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -1006,7 +1006,7 @@ namespace Octokit
         /// <param name="branch">The name of the branch</param>
         /// <param name="teams">List of teams with push access to add</param>
         [Preview("luke-cage")]
-        [ManualRoute("POST", "/repos/{owner}/{name}/branches/{branch}/protection/restrictions/teams")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams")]
         public Task<IReadOnlyList<Team>> AddProtectedBranchTeamRestrictions(string owner, string name, string branch, BranchProtectionTeamCollection teams)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -1047,7 +1047,7 @@ namespace Octokit
         /// <param name="branch">The name of the branch</param>
         /// <param name="teams">List of teams to remove</param>
         [Preview("luke-cage")]
-        [ManualRoute("DELETE", "/repos/{owner}/{name}/branches/{branch}/protection/restrictions/teams")]
+        [ManualRoute("DELETE", "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams")]
         public Task<IReadOnlyList<Team>> DeleteProtectedBranchTeamRestrictions(string owner, string name, string branch, BranchProtectionTeamCollection teams)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -1087,7 +1087,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         [Preview("luke-cage")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/branches/{branch}/protection/restrictions/users")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users")]
         public Task<IReadOnlyList<User>> GetAllProtectedBranchUserRestrictions(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -1125,7 +1125,7 @@ namespace Octokit
         /// <param name="branch">The name of the branch</param>
         /// <param name="users">List of users with push access</param>
         [Preview("luke-cage")]
-        [ManualRoute("UPDATE", "/repos/{owner}/{name}/branches/{branch}/protection/restrictions/users")]
+        [ManualRoute("UPDATE", "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users")]
         public Task<IReadOnlyList<User>> UpdateProtectedBranchUserRestrictions(string owner, string name, string branch, BranchProtectionUserCollection users)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -1166,7 +1166,7 @@ namespace Octokit
         /// <param name="branch">The name of the branch</param>
         /// <param name="users">List of users with push access to add</param>
         [Preview("luke-cage")]
-        [ManualRoute("POST", "/repos/{owner}/{name}/branches/{branch}/protection/restrictions/users")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users")]
         public Task<IReadOnlyList<User>> AddProtectedBranchUserRestrictions(string owner, string name, string branch, BranchProtectionUserCollection users)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -1207,7 +1207,7 @@ namespace Octokit
         /// <param name="branch">The name of the branch</param>
         /// <param name="users">List of users with push access to remove</param>
         [Preview("luke-cage")]
-        [ManualRoute("DELETE", "/repos/{owner}/{name}/branches/{branch}/protection/restrictions/users")]
+        [ManualRoute("DELETE", "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users")]
         public Task<IReadOnlyList<User>> DeleteProtectedBranchUserRestrictions(string owner, string name, string branch, BranchProtectionUserCollection users)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/RepositoryCommentsClient.cs
+++ b/Octokit/Clients/RepositoryCommentsClient.cs
@@ -28,7 +28,7 @@ namespace Octokit
         /// <param name="number">The comment id</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#get-a-single-commit-comment</remarks>
         [Preview("squirrel-girl")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/comments/{number}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/comments/{comment_id}")]
         public Task<CommitComment> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -56,7 +56,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository</remarks>
-        [ManualRoute("GET", "/repos/{owner}/{name}/comments")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/comments")]
         public Task<IReadOnlyList<CommitComment>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -84,7 +84,7 @@ namespace Octokit
         /// <param name="options">Options to change the API response</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository</remarks>
         [Preview("squirrel-girl")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/comments")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/comments")]
         public Task<IReadOnlyList<CommitComment>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -116,7 +116,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="sha">The sha of the commit</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit</remarks>
-        [ManualRoute("GET", "/repos/{owner}/{name}/commits/{sha}/comments")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/commits/{commit_sha}/comments")]
         public Task<IReadOnlyList<CommitComment>> GetAllForCommit(string owner, string name, string sha)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -132,7 +132,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="sha">The sha of the commit</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit</remarks>
-        [ManualRoute("GET", "/repositories/{id}/commits/{sha}/comments")]
+        [ManualRoute("GET", "/repositories/{id}/commits/{commit_sha}/comments")]
         public Task<IReadOnlyList<CommitComment>> GetAllForCommit(long repositoryId, string sha)
         {
             Ensure.ArgumentNotNullOrEmptyString(sha, nameof(sha));
@@ -149,7 +149,7 @@ namespace Octokit
         /// <param name="options">Options to change the API response</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit</remarks>
         [Preview("squirrel-girl")]
-        [ManualRoute("GET", "/repos/{owner}/{name}/commits/{sha}/comments")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/commits/{commit_sha}/comments")]
         public Task<IReadOnlyList<CommitComment>> GetAllForCommit(string owner, string name, string sha, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -168,7 +168,7 @@ namespace Octokit
         /// <param name="options">Options to change the API response</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit</remarks>
         [Preview("squirrel-girl")]
-        [ManualRoute("GET", "/repositories/{id}/commits/{sha}/comments")]
+        [ManualRoute("GET", "/repositories/{id}/commits/{commit_sha}/comments")]
         public Task<IReadOnlyList<CommitComment>> GetAllForCommit(long repositoryId, string sha, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(sha, nameof(sha));
@@ -185,7 +185,7 @@ namespace Octokit
         /// <param name="sha">The sha reference of commit</param>
         /// <param name="newCommitComment">The new comment to add to the commit</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#create-a-commit-comment</remarks>
-        [ManualRoute("POST", "/repos/{owner}/{name}/commits/{sha}/comments")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/commits/{commit_sha}/comments")]
         public Task<CommitComment> Create(string owner, string name, string sha, NewCommitComment newCommitComment)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -203,7 +203,7 @@ namespace Octokit
         /// <param name="sha">The sha reference of commit</param>
         /// <param name="newCommitComment">The new comment to add to the commit</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#create-a-commit-comment</remarks>
-        [ManualRoute("POST", "/repositories/{id}/commits/{sha}/comments")]
+        [ManualRoute("POST", "/repositories/{id}/commits/{commit_sha}/comments")]
         public Task<CommitComment> Create(long repositoryId, string sha, NewCommitComment newCommitComment)
         {
             Ensure.ArgumentNotNullOrEmptyString(sha, nameof(sha));
@@ -220,7 +220,7 @@ namespace Octokit
         /// <param name="number">The comment number</param>
         /// <param name="commentUpdate">The modified comment</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#update-a-commit-comment</remarks>
-        [ManualRoute("PATCH", "/repos/{owner}/{name}/comments/{number}")]
+        [ManualRoute("PATCH", "/repos/{owner}/{repo}/comments/{comment_id}")]
         public Task<CommitComment> Update(string owner, string name, int number, string commentUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -252,7 +252,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#delete-a-commit-comment</remarks>
-        [ManualRoute("DELETE", "/repos/{owner}/{name}/comments/{number}")]
+        [ManualRoute("DELETE", "/repos/{owner}/{repo}/comments/{comment_id}")]
         public Task Delete(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/RepositoryCommitsClient.cs
+++ b/Octokit/Clients/RepositoryCommitsClient.cs
@@ -23,7 +23,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="base">The reference to use as the base commit</param>
         /// <param name="head">The reference to use as the head commit</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/compare/{base}...{head}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/compare/{base}...{head}")]
         public Task<CompareResult> Compare(string owner, string name, string @base, string head)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -55,7 +55,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference for the commit (SHA)</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/commits/{sha}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/commits/{commit_sha}")]
         public Task<GitHubCommit> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -70,7 +70,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference for the commit (SHA)</param>
-        [ManualRoute("GET", "/repositories/{id}/commits/{sha}")]
+        [ManualRoute("GET", "/repositories/{id}/commits/{commit_sha}")]
         public Task<GitHubCommit> Get(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
@@ -83,7 +83,7 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/commits")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/commits")]
         public Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -108,7 +108,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/commits")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/commits")]
         public Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -134,7 +134,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/commits")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/commits")]
         public Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name, CommitRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -164,7 +164,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
         /// <param name="options">Options for changing the API response</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/commits")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/commits")]
         public Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name, CommitRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -196,7 +196,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The repository reference</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/commits/{sha}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/commits/{commit_sha}")]
         public Task<string> GetSha1(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -211,7 +211,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The repository reference</param>
-        [ManualRoute("GET", "/repositories/{id}/commits/{sha}")]
+        [ManualRoute("GET", "/repositories/{id}/commits/{commit_sha}")]
         public Task<string> GetSha1(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));

--- a/Octokit/Clients/RepositoryContentsClient.cs
+++ b/Octokit/Clients/RepositoryContentsClient.cs
@@ -29,7 +29,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The content path</param>
-        [ManualRoute("GET", "repos/{owner}/{repo}/contents/{path}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/contents/{path}")]
         public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, string path)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -49,7 +49,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The content path</param>
-        [ManualRoute("GET", "repoitories/{id}/contents/{path}")]
+        [ManualRoute("GET", "/repoitories/{id}/contents/{path}")]
         public Task<IReadOnlyList<RepositoryContent>> GetAllContents(long repositoryId, string path)
         {
             Ensure.ArgumentNotNullOrEmptyString(path, nameof(path));
@@ -67,7 +67,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        [ManualRoute("GET", "repos/{owner}/{name}/contents/{path}")]
+        [ManualRoute("GET", "/repos/{owner}/{name}/contents/{path}")]
         public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -85,7 +85,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        [ManualRoute("GET", "repositories/{id}/contents/{path}")]
+        [ManualRoute("GET", "/repositories/{id}/contents/{path}")]
         public Task<IReadOnlyList<RepositoryContent>> GetAllContents(long repositoryId)
         {
             var url = ApiUrls.RepositoryContent(repositoryId, string.Empty);
@@ -104,7 +104,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The content path</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository�s default branch (usually master)</param>
-        [ManualRoute("GET", "repos/{owner}/{repo}/contents/{path}?ref={ref}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/contents/{path}?ref={ref}")]
         public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string path, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -128,7 +128,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The content path</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
-        [ManualRoute("GET", "repositories/{id}/contents/{path}?ref={ref}")]
+        [ManualRoute("GET", "/repositories/{id}/contents/{path}?ref={ref}")]
         public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(long repositoryId, string path, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(path, nameof(path));
@@ -148,7 +148,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository�s default branch (usually master)</param>
-        [ManualRoute("GET", "repos/{owner}/{repo}/contents/{path}?ref={ref}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/contents/{path}?ref={ref}")]
         public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -169,7 +169,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
-        [ManualRoute("GET", "repositories/{id}/contents/{path}?ref={ref}")]
+        [ManualRoute("GET", "/repositories/{id}/contents/{path}?ref={ref}")]
         public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
@@ -188,7 +188,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [ManualRoute("GET", "repos/{owner}/{name}/readme")]
+        [ManualRoute("GET", "/repos/{owner}/{name}/readme")]
         public async Task<Readme> GetReadme(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -208,7 +208,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [ManualRoute("GET", "repositories/{id}/readme")]
+        [ManualRoute("GET", "/repositories/{id}/readme")]
         public async Task<Readme> GetReadme(long repositoryId)
         {
             var endpoint = ApiUrls.RepositoryReadme(repositoryId);
@@ -282,7 +282,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/{archive_format}/{ref}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/{archive_format}/{ref}")]
         public Task<byte[]> GetArchive(string owner, string name, ArchiveFormat archiveFormat)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -311,7 +311,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/{archive_format}/{ref}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/{archive_format}/{ref}")]
         public Task<byte[]> GetArchive(string owner, string name, ArchiveFormat archiveFormat, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -345,7 +345,7 @@ namespace Octokit
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
         /// <param name="timeout"> Time span until timeout </param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/{archive_format}/{ref}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/{archive_format}/{ref}")]
         public async Task<byte[]> GetArchive(string owner, string name, ArchiveFormat archiveFormat, string reference, TimeSpan timeout)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -388,7 +388,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to create</param>
-        [ManualRoute("PUT", "/repos/{owner}/{name}/contents/{path}")]
+        [ManualRoute("PUT", "/repos/{owner}/{repo}/contents/{path}")]
         public Task<RepositoryContentChangeSet> CreateFile(string owner, string name, string path, CreateFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -423,7 +423,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to update</param>
-        [ManualRoute("PUT", "/repos/{owner}/{name}/contents/{path}")]
+        [ManualRoute("PUT", "/repos/{owner}/{repo}/contents/{path}")]
         public Task<RepositoryContentChangeSet> UpdateFile(string owner, string name, string path, UpdateFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -458,7 +458,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to delete</param>
-        [ManualRoute("DELETE", "/repos/{owner}/{name}/contents/{path}")]
+        [ManualRoute("DELETE", "/repos/{owner}/{repo}/contents/{path}")]
         public Task DeleteFile(string owner, string name, string path, DeleteFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/RepositoryDeployKeysClient.cs
+++ b/Octokit/Clients/RepositoryDeployKeysClient.cs
@@ -30,7 +30,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="number">The id of the deploy key.</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/keys/{number}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/keys/{number}")]
         public Task<DeployKey> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -61,7 +61,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/keys")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/keys")]
         public Task<IReadOnlyList<DeployKey>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -92,7 +92,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/keys")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/keys")]
         public Task<IReadOnlyList<DeployKey>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -127,7 +127,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="newDeployKey">The deploy key to create for the repository.</param>
-        [ManualRoute("POST", "/repos/{owner}/{name}/keys")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/keys")]
         public Task<DeployKey> Create(string owner, string name, NewDeployKey newDeployKey)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/RepositoryHooksClient.cs
+++ b/Octokit/Clients/RepositoryHooksClient.cs
@@ -26,7 +26,7 @@ namespace Octokit
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        [ManualRoute("GET", "/repos/{owner}/{name}/hooks")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/hooks")]
         public Task<IReadOnlyList<RepositoryHook>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -53,7 +53,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        [ManualRoute("GET", "/repos/{owner}/{name}/hooks")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/hooks")]
         public Task<IReadOnlyList<RepositoryHook>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -84,7 +84,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
-        [ManualRoute("GET", "/repos/{owner}/{name}/hooks/{id}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/hooks/{id}")]
         public Task<RepositoryHook> Get(string owner, string name, int hookId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -112,7 +112,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="hook">The hook's parameters</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
-        [ManualRoute("POST", "/repos/{owner}/{name}/hooks")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/hooks")]
         public Task<RepositoryHook> Create(string owner, string name, NewRepositoryHook hook)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -144,7 +144,7 @@ namespace Octokit
         /// <param name="hookId">The repository's hook id</param>
         /// <param name="hook">The requested changes to an edit repository hook</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        [ManualRoute("PATCH", "/repos/{owner}/{name}/hooks/{id}")]
+        [ManualRoute("PATCH", "/repos/{owner}/{repo}/hooks/{id}")]
         public Task<RepositoryHook> Edit(string owner, string name, int hookId, EditRepositoryHook hook)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -178,7 +178,7 @@ namespace Octokit
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#test-a-hook">API documentation</a> for more information.
         /// This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook
         /// is not subscribed to push events, the server will respond with 204 but no test POST will be generated.</remarks>
-        [ManualRoute("POST", "/repos/{owner}/{name}/hooks/{id}/tests")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/hooks/{id}/tests")]
         public Task Test(string owner, string name, int hookId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -208,7 +208,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        [ManualRoute("POST", "/repos/{owner}/{name}/hooks/{id}/pings")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/hooks/{id}/pings")]
         public Task Ping(string owner, string name, int hookId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -236,7 +236,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#delete-a-hook">API documentation</a> for more information.</remarks>
-        [ManualRoute("DELETE", "/repos/{owner}/{name}/hooks/{id}")]
+        [ManualRoute("DELETE", "/repos/{owner}/{repo}/hooks/{id}")]
         public Task Delete(string owner, string name, int hookId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/RepositoryPagesClient.cs
+++ b/Octokit/Clients/RepositoryPagesClient.cs
@@ -27,7 +27,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
-        [ManualRoute("GET", "/repos/{owner}/{name}/pages")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/pages")]
         public Task<Page> Get(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -57,7 +57,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        [ManualRoute("GET", "/repos/{owner}/{name}/pages/builds")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/pages/builds")]
         public Task<IReadOnlyList<PagesBuild>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -88,7 +88,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        [ManualRoute("GET", "/repos/{owner}/{name}/pages/builds")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/pages/builds")]
         public Task<IReadOnlyList<PagesBuild>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -124,7 +124,7 @@ namespace Octokit
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>
-        [ManualRoute("GET", "/repos/{owner}/{name}/pages/builds/latest")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/pages/builds/latest")]
         public Task<PagesBuild> GetLatest(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -154,7 +154,7 @@ namespace Octokit
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#request-a-page-build">API documentation</a> for more information.
         /// </remarks>
-        [ManualRoute("POST", "/repos/{owner}/{name}/pages/builds")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/pages/builds")]
         public Task<PagesBuild> RequestPageBuild(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/RepositoryTrafficClient.cs
+++ b/Octokit/Clients/RepositoryTrafficClient.cs
@@ -27,7 +27,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/repos/traffic/#list-paths</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        [ManualRoute("GET", "/repositories/{owner}/{name}/traffic/popular/paths")]
+        [ManualRoute("GET", "/repositories/{owner}/{repo}/traffic/popular/paths")]
         public Task<IReadOnlyList<RepositoryTrafficPath>> GetAllPaths(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -53,7 +53,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/repos/traffic/#list-referrers</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        [ManualRoute("GET", "/repositories/{owner}/{name}/traffic/popular/referrers")]
+        [ManualRoute("GET", "/repositories/{owner}/{repo}/traffic/popular/referrers")]
         public Task<IReadOnlyList<RepositoryTrafficReferrer>> GetAllReferrers(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -83,7 +83,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="per">Breakdown per day or week</param>
-        [ManualRoute("GET", "/repositories/{owner}/{name}/traffic/clones")]
+        [ManualRoute("GET", "/repositories/{owner}/{repo}/traffic/clones")]
         public Task<RepositoryTrafficCloneSummary> GetClones(string owner, string name, RepositoryTrafficRequest per)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -114,7 +114,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="per">Breakdown per day or week</param>
-        [ManualRoute("GET", "/repositories/{owner}/{name}/traffic/views")]
+        [ManualRoute("GET", "/repositories/{owner}/{repo}/traffic/views")]
         public Task<RepositoryTrafficViewSummary> GetViews(string owner, string name, RepositoryTrafficRequest per)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/StarredClient.cs
+++ b/Octokit/Clients/StarredClient.cs
@@ -26,7 +26,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        [ManualRoute("GET", "/repos/{owner}/{name}/stargazers")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/stargazers")]
         public Task<IReadOnlyList<User>> GetAllStargazers(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -53,7 +53,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        [ManualRoute("GET", "/repos/{owner}/{name}/stargazers")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/stargazers")]
         public Task<IReadOnlyList<User>> GetAllStargazers(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -83,7 +83,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        [ManualRoute("GET", "/repos/{owner}/{name}/stargazers")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/stargazers")]
         public Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -110,7 +110,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        [ManualRoute("GET", "/repos/{owner}/{name}/stargazers")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/stargazers")]
         public Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -245,7 +245,7 @@ namespace Octokit
         /// </summary>
         /// <param name="user">The login of the user</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        [ManualRoute("GET", "/users/{user}/starred")]
+        [ManualRoute("GET", "/users/{username}/starred")]
         public Task<IReadOnlyList<Repository>> GetAllForUser(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -259,7 +259,7 @@ namespace Octokit
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        [ManualRoute("GET", "/users/{user}/starred")]
+        [ManualRoute("GET", "/users/{username}/starred")]
         public Task<IReadOnlyList<Repository>> GetAllForUser(string user, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -273,7 +273,7 @@ namespace Octokit
         /// </summary>
         /// <param name="user">The login of the user</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        [ManualRoute("GET", "/users/{user}/starred")]
+        [ManualRoute("GET", "/users/{username}/starred")]
         public Task<IReadOnlyList<RepositoryStar>> GetAllForUserWithTimestamps(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -287,7 +287,7 @@ namespace Octokit
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        [ManualRoute("GET", "/users/{user}/starred")]
+        [ManualRoute("GET", "/users/{username}/starred")]
         public Task<IReadOnlyList<RepositoryStar>> GetAllForUserWithTimestamps(string user, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -303,7 +303,7 @@ namespace Octokit
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
-        [ManualRoute("GET", "/users/{user}/starred")]
+        [ManualRoute("GET", "/users/{username}/starred")]
         public Task<IReadOnlyList<Repository>> GetAllForUser(string user, StarredRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -319,7 +319,7 @@ namespace Octokit
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        [ManualRoute("GET", "/users/{user}/starred")]
+        [ManualRoute("GET", "/users/{username}/starred")]
         public Task<IReadOnlyList<Repository>> GetAllForUser(string user, StarredRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -336,7 +336,7 @@ namespace Octokit
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
-        [ManualRoute("GET", "/users/{user}/starred")]
+        [ManualRoute("GET", "/users/{username}/starred")]
         public Task<IReadOnlyList<RepositoryStar>> GetAllForUserWithTimestamps(string user, StarredRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -352,7 +352,7 @@ namespace Octokit
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        [ManualRoute("GET", "/users/{user}/starred")]
+        [ManualRoute("GET", "/users/{username}/starred")]
         public Task<IReadOnlyList<RepositoryStar>> GetAllForUserWithTimestamps(string user, StarredRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -368,7 +368,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        [ManualRoute("GET", "/user/starred/{owner}/{name}")]
+        [ManualRoute("GET", "/user/starred/{owner}/{repo}")]
         public async Task<bool> CheckStarred(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -390,7 +390,7 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository to star</param>
         /// <param name="name">The name of the repository to star</param>
-        [ManualRoute("PUT", "/user/starred/{owner}/{name}")]
+        [ManualRoute("PUT", "/user/starred/{owner}/{repo}")]
         public async Task<bool> StarRepo(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -412,7 +412,7 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository to unstar</param>
         /// <param name="name">The name of the repository to unstar</param>
-        [ManualRoute("DELETE", "/user/starred/{owner}/{name}")]
+        [ManualRoute("DELETE", "/user/starred/{owner}/{repo}")]
         public async Task<bool> RemoveStarFromRepo(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/StatisticsClient.cs
+++ b/Octokit/Clients/StatisticsClient.cs
@@ -28,6 +28,7 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        [ManualRoute("GET", "/repos/{owner}/{repo}/stats/contributors")]
         public Task<IReadOnlyList<Contributor>> GetContributors(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -40,6 +41,7 @@ namespace Octokit
         /// Returns a list of <see cref="Contributor"/> for the given repository
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
+        [ManualRoute("GET", "/repositories/{id}/stats/contributors")]
         public Task<IReadOnlyList<Contributor>> GetContributors(long repositoryId)
         {
             return GetContributors(repositoryId, CancellationToken.None);
@@ -51,6 +53,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="cancellationToken">A token used to cancel this potentially long running request</param>
+        [ManualRoute("GET", "/repos/{owner}/{repo}/stats/contributors")]
         public Task<IReadOnlyList<Contributor>> GetContributors(string owner, string name, CancellationToken cancellationToken)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -64,6 +67,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="cancellationToken">A token used to cancel this potentially long running request</param>
+        [ManualRoute("GET", "/repositories/{id}/stats/contributors")]
         public Task<IReadOnlyList<Contributor>> GetContributors(long repositoryId, CancellationToken cancellationToken)
         {
             return ApiConnection.GetQueuedOperation<Contributor>(ApiUrls.StatsContributors(repositoryId), cancellationToken);
@@ -74,6 +78,7 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        [ManualRoute("GET", "/repos/{owner}/{repo}/stats/commit_activity")]
         public Task<CommitActivity> GetCommitActivity(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -86,6 +91,7 @@ namespace Octokit
         /// Returns the last year of commit activity grouped by week.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
+        [ManualRoute("GET", "/repositories/{id}/stats/commit_activity")]
         public Task<CommitActivity> GetCommitActivity(long repositoryId)
         {
             return GetCommitActivity(repositoryId, CancellationToken.None);
@@ -97,6 +103,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="cancellationToken">A token used to cancel this potentially long running request</param>
+        [ManualRoute("GET", "/repos/{owner}/{repo}/stats/commit_activity")]
         public async Task<CommitActivity> GetCommitActivity(string owner, string name, CancellationToken cancellationToken)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -111,6 +118,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="cancellationToken">A token used to cancel this potentially long running request</param>
+        [ManualRoute("GET", "/repositories/{id}/stats/commit_activity")]
         public async Task<CommitActivity> GetCommitActivity(long repositoryId, CancellationToken cancellationToken)
         {
             var activity = await ApiConnection.GetQueuedOperation<WeeklyCommitActivity>(ApiUrls.StatsCommitActivity(repositoryId), cancellationToken).ConfigureAwait(false);
@@ -118,10 +126,11 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Returns a weekly aggregate of the number of additions and deletions pushed to a repository. 
+        /// Returns a weekly aggregate of the number of additions and deletions pushed to a repository.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        [ManualRoute("GET", "/repos/{owner}/{repo}/stats/code_frequency")]
         public Task<CodeFrequency> GetCodeFrequency(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -131,20 +140,22 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Returns a weekly aggregate of the number of additions and deletions pushed to a repository. 
+        /// Returns a weekly aggregate of the number of additions and deletions pushed to a repository.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
+        [ManualRoute("GET", "/repositories/{id}/stats/code_frequency")]
         public Task<CodeFrequency> GetCodeFrequency(long repositoryId)
         {
             return GetCodeFrequency(repositoryId, CancellationToken.None);
         }
 
         /// <summary>
-        /// Returns a weekly aggregate of the number of additions and deletions pushed to a repository. 
+        /// Returns a weekly aggregate of the number of additions and deletions pushed to a repository.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="cancellationToken">A token used to cancel this potentially long running request</param>
+        [ManualRoute("GET", "/repos/{owner}/{repo}/stats/code_frequency")]
         public async Task<CodeFrequency> GetCodeFrequency(string owner, string name, CancellationToken cancellationToken)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -155,10 +166,11 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Returns a weekly aggregate of the number of additions and deletions pushed to a repository. 
+        /// Returns a weekly aggregate of the number of additions and deletions pushed to a repository.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="cancellationToken">A token used to cancel this potentially long running request</param>
+        [ManualRoute("GET", "/repositories/{id}/stats/code_frequency")]
         public async Task<CodeFrequency> GetCodeFrequency(long repositoryId, CancellationToken cancellationToken)
         {
             var rawFrequencies = await ApiConnection.GetQueuedOperation<long[]>(ApiUrls.StatsCodeFrequency(repositoryId), cancellationToken).ConfigureAwait(false);
@@ -166,10 +178,11 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Returns the total commit counts for the owner and total commit counts in total. 
+        /// Returns the total commit counts for the owner and total commit counts in total.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        [ManualRoute("GET", "/repos/{owner}/{repo}/stats/participation")]
         public Task<Participation> GetParticipation(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -179,20 +192,22 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Returns the total commit counts for the owner and total commit counts in total. 
+        /// Returns the total commit counts for the owner and total commit counts in total.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
+        [ManualRoute("GET", "/repositories/{id}/stats/participation")]
         public Task<Participation> GetParticipation(long repositoryId)
         {
             return GetParticipation(repositoryId, CancellationToken.None);
         }
 
         /// <summary>
-        /// Returns the total commit counts for the owner and total commit counts in total. 
+        /// Returns the total commit counts for the owner and total commit counts in total.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="cancellationToken">A token used to cancel this potentially long running request</param>
+        [ManualRoute("GET", "/repos/{owner}/{repo}/stats/participation")]
         public async Task<Participation> GetParticipation(string owner, string name, CancellationToken cancellationToken)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -203,10 +218,11 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Returns the total commit counts for the owner and total commit counts in total. 
+        /// Returns the total commit counts for the owner and total commit counts in total.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="cancellationToken">A token used to cancel this potentially long running request</param>
+        [ManualRoute("GET", "/repositories/{id}/stats/participation")]
         public async Task<Participation> GetParticipation(long repositoryId, CancellationToken cancellationToken)
         {
             var result = await ApiConnection.GetQueuedOperation<Participation>(ApiUrls.StatsParticipation(repositoryId), cancellationToken).ConfigureAwait(false);
@@ -218,6 +234,7 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        [ManualRoute("GET", "/repos/{owner}/{repo}/stats/punch_card")]
         public Task<PunchCard> GetPunchCard(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -230,6 +247,7 @@ namespace Octokit
         /// Returns a list of the number of commits per hour in each day
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
+        [ManualRoute("GET", "/repositories/{id}/stats/punch_card")]
         public Task<PunchCard> GetPunchCard(long repositoryId)
         {
             return GetPunchCard(repositoryId, CancellationToken.None);
@@ -241,6 +259,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="cancellationToken">A token used to cancel this potentially long running request</param>
+        [ManualRoute("GET", "/repos/{owner}/{repo}/stats/punch_card")]
         public async Task<PunchCard> GetPunchCard(string owner, string name, CancellationToken cancellationToken)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -255,6 +274,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="cancellationToken">A token used to cancel this potentially long running request</param>
+        [ManualRoute("GET", "/repositories/{id}/stats/punch_card")]
         public async Task<PunchCard> GetPunchCard(long repositoryId, CancellationToken cancellationToken)
         {
             var punchCardData = await ApiConnection.GetQueuedOperation<int[]>(ApiUrls.StatsPunchCard(repositoryId), cancellationToken).ConfigureAwait(false);

--- a/Octokit/Clients/TagsClient.cs
+++ b/Octokit/Clients/TagsClient.cs
@@ -28,7 +28,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">Tha sha reference of the tag</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/git/tags/{sha}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/git/tags/{sha}")]
         public Task<GitTag> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -63,7 +63,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="tag">The tag to create</param>
-        [ManualRoute("POST", "/repos/{owner}/{name}/git/tags")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/git/tags")]
         public Task<GitTag> Create(string owner, string name, NewTag tag)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -30,7 +30,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The team identifier.</param>
         /// <returns>The <see cref="Team"/> with the given identifier.</returns>
-        [ManualRoute("GET", "/teams/{id}")]
+        [ManualRoute("GET", "/teams/{team_id}")]
         public Task<Team> Get(int id)
         {
             var endpoint = ApiUrls.Teams(id);
@@ -202,7 +202,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The team to check.</param>
         /// <param name="login">The user to check.</param>
-        [ManualRoute("GET", "/teams/{id}/memberships/{username}")]
+        [ManualRoute("GET", "/teams/{team_id}/memberships/{username}")]
         public Task<TeamMembershipDetails> GetMembershipDetails(int id, string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
@@ -232,7 +232,7 @@ namespace Octokit
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>Updated <see cref="Team"/></returns>
-        [ManualRoute("PATCH", "/teams/{id}")]
+        [ManualRoute("PATCH", "/teams/{team_id}")]
         public Task<Team> Update(int id, UpdateTeam team)
         {
             Ensure.ArgumentNotNull(team, nameof(team));
@@ -246,7 +246,7 @@ namespace Octokit
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns></returns>
-        [ManualRoute("DELETE", "/teams/{id}")]
+        [ManualRoute("DELETE", "/teams/{team_id}")]
         public Task Delete(int id)
         {
             var endpoint = ApiUrls.Teams(id);
@@ -263,7 +263,7 @@ namespace Octokit
         /// <param name="id">The team identifier.</param>
         /// <param name="login">The user to add to the team.</param>
         /// <param name="request">Additional parameters for the request</param>
-        [ManualRoute("PUT", "/teams/{id}/memberships/{username}")]
+        [ManualRoute("PUT", "/teams/{team_id}/memberships/{username}")]
         public Task<TeamMembershipDetails> AddOrEditMembership(int id, string login, UpdateTeamMembership request)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
@@ -283,7 +283,7 @@ namespace Octokit
         /// <param name="id">The team identifier.</param>
         /// <param name="login">The user to remove from the team.</param>
         /// <returns><see langword="true"/> if the user was removed from the team; <see langword="false"/> otherwise.</returns>
-        [ManualRoute("DELETE", "/teams/{id}/memberships/{username}")]
+        [ManualRoute("DELETE", "/teams/{team_id}/memberships/{username}")]
         public async Task<bool> RemoveMembership(int id, string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
@@ -308,7 +308,7 @@ namespace Octokit
         /// <param name="id">Team Id.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The team's repositories</returns>
-        [ManualRoute("GET", "/teams/{id}/repos")]
+        [ManualRoute("GET", "/teams/{team_id}/repos")]
         public Task<IReadOnlyList<Repository>> GetAllRepositories(int id)
         {
             return GetAllRepositories(id, ApiOptions.None);
@@ -321,7 +321,7 @@ namespace Octokit
         /// <param name="options">Options to change API behaviour.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The team's repositories</returns>
-        [ManualRoute("GET", "/teams/{id}/repos")]
+        [ManualRoute("GET", "/teams/{team_id}/repos")]
         public Task<IReadOnlyList<Repository>> GetAllRepositories(int id, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -454,7 +454,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/orgs/teams/#get-team-repo">API documentation</a> for more information.
         /// </remarks>
         /// <returns><see langword="true"/> if the repository is managed by the given team; <see langword="false"/> otherwise.</returns>
-        [ManualRoute("GET", "/teams/{id}/repos/{owner}/{name}")]
+        [ManualRoute("GET", "/teams/{team_id}/repos/{owner}/{name}")]
         public async Task<bool> IsRepositoryManagedByTeam(int id, string owner, string repo)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -482,7 +482,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The team identifier</param>
         /// <returns></returns>
-        [ManualRoute("GET", "/teams/{id}/invitations")]
+        [ManualRoute("GET", "/teams/{team_id}/invitations")]
         public Task<IReadOnlyList<OrganizationMembershipInvitation>> GetAllPendingInvitations(int id)
         {
             Ensure.ArgumentNotNull(id, nameof(id));
@@ -500,7 +500,7 @@ namespace Octokit
         /// <param name="id">The team identifier</param>
         /// <param name="options">Options to change API behaviour</param>
         /// <returns></returns>
-        [ManualRoute("GET", "/teams/{id}/invitations")]
+        [ManualRoute("GET", "/teams/{team_id}/invitations")]
         public Task<IReadOnlyList<OrganizationMembershipInvitation>> GetAllPendingInvitations(int id, ApiOptions options)
         {
             return ApiConnection.GetAll<OrganizationMembershipInvitation>(ApiUrls.TeamPendingInvitations(id), null, AcceptHeaders.OrganizationMembershipPreview, options);

--- a/Octokit/Clients/TreesClient.cs
+++ b/Octokit/Clients/TreesClient.cs
@@ -30,7 +30,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The SHA that references the tree</param>
-        [ManualRoute("GET", "repos/{owner}/{repo}/git/trees/{tree_sha}")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/git/trees/{tree_sha}")]
         public Task<TreeResponse> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -65,7 +65,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The SHA that references the tree</param>
-        [ManualRoute("GET", "repos/{owner}/{repo}/git/trees/{tree_sha}?recursive=1")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/git/trees/{tree_sha}?recursive=1")]
         public Task<TreeResponse> GetRecursive(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/UserGpgKeysClient.cs
+++ b/Octokit/Clients/UserGpgKeysClient.cs
@@ -58,7 +58,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/users/gpg_keys/#get-a-single-gpg-key">API documentation</a> for more information.
         /// </remarks>
         /// <returns>The <see cref="GpgKey"/> for the specified Id.</returns>
-        [ManualRoute("GET", "/user/gpg_keys/{id}")]
+        [ManualRoute("GET", "/user/gpg_keys/{gpg_key_id}")]
         public Task<GpgKey> Get(int id)
         {
             return ApiConnection.Get<GpgKey>(ApiUrls.GpgKeys(id), null, AcceptHeaders.GpgKeysPreview);
@@ -88,7 +88,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/users/gpg_keys/#delete-a-gpg-key">API documentation</a> for more information.
         /// </remarks>
         /// <returns></returns>
-        [ManualRoute("DELETE", "/user/gpg_keys/{id}")]
+        [ManualRoute("DELETE", "/user/gpg_keys/{gpg_key_id}")]
         public Task Delete(int id)
         {
             return ApiConnection.Delete(ApiUrls.GpgKeys(id), new object(), AcceptHeaders.GpgKeysPreview);

--- a/Octokit/Clients/UserKeysClient.cs
+++ b/Octokit/Clients/UserKeysClient.cs
@@ -87,7 +87,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The Id of the SSH key</param>
         /// <returns></returns>
-        [ManualRoute("GET", "/user/keys/{public_key_id}")]
+        [ManualRoute("GET", "/user/keys/{key_id}")]
         public Task<PublicKey> Get(int id)
         {
             return ApiConnection.Get<PublicKey>(ApiUrls.Keys(id));
@@ -117,7 +117,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The id of the key to delete</param>
         /// <returns></returns>
-        [ManualRoute("DELETE", "/user/keys/{public_key_id}")]
+        [ManualRoute("DELETE", "/user/keys/{key_id}")]
         public Task Delete(int id)
         {
             return ApiConnection.Delete(ApiUrls.Keys(id));

--- a/Octokit/Clients/WatchedClient.cs
+++ b/Octokit/Clients/WatchedClient.cs
@@ -27,7 +27,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        [ManualRoute("GET", "/repos/{owner}/{name}/subscribers")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/subscribers")]
         public Task<IReadOnlyList<User>> GetAllWatchers(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -54,7 +54,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        [ManualRoute("GET", "/repos/{owner}/{name}/subscribers")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/subscribers")]
         public Task<IReadOnlyList<User>> GetAllWatchers(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -147,7 +147,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        [ManualRoute("GET", "/repos/{owner}/{name}/subscription")]
+        [ManualRoute("GET", "/repos/{owner}/{repo}/subscription")]
         public async Task<bool> CheckWatched(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -193,7 +193,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository to star</param>
         /// <param name="name">The name of the repository to star</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
-        [ManualRoute("PUT", "/repos/{owner}/{name}/subscription")]
+        [ManualRoute("PUT", "/repos/{owner}/{repo}/subscription")]
         public Task<Subscription> WatchRepo(string owner, string name, NewSubscription newSubscription)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -221,7 +221,7 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository to unstar</param>
         /// <param name="name">The name of the repository to unstar</param>
-        [ManualRoute("DELETE", "/repos/{owner}/{name}/subscription")]
+        [ManualRoute("DELETE", "/repos/{owner}/{repo}/subscription")]
         public async Task<bool> UnwatchRepo(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));


### PR DESCRIPTION
This builds upon #2124 now that I've given it a first pass at auditing using the `octokit/routes` schema

 - [x] review diff