### PR TITLE
remove all usages of TaskFactory in test suite

### DIFF
--- a/Octokit.Tests/Clients/AssigneesClientTests.cs
+++ b/Octokit.Tests/Clients/AssigneesClientTests.cs
@@ -114,11 +114,10 @@ namespace Octokit.Tests.Clients
             [InlineData(HttpStatusCode.NotFound, false)]
             public async Task RequestsCorrectValueForStatusCode(HttpStatusCode status, bool expected)
             {
-                var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(status, null, new Dictionary<string, string>(), "application/json")));
+                var responseTask = TestSetup.GetApiResponse(status);
                 var connection = Substitute.For<IConnection>();
                 connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "repos/foo/bar/assignees/cody"),
-                    null, null).Returns(response);
+                    null, null).Returns(responseTask);
                 var apiConnection = Substitute.For<IApiConnection>();
                 apiConnection.Connection.Returns(connection);
                 var client = new AssigneesClient(apiConnection);
@@ -133,11 +132,12 @@ namespace Octokit.Tests.Clients
             [InlineData(HttpStatusCode.NotFound, false)]
             public async Task RequestsCorrectValueForStatusCodeWithRepositoryId(HttpStatusCode status, bool expected)
             {
-                var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(status, null, new Dictionary<string, string>(), "application/json")));
+                var responseTask = TestSetup.GetApiResponse(status);
+
                 var connection = Substitute.For<IConnection>();
-                connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/assignees/cody"),
-                    null, null).Returns(response);
+                connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/assignees/cody"), null, null)
+                          .Returns(responseTask);
+
                 var apiConnection = Substitute.For<IApiConnection>();
                 apiConnection.Connection.Returns(connection);
                 var client = new AssigneesClient(apiConnection);
@@ -150,11 +150,12 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task ThrowsExceptionForInvalidStatusCode()
             {
-                var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json")));
+                var responseTask = TestSetup.GetApiResponse(HttpStatusCode.Conflict);
+
                 var connection = Substitute.For<IConnection>();
-                connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "repos/foo/bar/assignees/cody"),
-                    null, null).Returns(response);
+                connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "repos/foo/bar/assignees/cody"), null, null)
+                          .Returns(responseTask);
+
                 var apiConnection = Substitute.For<IApiConnection>();
                 apiConnection.Connection.Returns(connection);
                 var client = new AssigneesClient(apiConnection);
@@ -165,11 +166,11 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task ThrowsExceptionForInvalidStatusCodeWithRepositoryId()
             {
-                var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json")));
+                var response = new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json");
+                var responseTask = Task.FromResult<IApiResponse<object>>(new ApiResponse<object>(response));
                 var connection = Substitute.For<IConnection>();
                 connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/assignees/cody"),
-                    null, null).Returns(response);
+                    null, null).Returns(responseTask);
                 var apiConnection = Substitute.For<IApiConnection>();
                 apiConnection.Connection.Returns(connection);
                 var client = new AssigneesClient(apiConnection);

--- a/Octokit.Tests/Clients/AuthorizationsClientTests.cs
+++ b/Octokit.Tests/Clients/AuthorizationsClientTests.cs
@@ -173,12 +173,12 @@ namespace Octokit.Tests.Clients
                     "secret",
                     Arg.Any<NewAuthorization>(),
                     "two-factor-code")
-                    .Returns(Task.Factory.StartNew(() => new ApplicationAuthorization(0, null, null, null, null, null, null, null, DateTimeOffset.Now, DateTimeOffset.Now, null, "xyz")));
+                    .Returns(Task.FromResult(new ApplicationAuthorization(0, null, null, null, null, null, null, null, DateTimeOffset.Now, DateTimeOffset.Now, null, "xyz")));
 
                 var result = await client.GetOrCreateApplicationAuthentication("clientId",
                     "secret",
                     data,
-                    e => Task.Factory.StartNew(() => twoFactorChallengeResult));
+                    e => Task.FromResult(twoFactorChallengeResult));
 
                 client.Received().GetOrCreateApplicationAuthentication("clientId",
                     "secret",
@@ -205,12 +205,12 @@ namespace Octokit.Tests.Clients
                     "secret",
                     Arg.Any<NewAuthorization>(),
                     "two-factor-code")
-                    .Returns(Task.Factory.StartNew(() => new ApplicationAuthorization(0, null, null, null, null, null, null, null, DateTimeOffset.Now, DateTimeOffset.Now, null, "OAUTHSECRET")));
+                    .Returns(Task.FromResult(new ApplicationAuthorization(0, null, null, null, null, null, null, null, DateTimeOffset.Now, DateTimeOffset.Now, null, "OAUTHSECRET")));
 
                 var result = await client.GetOrCreateApplicationAuthentication("clientId",
                     "secret",
                     data,
-                    e => Task.Factory.StartNew(() => challengeResults.Dequeue()));
+                    e => Task.FromResult(challengeResults.Dequeue()));
 
                 client.Received(2).GetOrCreateApplicationAuthentication("clientId",
                     "secret",
@@ -245,7 +245,7 @@ namespace Octokit.Tests.Clients
                         "clientId",
                         "secret",
                         data,
-                        e => Task.Factory.StartNew(() => challengeResults.Dequeue())));
+                        e => Task.FromResult(challengeResults.Dequeue())));
 
                 Assert.NotNull(exception);
                 client.Received().GetOrCreateApplicationAuthentication("clientId",

--- a/Octokit.Tests/Clients/FollowersClientTests.cs
+++ b/Octokit.Tests/Clients/FollowersClientTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 namespace Octokit.Tests.Clients
 {
     /// <summary>
-    /// Client tests mostly just need to make sure they call the IApiConnection with the correct 
+    /// Client tests mostly just need to make sure they call the IApiConnection with the correct
     /// relative Uri. No need to fake up the response. All *those* tests are in ApiConnectionTests.cs.
     /// </summary>
     public class FollowersClientTests
@@ -204,11 +204,11 @@ namespace Octokit.Tests.Clients
             [InlineData(HttpStatusCode.NotFound, false)]
             public async Task RequestsCorrectValueForStatusCode(HttpStatusCode status, bool expected)
             {
-                var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(status, null, new Dictionary<string, string>(), "application/json")));
+                var response = new Response(status, null, new Dictionary<string, string>(), "application/json");
+                var responseTask = Task.FromResult<IApiResponse<object>>(new ApiResponse<object>(response));
                 var connection = Substitute.For<IConnection>();
                 connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "user/following/alfhenrik"),
