### PR TITLE
handle case insensitive headers when parsing for API rate limiting

### DIFF
--- a/Octokit.Tests/Clients/Enterprise/EnterpriseProbeTests.cs
+++ b/Octokit.Tests/Clients/Enterprise/EnterpriseProbeTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Reactive.Linq;
@@ -19,10 +20,15 @@ public class EnterpriseProbeTests
         [InlineData(HttpStatusCode.NotFound)]
         public async Task ReturnsExistsForResponseWithCorrectHeadersRegardlessOfResponse(HttpStatusCode httpStatusCode)
         {
+            var headers = new Dictionary<string,string>()
+            {
+                { "Server", "REVERSE-PROXY" },
+                { "X-GitHub-Request-Id", Guid.NewGuid().ToString() }
+            };
             var response = Substitute.For<IResponse>();
             response.StatusCode.Returns(httpStatusCode);
-            response.Headers["Server"].Returns("REVERSE-PROXY");
-            response.Headers.ContainsKey("X-GitHub-Request-Id").Returns(true);
+            response.Headers.Returns(headers);
+
             var productHeader = new ProductHeaderValue("GHfW", "99");
             var httpClient = Substitute.For<IHttpClient>();
             httpClient.Send(Args.Request, CancellationToken.None).Returns(Task.FromResult(response));
@@ -43,10 +49,16 @@ public class EnterpriseProbeTests
         [Fact]
         public async Task ReturnsExistsForApiExceptionWithCorrectHeaders()
         {
+
+            var headers = new Dictionary<string,string>()
+            {
+                { "Server", "GitHub.com" },
+                { "X-GitHub-Request-Id", Guid.NewGuid().ToString() }
+            };
             var httpClient = Substitute.For<IHttpClient>();
             var response = Substitute.For<IResponse>();
-            response.Headers["Server"].Returns("GitHub.com");
-            response.Headers.ContainsKey("X-GitHub-Request-Id").Returns(true);
+            response.Headers.Returns(headers);
+
             var apiException = new ApiException(response);
             httpClient.Send(Args.Request, CancellationToken.None).ThrowsAsync(apiException);
             var productHeader = new ProductHeaderValue("GHfW", "99");

--- a/Octokit.Tests/Clients/Enterprise/EnterpriseProbeTests.cs
+++ b/Octokit.Tests/Clients/Enterprise/EnterpriseProbeTests.cs
@@ -20,7 +20,7 @@ public class EnterpriseProbeTests
         [InlineData(HttpStatusCode.NotFound)]
         public async Task ReturnsExistsForResponseWithCorrectHeadersRegardlessOfResponse(HttpStatusCode httpStatusCode)
         {
-            var headers = new Dictionary<string,string>()
+            var headers = new Dictionary<string, string>()
             {
                 { "Server", "REVERSE-PROXY" },
                 { "X-GitHub-Request-Id", Guid.NewGuid().ToString() }
@@ -50,7 +50,7 @@ public class EnterpriseProbeTests
         public async Task ReturnsExistsForApiExceptionWithCorrectHeaders()
         {
 
-            var headers = new Dictionary<string,string>()
+            var headers = new Dictionary<string, string>()
             {
                 { "Server", "GitHub.com" },
                 { "X-GitHub-Request-Id", Guid.NewGuid().ToString() }

--- a/Octokit.Tests/Exceptions/AbuseExceptionTests.cs
+++ b/Octokit.Tests/Exceptions/AbuseExceptionTests.cs
@@ -54,6 +54,17 @@ namespace Octokit.Tests.Exceptions
                     }
 
                     [Fact]
+                    public void WithRetryAfterCaseInsensitiveHeader_PopulatesRetryAfterSeconds()
+                    {
+                        var headerDictionary = new Dictionary<string, string> { { "retry-after", "20" } };
+
+                        var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
+                        var abuseException = new AbuseException(response);
+
+                        Assert.Equal(20, abuseException.RetryAfterSeconds);
+                    }
+
+                    [Fact]
                     public void WithZeroHeaderValue_RetryAfterSecondsIsZero()
                     {
                         var headerDictionary = new Dictionary<string, string> { { "Retry-After", "0" } };

--- a/Octokit.Tests/Http/ApiInfoParserTests.cs
+++ b/Octokit.Tests/Http/ApiInfoParserTests.cs
@@ -33,6 +33,28 @@ namespace Octokit.Tests
             }
 
             [Fact]
+            public void ParsesApiInfoFromCaseInsensitiveHeaders()
+            {
+                var headers = new Dictionary<string, string>
+                {
+                    { "x-accepted-oauth-scopes", "user" },
+                    { "x-oauth-scopes", "user, public_repo, repo, gist" },
+                    { "x-ratelimit-limit", "5000" },
+                    { "x-ratelimit-remaining", "4997" },
+                    { "etag", "5634b0b187fd2e91e3126a75006cc4fa" }
+                };
+
+                var apiInfo = ApiInfoParser.ParseResponseHeaders(headers);
+
+                Assert.NotNull(apiInfo);
+                Assert.Equal(new[] { "user" }, apiInfo.AcceptedOauthScopes.ToArray());
+                Assert.Equal(new[] { "user", "public_repo", "repo", "gist" }, apiInfo.OauthScopes.ToArray());
+                Assert.Equal(5000, apiInfo.RateLimit.Limit);
+                Assert.Equal(4997, apiInfo.RateLimit.Remaining);
+                Assert.Equal("5634b0b187fd2e91e3126a75006cc4fa", apiInfo.Etag);
+            }
+
+            [Fact]
             public void BadHeadersAreIgnored()
             {
                 var headers = new Dictionary<string, string>

--- a/Octokit/Clients/Enterprise/EnterpriseProbe.cs
+++ b/Octokit/Clients/Enterprise/EnterpriseProbe.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text.RegularExpressions;
@@ -103,7 +104,7 @@ namespace Octokit
 
         static bool IsEnterpriseResponse(IResponse response)
         {
-            return response.Headers.ContainsKey("X-GitHub-Request-Id");
+            return response.Headers.Any(h => string.Equals(h.Key, "X-GitHub-Request-Id", StringComparison.OrdinalIgnoreCase));
         }
     }
 

--- a/Octokit/Exceptions/AbuseException.cs
+++ b/Octokit/Exceptions/AbuseException.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Net;
 #if !NO_SERIALIZABLE
 using System.Runtime.Serialization;
@@ -44,11 +46,11 @@ namespace Octokit
 
         private static int? ParseRetryAfterSeconds(IResponse response)
         {
-            string secondsValue;
-            if (!response.Headers.TryGetValue("Retry-After", out secondsValue)) { return null; }
+            var header = response.Headers.FirstOrDefault(h => string.Equals(h.Key, "Retry-After", StringComparison.OrdinalIgnoreCase));
+            if (header.Equals(default(KeyValuePair<string, string>))) { return null; }
 
             int retrySeconds;
-            if (!int.TryParse(secondsValue, out retrySeconds)) { return null; }
+            if (!int.TryParse(header.Value, out retrySeconds)) { return null; }
             if (retrySeconds < 0) { return null; }
 
             return retrySeconds;

--- a/Octokit/Helpers/ConcurrentCache.cs
+++ b/Octokit/Helpers/ConcurrentCache.cs
@@ -11,6 +11,7 @@ namespace Octokit
     /// </summary>
     /// <typeparam name="TKey"></typeparam>
     /// <typeparam name="TValue"></typeparam>
+    [Obsolete("This component is no longer used, and will be removed in a future update")]
     public class ConcurrentCache<TKey, TValue>
     {
         Dictionary<TKey, TValue> _cache = new Dictionary<TKey, TValue>();

--- a/Octokit/Http/ApiInfoParser.cs
+++ b/Octokit/Http/ApiInfoParser.cs
@@ -21,6 +21,11 @@ namespace Octokit.Internal
             return headers.FirstOrDefault(h => string.Equals(h.Key, key, StringComparison.OrdinalIgnoreCase));
         }
 
+        static bool Exists(KeyValuePair<string, string> kvp)
+        {
+            return !kvp.Equals(default(KeyValuePair<string, string>));
+        }
+
         public static ApiInfo ParseResponseHeaders(IDictionary<string, string> responseHeaders)
         {
             Ensure.ArgumentNotNull(responseHeaders, nameof(responseHeaders));
@@ -31,7 +36,7 @@ namespace Octokit.Internal
             string etag = null;
 
             var acceptedOauthScopesKey = LookupHeader(responseHeaders, "X-Accepted-OAuth-Scopes");
-            if (!acceptedOauthScopesKey.Equals(default(KeyValuePair<string, string>)))
+            if (Exists(acceptedOauthScopesKey))
             {
                 acceptedOauthScopes.AddRange(acceptedOauthScopesKey.Value
                     .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
@@ -39,7 +44,7 @@ namespace Octokit.Internal
             }
 
             var oauthScopesKey = LookupHeader(responseHeaders, "X-OAuth-Scopes");
-            if (!oauthScopesKey.Equals(default(KeyValuePair<string, string>)))
+            if (Exists(oauthScopesKey))
             {
                 oauthScopes.AddRange(oauthScopesKey.Value
                     .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
@@ -47,13 +52,13 @@ namespace Octokit.Internal
             }
 
             var etagKey = LookupHeader(responseHeaders, "ETag");
-            if (!etagKey.Equals(default(KeyValuePair<string, string>)))
+            if (Exists(etagKey))
             {
                 etag = etagKey.Value;
             }
 
             var linkKey = LookupHeader(responseHeaders, "Link");
-            if (!linkKey.Equals(default(KeyValuePair<string, string>)))
+            if (Exists(linkKey))
             {
                 var links = linkKey.Value.Split(',');
                 foreach (var link in links)

--- a/Octokit/Http/RateLimit.cs
+++ b/Octokit/Http/RateLimit.cs
@@ -71,12 +71,17 @@ namespace Octokit
             return headers.FirstOrDefault(h => string.Equals(h.Key, key, StringComparison.OrdinalIgnoreCase));
         }
 
+        static bool Exists(KeyValuePair<string, string> kvp)
+        {
+            return !kvp.Equals(default(KeyValuePair<string, string>));
+        }
+
         static long GetHeaderValueAsInt32Safe(IDictionary<string, string> responseHeaders, string key)
         {
             long result;
 
             var foundKey = LookupHeader(responseHeaders, key);
-            if (foundKey.Equals(default(KeyValuePair<string, string>)))
+            if (!Exists(foundKey))
             {
                 return 0;
             }


### PR DESCRIPTION
Related to #2161 but probably not the full fix, given we pass around a dictionary and lookup by key, rather than following the HTTP spec and supporting case insensitive headers.

I chatted with some others inside GitHub and they reminded me about [RFC 2616, section 4.2](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2):

> Each header field consists of a name followed by a colon (":") and the field value. **Field names are case-insensitive.**

I'd love to get to a place where we can leverage `HttpResponseHeaders` but we are very tightly coupled to `IResponse` in the internals, and it's this component that manages the headers as a dictionary:

https://github.com/octokit/octokit.net/blob/a25863f2289050fdfb091ba1ff2808cd1218d7e1/Octokit/Http/IResponse.cs#L32-L35

The setup is here, which converts the `HttpResponseHeaders` into a dictionary:

https://github.com/octokit/octokit.net/blob/a25863f2289050fdfb091ba1ff2808cd1218d7e1/Octokit/Http/HttpClientAdapter.cs#L125-L129

You'll also note that headers can have multiple values, so the eventual refactoring would need to support that. 

 - [x] identify other places where we `TryGetValue` without handling case-insensitive headers