### PR TITLE
Add support for creating project cards from pull requests

### DIFF
--- a/Octokit/Models/Request/NewProjectCard.cs
+++ b/Octokit/Models/Request/NewProjectCard.cs
@@ -12,7 +12,7 @@ namespace Octokit
             Note = note;
         }
 
-        public NewProjectCard(int contentId, ProjectCardContentType contentType)
+        public NewProjectCard(long contentId, ProjectCardContentType contentType)
         {
             ContentId = contentId;
             ContentType = contentType;
@@ -27,7 +27,7 @@ namespace Octokit
         /// The id of the Issue or Pull Request to associate with this card.
         /// </summary>
         [Parameter(Key = "content_id")]
-        public int? ContentId { get; protected set; }
+        public long? ContentId { get; protected set; }
 
         /// <summary>
         /// The type of content to associate with this card.
@@ -46,7 +46,9 @@ namespace Octokit
 
     public enum ProjectCardContentType
     {
-        [Parameter(Value = "Issue")]
-        Issue
+        [Parameter(Value = nameof(Issue))]
+        Issue,
+        [Parameter(Value = nameof(PullRequest))]
+        PullRequest
     }
 }


### PR DESCRIPTION
The v3 GitHub API [now supports adding Pull Requests as project cards](https://developer.github.com/v3/projects/cards/#create-a-project-card), which was disabled when support for project cards was initially added to OctoKit. This PR reintroduces support for PRs as cards, including a new integration test.

### Plan of Action

- [x] Write an integration test
- [x] Update enum to support Pull Requests
- [x] Test successfully passes