-                    null, null).Returns(response);
+                    null, null).Returns(responseTask);
                 var apiConnection = Substitute.For<IApiConnection>();
                 apiConnection.Connection.Returns(connection);
                 var client = new FollowersClient(apiConnection);
@@ -221,11 +221,11 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task ThrowsExceptionForInvalidStatusCode()
             {
-                var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json")));
+                var response = new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json");
+                var responseTask = Task.FromResult<IApiResponse<object>>(new ApiResponse<object>(response));
                 var connection = Substitute.For<IConnection>();
                 connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "user/following/alfhenrik"),
-                    null, null).Returns(response);
+                    null, null).Returns(responseTask);
                 var apiConnection = Substitute.For<IApiConnection>();
                 apiConnection.Connection.Returns(connection);
                 var client = new FollowersClient(apiConnection);
@@ -251,11 +251,11 @@ namespace Octokit.Tests.Clients
             [InlineData(HttpStatusCode.NotFound, false)]
             public async Task RequestsCorrectValueForStatusCode(HttpStatusCode status, bool expected)
             {
-                var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(status, null, new Dictionary<string, string>(), "application/json")));
+                var response = new Response(status, null, new Dictionary<string, string>(), "application/json");
+                var responseTask = Task.FromResult<IApiResponse<object>>(new ApiResponse<object>(response));
                 var connection = Substitute.For<IConnection>();
                 connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "users/alfhenrik/following/alfhenrik-test"),
-                    null, null).Returns(response);
+                    null, null).Returns(responseTask);
                 var apiConnection = Substitute.For<IApiConnection>();
                 apiConnection.Connection.Returns(connection);
                 var client = new FollowersClient(apiConnection);
@@ -268,11 +268,11 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task ThrowsExceptionForInvalidStatusCode()
             {
-                var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json")));
+                var response = new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json");
+                var responseTask = Task.FromResult<IApiResponse<object>>(new ApiResponse<object>(response));
                 var connection = Substitute.For<IConnection>();
                 connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "users/alfhenrik/following/alfhenrik-test"),
-                    null, null).Returns(response);
+                    null, null).Returns(responseTask);
                 var apiConnection = Substitute.For<IApiConnection>();
                 apiConnection.Connection.Returns(connection);
                 var client = new FollowersClient(apiConnection);
@@ -299,11 +299,13 @@ namespace Octokit.Tests.Clients
             [InlineData(HttpStatusCode.NoContent, true)]
             public async Task RequestsCorrectValueForStatusCode(HttpStatusCode status, bool expected)
             {
-                var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(status, null, new Dictionary<string, string>(), "application/json")));
+                var response = new Response(status, null, new Dictionary<string, string>(), "application/json");
+                var responseTask = Task.FromResult<IApiResponse<object>>(new ApiResponse<object>(response));
+
                 var connection = Substitute.For<IConnection>();
-                connection.Put<object>(Arg.Is<Uri>(u => u.ToString() == "user/following/alfhenrik"),
-                    Args.Object).Returns(response);
+                connection.Put<object>(Arg.Is<Uri>(u => u.ToString() == "user/following/alfhenrik"), Args.Object)
+                          .Returns(responseTask);
+
                 var apiConnection = Substitute.For<IApiConnection>();
                 apiConnection.Connection.Returns(connection);
                 var client = new FollowersClient(apiConnection);
@@ -316,11 +318,13 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task ThrowsExceptionForInvalidStatusCode()
             {
-                var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json")));
+                var response = new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json");
+                var responseTask = Task.FromResult<IApiResponse<object>>(new ApiResponse<object>(response));
+
                 var connection = Substitute.For<IConnection>();
-                connection.Put<object>(Arg.Is<Uri>(u => u.ToString() == "user/following/alfhenrik"),
-                    new { }).Returns(response);
+                connection.Put<object>(Arg.Is<Uri>(u => u.ToString() == "user/following/alfhenrik"), Args.Object)
+                          .Returns(responseTask);
+
                 var apiConnection = Substitute.For<IApiConnection>();
                 apiConnection.Connection.Returns(connection);
                 var client = new FollowersClient(apiConnection);

--- a/Octokit.Tests/Clients/GistsClientTests.cs
+++ b/Octokit.Tests/Clients/GistsClientTests.cs
@@ -499,11 +499,13 @@ public class GistsClientTests
         [InlineData(HttpStatusCode.NotFound, false)]
         public async Task RequestsCorrectValueForStatusCode(HttpStatusCode status, bool expected)
         {
-            var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                new ApiResponse<object>(new Response(status, null, new Dictionary<string, string>(), "application/json")));
+            var response = new Response(status, null, new Dictionary<string, string>(), "application/json");
+            var responseTask = Task.FromResult<IApiResponse<object>>(new ApiResponse<object>(response));
+
             var connection = Substitute.For<IConnection>();
-            connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "gists/1/star"),
-                null, null).Returns(response);
+            connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "gists/1/star"), null, null)
+                      .Returns(responseTask);
+
             var apiConnection = Substitute.For<IApiConnection>();
             apiConnection.Connection.Returns(connection);
             var client = new GistsClient(apiConnection);
@@ -516,11 +518,13 @@ public class GistsClientTests
         [Fact]
         public async Task ThrowsExceptionForInvalidStatusCode()
         {
-            var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                new ApiResponse<object>(new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json")));
+            var response = new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json");
+            var responseTask = Task.FromResult<IApiResponse<object>>(new ApiResponse<object>(response));
+
             var connection = Substitute.For<IConnection>();
-            connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "gists/1/star"),
-                null, null).Returns(response);
+            connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "gists/1/star"), null, null)
+                      .Returns(responseTask);
+
             var apiConnection = Substitute.For<IApiConnection>();
             apiConnection.Connection.Returns(connection);
 

--- a/Octokit.Tests/Clients/OrganizationMembersClientTests.cs
+++ b/Octokit.Tests/Clients/OrganizationMembersClientTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 namespace Octokit.Tests.Clients
 {
     /// <summary>
-    /// Client tests mostly just need to make sure they call the IApiConnection with the correct 
+    /// Client tests mostly just need to make sure they call the IApiConnection with the correct
     /// relative Uri. No need to fake up the response. All *those* tests are in ApiConnectionTests.cs.
     /// </summary>
     public class OrganizationMembersClientTests
@@ -309,11 +309,13 @@ namespace Octokit.Tests.Clients
             [InlineData(HttpStatusCode.Found, false)]
             public async Task RequestsCorrectValueForStatusCode(HttpStatusCode status, bool expected)
             {
-                var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(status, null, new Dictionary<string, string>(), "application/json")));
+                var response = new Response(status, null, new Dictionary<string, string>(), "application/json");
+                var responseTask = Task.FromResult<IApiResponse<object>>(new ApiResponse<object>(response));
+
                 var connection = Substitute.For<IConnection>();
-                connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members/username"),
-                    null, null).Returns(response);
+                connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members/username"), null, null)
+                          .Returns(responseTask);
+
                 var apiConnection = Substitute.For<IApiConnection>();
                 apiConnection.Connection.Returns(connection);
                 var client = new OrganizationMembersClient(apiConnection);
@@ -326,11 +328,13 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task ThrowsExceptionForInvalidStatusCode()
             {
-                var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json")));
+                var response = new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json");
+                var responseTask = Task.FromResult<IApiResponse<object>>(new ApiResponse<object>(response));
+
                 var connection = Substitute.For<IConnection>();
-                connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members/username"),
-                    null, null).Returns(response);
+                connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members/username"), null, null)
+                          .Returns(responseTask);
+
                 var apiConnection = Substitute.For<IApiConnection>();
                 apiConnection.Connection.Returns(connection);
                 var client = new OrganizationMembersClient(apiConnection);
@@ -357,11 +361,13 @@ namespace Octokit.Tests.Clients
             [InlineData(HttpStatusCode.NotFound, false)]
             public async Task RequestsCorrectValueForStatusCode(HttpStatusCode status, bool expected)
             {
-                var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(status, null, new Dictionary<string, string>(), "application/json")));
+                var response = new Response(status, null, new Dictionary<string, string>(), "application/json");
+                var responseTask = Task.FromResult<IApiResponse<object>>(new ApiResponse<object>(response));
+
                 var connection = Substitute.For<IConnection>();
-                connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/public_members/username"),
-                    null, null).Returns(response);
+                connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/public_members/username"), null, null)
+                          .Returns(responseTask);
+
                 var apiConnection = Substitute.For<IApiConnection>();
                 apiConnection.Connection.Returns(connection);
                 var client = new OrganizationMembersClient(apiConnection);
@@ -374,11 +380,13 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task ThrowsExceptionForInvalidStatusCode()
             {
-                var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json")));
+                var response = new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json");
+                var responseTask = Task.FromResult<IApiResponse<object>>(new ApiResponse<object>(response));
+
                 var connection = Substitute.For<IConnection>();
-                connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/public_members/username"),
-                    null, null).Returns(response);
+                connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/public_members/username"), null, null)
+                          .Returns(responseTask);
+
                 var apiConnection = Substitute.For<IApiConnection>();
                 apiConnection.Connection.Returns(connection);
                 var client = new OrganizationMembersClient(apiConnection);
@@ -429,11 +437,13 @@ namespace Octokit.Tests.Clients
             [InlineData(HttpStatusCode.NoContent, true)]
             public async Task RequestsCorrectValueForStatusCode(HttpStatusCode status, bool expected)
             {
-                var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(status, null, new Dictionary<string, string>(), "application/json")));
+                var response = new Response(status, null, new Dictionary<string, string>(), "application/json");
+                var responseTask = Task.FromResult<IApiResponse<object>>(new ApiResponse<object>(response));
+
                 var connection = Substitute.For<IConnection>();
-                connection.Put<object>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/public_members/username"),
-                    Args.Object).Returns(response);
+                connection.Put<object>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/public_members/username"), Args.Object)
+                          .Returns(responseTask);
+
                 var apiConnection = Substitute.For<IApiConnection>();
                 apiConnection.Connection.Returns(connection);
                 var client = new OrganizationMembersClient(apiConnection);
@@ -446,11 +456,13 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task ThrowsExceptionForInvalidStatusCode()
             {
-                var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json")));
+                var response = new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json");
+                var responseTask = Task.FromResult<IApiResponse<object>>(new ApiResponse<object>(response));
+
                 var connection = Substitute.For<IConnection>();
-                connection.Put<object>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/public_members/username"),
-                    new { }).Returns(response);
+                connection.Put<object>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/public_members/username"), Args.Object)
+                          .Returns(responseTask);
+
                 var apiConnection = Substitute.For<IApiConnection>();
                 apiConnection.Connection.Returns(connection);
                 var client = new OrganizationMembersClient(apiConnection);

--- a/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
+++ b/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
@@ -206,11 +206,12 @@ namespace Octokit.Tests.Clients
             [InlineData(HttpStatusCode.NotFound, false)]
             public async Task RequestsCorrectValueForStatusCode(HttpStatusCode status, bool expected)
             {
-                var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(status, null, new Dictionary<string, string>(), "application/json")));
+                var responseTask = TestSetup.GetApiResponse(status);
+
                 var connection = Substitute.For<IConnection>();
-                connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/test/collaborators/user1"),
-                    null, null).Returns(response);
+                connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/test/collaborators/user1"), null, null)
+                          .Returns(responseTask);
+
                 var apiConnection = Substitute.For<IApiConnection>();
                 apiConnection.Connection.Returns(connection);
                 var client = new RepoCollaboratorsClient(apiConnection);
@@ -225,11 +226,12 @@ namespace Octokit.Tests.Clients
             [InlineData(HttpStatusCode.NotFound, false)]
             public async Task RequestsCorrectValueForStatusCodeWithRepositoryId(HttpStatusCode status, bool expected)
             {
-                var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(status, null, new Dictionary<string, string>(), "application/json")));
+                var responseTask = TestSetup.GetApiResponse(status);
+
                 var connection = Substitute.For<IConnection>();
-                connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/collaborators/user1"),
-                    null, null).Returns(response);
+                connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/collaborators/user1"), null, null)
+                          .Returns(responseTask);
+
                 var apiConnection = Substitute.For<IApiConnection>();
                 apiConnection.Connection.Returns(connection);
                 var client = new RepoCollaboratorsClient(apiConnection);
@@ -242,11 +244,12 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task ThrowsExceptionForInvalidStatusCode()
             {
-                var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json")));
+                var responseTask = TestSetup.GetApiResponse(HttpStatusCode.Conflict);
+
                 var connection = Substitute.For<IConnection>();
-                connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "repos/foo/bar/assignees/cody"),
-                    null, null).Returns(response);
+                connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "repos/foo/bar/assignees/cody"), null, null)
+                          .Returns(responseTask);
+
                 var apiConnection = Substitute.For<IApiConnection>();
                 apiConnection.Connection.Returns(connection);
                 var client = new RepoCollaboratorsClient(apiConnection);
@@ -257,11 +260,12 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task ThrowsExceptionForInvalidStatusCodeWithRepositoryId()
             {
-                var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json")));
+                var responseTask = TestSetup.GetApiResponse(HttpStatusCode.Conflict);
+
                 var connection = Substitute.For<IConnection>();
-                connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/assignees/cody"),
-                    null, null).Returns(response);
+                connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/assignees/cody"), null, null)
+                          .Returns(responseTask);
+
                 var apiConnection = Substitute.For<IApiConnection>();
                 apiConnection.Connection.Returns(connection);
                 var client = new RepoCollaboratorsClient(apiConnection);

--- a/Octokit.Tests/Clients/StarredClientTests.cs
+++ b/Octokit.Tests/Clients/StarredClientTests.cs
@@ -505,11 +505,12 @@ namespace Octokit.Tests.Clients
             [InlineData(HttpStatusCode.NotFound, false)]
             public async Task ReturnsCorrectResultBasedOnStatus(HttpStatusCode status, bool expected)
             {
-                var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(status, null, new Dictionary<string, string>(), "application/json")));
+                var responseTask = TestSetup.GetApiResponse(status);
+
                 var connection = Substitute.For<IConnection>();
                 connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "user/starred/yes/no"), null, null)
-                    .Returns(response);
+                          .Returns(responseTask);
+
                 var apiConnection = Substitute.For<IApiConnection>();
                 apiConnection.Connection.Returns(connection);
 
@@ -528,12 +529,11 @@ namespace Octokit.Tests.Clients
             [InlineData(HttpStatusCode.OK, false)]
             public async Task ReturnsCorrectResultBasedOnStatus(HttpStatusCode status, bool expected)
             {
-                var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(status, null, new Dictionary<string, string>(), "application/json")));
+                var responseTask = TestSetup.GetApiResponse(status);
 
                 var connection = Substitute.For<IConnection>();
-                connection.Put<object>(Arg.Is<Uri>(u => u.ToString() == "user/starred/yes/no"),
-                    Args.Object, Args.String).Returns(response);
+                connection.Put<object>(Arg.Is<Uri>(u => u.ToString() == "user/starred/yes/no"), Args.Object, Args.String)
+                          .Returns(responseTask);
 
                 var apiConnection = Substitute.For<IApiConnection>();
                 apiConnection.Connection.Returns(connection);
@@ -553,7 +553,7 @@ namespace Octokit.Tests.Clients
             [InlineData(HttpStatusCode.OK, false)]
             public async Task ReturnsCorrectResultBasedOnStatus(HttpStatusCode status, bool expected)
             {
-                var response = Task.Factory.StartNew(() => status);
+                var response = Task.FromResult(status);
 
                 var connection = Substitute.For<IConnection>();
                 connection.Delete(Arg.Is<Uri>(u => u.ToString() == "user/starred/yes/no"))

--- a/Octokit.Tests/Clients/WatchedClientTests.cs
+++ b/Octokit.Tests/Clients/WatchedClientTests.cs
@@ -326,7 +326,7 @@ namespace Octokit.Tests.Clients
             [InlineData(HttpStatusCode.OK, false)]
             public async Task ReturnsCorrectResultBasedOnStatus(HttpStatusCode status, bool expected)
             {
-                var response = Task.Factory.StartNew(() => status);
+                var response = Task.FromResult(status);
 
                 var connection = Substitute.For<IConnection>();
                 connection.Delete(Arg.Is<Uri>(u => u.ToString() == "repos/yes/no/subscription"))
@@ -347,7 +347,7 @@ namespace Octokit.Tests.Clients
             [InlineData(HttpStatusCode.OK, false)]
             public async Task ReturnsCorrectResultBasedOnStatusWithRepositoryId(HttpStatusCode status, bool expected)
             {
-                var response = Task.Factory.StartNew(() => status);
+                var response = Task.FromResult(status);
 
                 var connection = Substitute.For<IConnection>();
                 connection.Delete(Arg.Is<Uri>(u => u.ToString() == "repositories/1/subscription"))

--- a/Octokit.Tests/GitHubClientTests.cs
+++ b/Octokit.Tests/GitHubClientTests.cs
@@ -124,7 +124,7 @@ namespace Octokit.Tests
             public void IsRetrievedFromCredentialStore()
             {
                 var credentialStore = Substitute.For<ICredentialStore>();
-                credentialStore.GetCredentials().Returns(Task.Factory.StartNew(() => new Credentials("foo", "bar")));
+                credentialStore.GetCredentials().Returns(Task.FromResult(new Credentials("foo", "bar")));
                 var client = new GitHubClient(new ProductHeaderValue("OctokitTests"), credentialStore);
 
                 Assert.Equal("foo", client.Credentials.Login);

--- a/Octokit.Tests/Helpers/NSubstituteExtensions.cs
+++ b/Octokit.Tests/Helpers/NSubstituteExtensions.cs
@@ -9,7 +9,7 @@ public static class NSubstituteExtensions
         this TTask value, Func<CallInfo, TTaskType> returnThis,
         params Func<CallInfo, TTaskType>[] returnThese) where TTask : Task<TTaskType>
     {
-        return value.Returns(callInfo => Task.Factory.StartNew(() => returnThis(callInfo)));
+        return value.Returns(callInfo => Task.FromResult(returnThis(callInfo)));
     }
 
     public static ConfiguredCall ThrowsAsync<T>(this Task<T> value, Exception exception)

--- a/Octokit.Tests/Helpers/TaskHelper.cs
+++ b/Octokit.Tests/Helpers/TaskHelper.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Octokit.Internal
+{
+    public static class TestSetup
+    {
+        public static Task<IApiResponse<object>> GetApiResponse(HttpStatusCode statusCode)
+        {
+            var response = new Response(statusCode, null, new Dictionary<string, string>(), "application/json");
+            return Task.FromResult<IApiResponse<object>>(new ApiResponse<object>(response));
+
+        }
+    }
+}

--- a/Octokit.Tests/Models/ReadOnlyPagedCollectionTests.cs
+++ b/Octokit.Tests/Models/ReadOnlyPagedCollectionTests.cs
@@ -15,8 +15,9 @@ namespace Octokit.Tests.Models
             public async Task ReturnsTheNextPage()
             {
                 var nextPageUrl = new Uri("https://example.com/page/2");
-                var nextPageResponse = Task.Factory.StartNew<IApiResponse<List<object>>>(() =>
-                    new ApiResponse<List<object>>(new Response(), new List<object> { new object(), new object() }));
+                var listResponse = new ApiResponse<List<object>>(new Response(), new List<object> { new object(), new object() });
+                var nextPageResponse = Task.FromResult<IApiResponse<List<object>>>(listResponse);
+
                 var links = new Dictionary<string, Uri> { { "next", nextPageUrl } };
                 var scopes = new List<string>();
                 var httpResponse = Substitute.For<IResponse>();
@@ -38,8 +39,8 @@ namespace Octokit.Tests.Models
             public async Task WhenNoInformationSetReturnsNull()
             {
                 var nextPageUrl = new Uri("https://example.com/page/2");
-                var nextPageResponse = Task.Factory.StartNew<IApiResponse<List<object>>>(() =>
-                    new ApiResponse<List<object>>(new Response(), new List<object> { new object(), new object() }));
+                var listResponse = new ApiResponse<List<object>>(new Response(), new List<object> { new object(), new object() });
+                var nextPageResponse = Task.FromResult<IApiResponse<List<object>>>(listResponse);
 
                 var links = new Dictionary<string, Uri>();
                 var scopes = new List<string>();
@@ -64,8 +65,8 @@ namespace Octokit.Tests.Models
             public async Task WhenInlineFuncKillsPaginationReturnNull()
             {
                 var nextPageUrl = new Uri("https://example.com/page/2");
-                var nextPageResponse = Task.Factory.StartNew<IApiResponse<List<object>>>(() =>
-                    new ApiResponse<List<object>>(new Response(), new List<object> { new object(), new object() }));
+                var listResponse = new ApiResponse<List<object>>(new Response(), new List<object> { new object(), new object() });
+                var nextPageResponse = Task.FromResult<IApiResponse<List<object>>>(listResponse);
 
                 var links = new Dictionary<string, Uri> { { "next", nextPageUrl } };
                 var scopes = new List<string>();

--- a/Octokit.Tests/Reactive/ObservableIssuesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssuesClientTests.cs
@@ -301,11 +301,11 @@ public class ObservableIssuesClientTests
                     && d["state"] == "open"
                     && d["sort"] == "created"
                     && d["filter"] == "assigned"), Arg.Any<string>())
-                .Returns(Task.Factory.StartNew<IApiResponse<List<Issue>>>(() => firstPageResponse));
+                .Returns(Task.FromResult<IApiResponse<List<Issue>>>(firstPageResponse));
             gitHubClient.Connection.Get<List<Issue>>(secondPageUrl, Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview+json")
-                .Returns(Task.Factory.StartNew<IApiResponse<List<Issue>>>(() => secondPageResponse));
+                .Returns(Task.FromResult<IApiResponse<List<Issue>>>(secondPageResponse));
             gitHubClient.Connection.Get<List<Issue>>(thirdPageUrl, Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview+json")
-                .Returns(Task.Factory.StartNew<IApiResponse<List<Issue>>>(() => lastPageResponse));
+                .Returns(Task.FromResult<IApiResponse<List<Issue>>>(lastPageResponse));
             var client = new ObservableIssuesClient(gitHubClient);
 
             var results = await client.GetAllForRepository("fake", "repo").ToArray();
@@ -378,11 +378,11 @@ public class ObservableIssuesClientTests
                     && d["sort"] == "created"
                     && d["filter"] == "assigned"),
                 "application/vnd.github.squirrel-girl-preview+json")
-                .Returns(Task.Factory.StartNew<IApiResponse<List<Issue>>>(() => firstPageResponse));
+                .Returns(Task.FromResult<IApiResponse<List<Issue>>>(firstPageResponse));
             gitHubClient.Connection.Get<List<Issue>>(secondPageUrl, Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview+json")
-                .Returns(Task.Factory.StartNew<IApiResponse<List<Issue>>>(() => secondPageResponse));
+                .Returns(Task.FromResult<IApiResponse<List<Issue>>>(secondPageResponse));
             gitHubClient.Connection.Get<List<Issue>>(thirdPageUrl, Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview+json")
-                .Returns(Task.Factory.StartNew<IApiResponse<List<Issue>>>(() => lastPageResponse));
+                .Returns(Task.FromResult<IApiResponse<List<Issue>>>(lastPageResponse));
             var client = new ObservableIssuesClient(gitHubClient);
 
             var results = await client.GetAllForOwnedAndMemberRepositories().ToArray();
@@ -464,11 +464,11 @@ public class ObservableIssuesClientTests
                     && d["state"] == "open"
                     && d["sort"] == "created"
                     && d["filter"] == "assigned"), "application/vnd.github.squirrel-girl-preview+json")
-                .Returns(Task.Factory.StartNew<IApiResponse<List<Issue>>>(() => firstPageResponse));
+                .Returns(Task.FromResult<IApiResponse<List<Issue>>>(firstPageResponse));
             gitHubClient.Connection.Get<List<Issue>>(secondPageUrl, Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview+json")
-                .Returns(Task.Factory.StartNew<IApiResponse<List<Issue>>>(() => secondPageResponse));
+                .Returns(Task.FromResult<IApiResponse<List<Issue>>>(secondPageResponse));
             gitHubClient.Connection.Get<List<Issue>>(thirdPageUrl, Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview+json")
-                .Returns(Task.Factory.StartNew<IApiResponse<List<Issue>>>(() => lastPageResponse));
+                .Returns(Task.FromResult<IApiResponse<List<Issue>>>(lastPageResponse));
 
             var client = new ObservableIssuesClient(gitHubClient);
 
@@ -537,11 +537,11 @@ public class ObservableIssuesClientTests
                     && d["state"] == "open"
                     && d["sort"] == "created"
                     && d["filter"] == "assigned"), "application/vnd.github.squirrel-girl-preview+json")
-                .Returns(Task.Factory.StartNew<IApiResponse<List<Issue>>>(() => firstPageResponse));
+                .Returns(Task.FromResult<IApiResponse<List<Issue>>>(firstPageResponse));
             gitHubClient.Connection.Get<List<Issue>>(secondPageUrl, Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview+json")
-                .Returns(Task.Factory.StartNew<IApiResponse<List<Issue>>>(() => secondPageResponse));
+                .Returns(Task.FromResult<IApiResponse<List<Issue>>>(secondPageResponse));
             gitHubClient.Connection.Get<List<Issue>>(thirdPageUrl, Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview+json")
-                .Returns(Task.Factory.StartNew<IApiResponse<List<Issue>>>(() => lastPageResponse));
+                .Returns(Task.FromResult<IApiResponse<List<Issue>>>(lastPageResponse));
             var client = new ObservableIssuesClient(gitHubClient);
 
             var results = await client.GetAllForCurrent().ToArray();

--- a/Octokit.Tests/Reactive/ObservableMilestonesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableMilestonesClientTests.cs
@@ -248,11 +248,11 @@ namespace Octokit.Tests.Reactive
                 );
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 gitHubClient.Connection.Get<List<Milestone>>(firstPageUrl, Args.EmptyDictionary, null)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<Milestone>>>(() => firstPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<Milestone>>>(firstPageResponse));
                 gitHubClient.Connection.Get<List<Milestone>>(secondPageUrl, Args.EmptyDictionary, null)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<Milestone>>>(() => secondPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<Milestone>>>(secondPageResponse));
                 gitHubClient.Connection.Get<List<Milestone>>(thirdPageUrl, Args.EmptyDictionary, null)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<Milestone>>>(() => lastPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<Milestone>>>(lastPageResponse));
                 var client = new ObservableMilestonesClient(gitHubClient);
 
                 var results = await client.GetAllForRepository("fake", "repo").ToArray();
@@ -305,17 +305,17 @@ namespace Octokit.Tests.Reactive
                             && d["direction"] == "desc"
                             && d["state"] == "open"
                             && d["sort"] == "due_date"), null)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<Milestone>>>(() => firstPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<Milestone>>>(firstPageResponse));
                 gitHubClient.Connection.Get<List<Milestone>>(secondPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 3
                         && d["direction"] == "desc"
                         && d["state"] == "open"
                         && d["sort"] == "due_date"), null)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<Milestone>>>(() => secondPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<Milestone>>>(secondPageResponse));
                 gitHubClient.Connection.Get<List<Milestone>>(thirdPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 3
                         && d["direction"] == "desc"
                         && d["state"] == "open"
                         && d["sort"] == "due_date"), null)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<Milestone>>>(() => lastPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<Milestone>>>(lastPageResponse));
 
                 var client = new ObservableMilestonesClient(gitHubClient);
 

--- a/Octokit.Tests/Reactive/ObservablePullRequestReviewCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservablePullRequestReviewCommentsClientTests.cs
@@ -127,11 +127,11 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var acceptHeader = "application/vnd.github.squirrel-girl-preview+json";
                 gitHubClient.Connection.Get<List<PullRequestReviewComment>>(firstPageUrl, Args.EmptyDictionary, acceptHeader)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => firstPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequestReviewComment>>>(firstPageResponse));
                 gitHubClient.Connection.Get<List<PullRequestReviewComment>>(secondPageUrl, Args.EmptyDictionary, acceptHeader)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => secondPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequestReviewComment>>>(secondPageResponse));
                 gitHubClient.Connection.Get<List<PullRequestReviewComment>>(thirdPageUrl, Args.EmptyDictionary, acceptHeader)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => lastPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequestReviewComment>>>(lastPageResponse));
 
                 var client = new ObservablePullRequestReviewCommentsClient(gitHubClient);
 
@@ -181,11 +181,11 @@ namespace Octokit.Tests.Reactive
 
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 gitHubClient.Connection.Get<List<PullRequestReviewComment>>(firstPageUrl, Args.EmptyDictionary, null)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => firstPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequestReviewComment>>>(firstPageResponse));
                 gitHubClient.Connection.Get<List<PullRequestReviewComment>>(secondPageUrl, Args.EmptyDictionary, null)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => secondPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequestReviewComment>>>(secondPageResponse));
                 gitHubClient.Connection.Get<List<PullRequestReviewComment>>(thirdPageUrl, Args.EmptyDictionary, null)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => lastPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequestReviewComment>>>(lastPageResponse));
 
                 var client = new ObservablePullRequestReviewCommentsClient(gitHubClient);
 
@@ -351,17 +351,17 @@ namespace Octokit.Tests.Reactive
                         && d["direction"] == "desc"
                         && d["since"] == "2013-11-15T11:43:01Z"
                         && d["sort"] == "updated"), previewAcceptHeader)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => firstPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequestReviewComment>>>(firstPageResponse));
                 gitHubClient.Connection.Get<List<PullRequestReviewComment>>(secondPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 3
                         && d["direction"] == "desc"
                         && d["since"] == "2013-11-15T11:43:01Z"
                         && d["sort"] == "updated"), previewAcceptHeader)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => secondPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequestReviewComment>>>(secondPageResponse));
                 gitHubClient.Connection.Get<List<PullRequestReviewComment>>(thirdPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 3
                         && d["direction"] == "desc"
                         && d["since"] == "2013-11-15T11:43:01Z"
                         && d["sort"] == "updated"), previewAcceptHeader)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => lastPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequestReviewComment>>>(lastPageResponse));
 
                 var client = new ObservablePullRequestReviewCommentsClient(gitHubClient);
 
@@ -434,17 +434,17 @@ namespace Octokit.Tests.Reactive
                         && d["direction"] == "desc"
                         && d["since"] == "2013-11-15T11:43:01Z"
                         && d["sort"] == "updated"), "application/vnd.github.squirrel-girl-preview+json")
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => firstPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequestReviewComment>>>(firstPageResponse));
                 gitHubClient.Connection.Get<List<PullRequestReviewComment>>(secondPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 3
                         && d["direction"] == "desc"
                         && d["since"] == "2013-11-15T11:43:01Z"
                         && d["sort"] == "updated"), "application/vnd.github.squirrel-girl-preview+json")
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => secondPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequestReviewComment>>>(secondPageResponse));
                 gitHubClient.Connection.Get<List<PullRequestReviewComment>>(thirdPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 3
                         && d["direction"] == "desc"
                         && d["since"] == "2013-11-15T11:43:01Z"
                         && d["sort"] == "updated"), "application/vnd.github.squirrel-girl-preview+json")
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => lastPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequestReviewComment>>>(lastPageResponse));
 
                 var client = new ObservablePullRequestReviewCommentsClient(gitHubClient);
 
@@ -576,15 +576,15 @@ namespace Octokit.Tests.Reactive
                     Arg.Is<Dictionary<string, string>>(d => d.Count == 2
                         && d["direction"] == "asc"
                         && d["sort"] == "created"), previewAcceptHeader)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => firstPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequestReviewComment>>>(firstPageResponse));
                 gitHubClient.Connection.Get<List<PullRequestReviewComment>>(secondPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 2
                         && d["direction"] == "asc"
                         && d["sort"] == "created"), previewAcceptHeader)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => secondPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequestReviewComment>>>(secondPageResponse));
                 gitHubClient.Connection.Get<List<PullRequestReviewComment>>(thirdPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 2
                         && d["direction"] == "asc"
                         && d["sort"] == "created"), previewAcceptHeader)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => lastPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequestReviewComment>>>(lastPageResponse));
 
                 var client = new ObservablePullRequestReviewCommentsClient(gitHubClient);
 
@@ -646,15 +646,15 @@ namespace Octokit.Tests.Reactive
                     Arg.Is<Dictionary<string, string>>(d => d.Count == 2
                         && d["direction"] == "asc"
                         && d["sort"] == "created"), "application/vnd.github.squirrel-girl-preview+json")
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => firstPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequestReviewComment>>>(firstPageResponse));
                 gitHubClient.Connection.Get<List<PullRequestReviewComment>>(secondPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 2
                         && d["direction"] == "asc"
                         && d["sort"] == "created"), "application/vnd.github.squirrel-girl-preview+json")
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => secondPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequestReviewComment>>>(secondPageResponse));
                 gitHubClient.Connection.Get<List<PullRequestReviewComment>>(thirdPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 2
                         && d["direction"] == "asc"
                         && d["sort"] == "created"), "application/vnd.github.squirrel-girl-preview+json")
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => lastPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequestReviewComment>>>(lastPageResponse));
 
                 var client = new ObservablePullRequestReviewCommentsClient(gitHubClient);
 

--- a/Octokit.Tests/Reactive/ObservablePullRequestReviewsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservablePullRequestReviewsClientTests.cs
@@ -127,11 +127,11 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
 
                 gitHubClient.Connection.Get<List<PullRequestReview>>(firstPageUrl, Args.EmptyDictionary, null)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReview>>>(() => firstPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequestReview>>>(firstPageResponse));
                 gitHubClient.Connection.Get<List<PullRequestReview>>(secondPageUrl, Args.EmptyDictionary, null)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReview>>>(() => secondPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequestReview>>>(secondPageResponse));
                 gitHubClient.Connection.Get<List<PullRequestReview>>(thirdPageUrl, Args.EmptyDictionary, null)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReview>>>(() => lastPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequestReview>>>(lastPageResponse));
 
                 var client = new ObservablePullRequestReviewsClient(gitHubClient);
 
@@ -182,11 +182,11 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
 
                 gitHubClient.Connection.Get<List<PullRequestReview>>(firstPageUrl, Args.EmptyDictionary, null)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReview>>>(() => firstPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequestReview>>>(firstPageResponse));
                 gitHubClient.Connection.Get<List<PullRequestReview>>(secondPageUrl, Args.EmptyDictionary, null)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReview>>>(() => secondPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequestReview>>>(secondPageResponse));
                 gitHubClient.Connection.Get<List<PullRequestReview>>(thirdPageUrl, Args.EmptyDictionary, null)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReview>>>(() => lastPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequestReview>>>(lastPageResponse));
 
                 var client = new ObservablePullRequestReviewsClient(gitHubClient);
 
@@ -522,11 +522,11 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
 
                 gitHubClient.Connection.Get<List<PullRequestReviewComment>>(firstPageUrl, Args.EmptyDictionary, null)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => firstPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequestReviewComment>>>(firstPageResponse));
                 gitHubClient.Connection.Get<List<PullRequestReviewComment>>(secondPageUrl, Args.EmptyDictionary, null)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => secondPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequestReviewComment>>>(secondPageResponse));
                 gitHubClient.Connection.Get<List<PullRequestReviewComment>>(thirdPageUrl, Args.EmptyDictionary, null)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => lastPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequestReviewComment>>>(lastPageResponse));
 
                 var client = new ObservablePullRequestReviewsClient(gitHubClient);
 
@@ -577,11 +577,11 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
 
                 gitHubClient.Connection.Get<List<PullRequestReviewComment>>(firstPageUrl, Args.EmptyDictionary, null)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => firstPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequestReviewComment>>>(firstPageResponse));
                 gitHubClient.Connection.Get<List<PullRequestReviewComment>>(secondPageUrl, Args.EmptyDictionary, null)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => secondPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequestReviewComment>>>(secondPageResponse));
                 gitHubClient.Connection.Get<List<PullRequestReviewComment>>(thirdPageUrl, Args.EmptyDictionary, null)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => lastPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequestReviewComment>>>(lastPageResponse));
 
                 var client = new ObservablePullRequestReviewsClient(gitHubClient);
 

--- a/Octokit.Tests/Reactive/ObservablePullRequestsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservablePullRequestsClientTests.cs
@@ -210,11 +210,11 @@ namespace Octokit.Tests.Reactive
                 );
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 gitHubClient.Connection.Get<List<PullRequest>>(firstPageUrl, Args.EmptyDictionary, "application/vnd.github.shadow-cat-preview+json")
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequest>>>(() => firstPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequest>>>(firstPageResponse));
                 gitHubClient.Connection.Get<List<PullRequest>>(secondPageUrl, Args.EmptyDictionary, "application/vnd.github.shadow-cat-preview+json")
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequest>>>(() => secondPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequest>>>(secondPageResponse));
                 gitHubClient.Connection.Get<List<PullRequest>>(thirdPageUrl, Args.EmptyDictionary, "application/vnd.github.shadow-cat-preview+json")
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequest>>>(() => lastPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequest>>>(lastPageResponse));
                 var client = new ObservablePullRequestsClient(gitHubClient);
 
                 var results = await client.GetAllForRepository("fake", "repo").ToArray();
@@ -263,11 +263,11 @@ namespace Octokit.Tests.Reactive
                 );
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 gitHubClient.Connection.Get<List<PullRequest>>(firstPageUrl, Args.EmptyDictionary, "application/vnd.github.shadow-cat-preview+json")
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequest>>>(() => firstPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequest>>>(firstPageResponse));
                 gitHubClient.Connection.Get<List<PullRequest>>(secondPageUrl, Args.EmptyDictionary, "application/vnd.github.shadow-cat-preview+json")
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequest>>>(() => secondPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequest>>>(secondPageResponse));
                 gitHubClient.Connection.Get<List<PullRequest>>(thirdPageUrl, Args.EmptyDictionary, "application/vnd.github.shadow-cat-preview+json")
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequest>>>(() => lastPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequest>>>(lastPageResponse));
                 var client = new ObservablePullRequestsClient(gitHubClient);
 
                 var results = await client.GetAllForRepository(1).ToArray();
@@ -322,21 +322,21 @@ namespace Octokit.Tests.Reactive
                         && d["base"] == "fake_base_branch"
                         && d["sort"] == "created"
                         && d["direction"] == "desc"), "application/vnd.github.shadow-cat-preview+json")
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequest>>>(() => firstPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequest>>>(firstPageResponse));
                 gitHubClient.Connection.Get<List<PullRequest>>(secondPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 5
                         && d["head"] == "user:ref-name"
                         && d["state"] == "open"
                         && d["base"] == "fake_base_branch"
                         && d["sort"] == "created"
                         && d["direction"] == "desc"), "application/vnd.github.shadow-cat-preview+json")
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequest>>>(() => secondPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequest>>>(secondPageResponse));
                 gitHubClient.Connection.Get<List<PullRequest>>(thirdPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 5
                         && d["head"] == "user:ref-name"
                         && d["state"] == "open"
                         && d["base"] == "fake_base_branch"
                         && d["sort"] == "created"
                         && d["direction"] == "desc"), "application/vnd.github.shadow-cat-preview+json")
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequest>>>(() => lastPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequest>>>(lastPageResponse));
                 var client = new ObservablePullRequestsClient(gitHubClient);
 
                 var results = await client.GetAllForRepository("fake", "repo", new PullRequestRequest { Head = "user:ref-name", Base = "fake_base_branch" }).ToArray();
@@ -391,21 +391,21 @@ namespace Octokit.Tests.Reactive
                         && d["base"] == "fake_base_branch"
                         && d["sort"] == "created"
                         && d["direction"] == "desc"), "application/vnd.github.shadow-cat-preview+json")
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequest>>>(() => firstPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequest>>>(firstPageResponse));
                 gitHubClient.Connection.Get<List<PullRequest>>(secondPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 5
                         && d["head"] == "user:ref-name"
                         && d["state"] == "open"
                         && d["base"] == "fake_base_branch"
                         && d["sort"] == "created"
                         && d["direction"] == "desc"), "application/vnd.github.shadow-cat-preview+json")
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequest>>>(() => secondPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequest>>>(secondPageResponse));
                 gitHubClient.Connection.Get<List<PullRequest>>(thirdPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 5
                         && d["head"] == "user:ref-name"
                         && d["state"] == "open"
                         && d["base"] == "fake_base_branch"
                         && d["sort"] == "created"
                         && d["direction"] == "desc"), "application/vnd.github.shadow-cat-preview+json")
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequest>>>(() => lastPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<PullRequest>>>(lastPageResponse));
                 var client = new ObservablePullRequestsClient(gitHubClient);
 
                 var results = await client.GetAllForRepository(1, new PullRequestRequest { Head = "user:ref-name", Base = "fake_base_branch" }).ToArray();

--- a/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
@@ -153,8 +153,7 @@ namespace Octokit.Tests.Reactive
             public async Task IsALukeWarmObservable()
             {
                 var repository = new Repository();
-                var response = Task.Factory.StartNew<IApiResponse<Repository>>(() =>
-                    new ApiResponse<Repository>(new Response(), repository));
+                var response = Task.FromResult<IApiResponse<Repository>>(new ApiResponse<Repository>(new Response(), repository));
                 var connection = Substitute.For<IConnection>();
                 connection.Get<Repository>(Args.Uri, null, Args.AnyAcceptHeaders).Returns(response);
                 var gitHubClient = new GitHubClient(connection);
@@ -179,8 +178,7 @@ namespace Octokit.Tests.Reactive
             public async Task IsALukeWarmObservableWithRepositoryId()
             {
                 var repository = new Repository();
-                var response = Task.Factory.StartNew<IApiResponse<Repository>>(() =>
-                    new ApiResponse<Repository>(new Response(), repository));
+                var response = Task.FromResult<IApiResponse<Repository>>(new ApiResponse<Repository>(new Response(), repository));
                 var connection = Substitute.For<IConnection>();
                 connection.Get<Repository>(Args.Uri, null, Args.AnyAcceptHeaders).Returns(response);
                 var gitHubClient = new GitHubClient(connection);
@@ -248,11 +246,11 @@ namespace Octokit.Tests.Reactive
 
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 gitHubClient.Connection.Get<List<Repository>>(firstPageUrl, Arg.Any<IDictionary<string, string>>(), Args.AnyAcceptHeaders)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<Repository>>>(() => firstPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<Repository>>>(firstPageResponse));
                 gitHubClient.Connection.Get<List<Repository>>(secondPageUrl, Arg.Any<IDictionary<string, string>>(), Args.AnyAcceptHeaders)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<Repository>>>(() => secondPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<Repository>>>(secondPageResponse));
                 gitHubClient.Connection.Get<List<Repository>>(thirdPageUrl, Arg.Any<IDictionary<string, string>>(), Args.AnyAcceptHeaders)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<Repository>>>(() => lastPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<Repository>>>(lastPageResponse));
                 var repositoriesClient = new ObservableRepositoriesClient(gitHubClient);
 
                 var results = await repositoriesClient.GetAllForCurrent().ToArray();
@@ -311,13 +309,13 @@ namespace Octokit.Tests.Reactive
                 );
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 gitHubClient.Connection.GetResponse<List<Repository>>(firstPageUrl)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<Repository>>>(() => firstPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<Repository>>>(firstPageResponse));
                 gitHubClient.Connection.GetResponse<List<Repository>>(secondPageUrl)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<Repository>>>(() => secondPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<Repository>>>(secondPageResponse));
                 gitHubClient.Connection.GetResponse<List<Repository>>(thirdPageUrl)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<Repository>>>(() => thirdPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<Repository>>>(thirdPageResponse));
                 gitHubClient.Connection.GetResponse<List<Repository>>(fourthPageUrl)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<Repository>>>(() => lastPageResponse));
+                    .Returns(Task.FromResult<IApiResponse<List<Repository>>>(lastPageResponse));
                 var repositoriesClient = new ObservableRepositoriesClient(gitHubClient);
 
                 var results = await repositoriesClient.GetAllForCurrent().Take(4).ToArray();


### PR DESCRIPTION
`Task.Factory.StartNew` is from a time before we had the ability to wrap a result in a `Task`, and as part of simplifying tests to be able to refactor the internals I decided to drop these usages.

You may also note the `TestSetup.GetApiResponse` helper function - that helps eliminate repetitive code and make the tests more readable.