### PR TITLE
add support for repository templates API

### DIFF
--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -219,6 +219,50 @@ public class RepositoriesClientTests
             }
         }
 
+        [IntegrationTest]
+        public async Task CreatesARepositoryAsTemplate()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var repoName = Helper.MakeNameWithTimestamp("repo-as-template");
+
+            var newRepository = new NewRepository(repoName)
+            {
+                IsTemplate = true
+            };
+
+            using (var context = await github.CreateRepositoryContext(newRepository))
+            {
+                var createdRepository = context.Repository;
+
+                var repository = await github.Repository.Get(Helper.UserName, repoName);
+
+                Assert.True(repository.IsTemplate);
+            }
+        }
+
+        [IntegrationTest]
+        public async Task CreatesARepositoryFromTemplate()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var repoTemplateName = Helper.MakeNameWithTimestamp("repo-template");
+            var repoFromTemplateName = Helper.MakeNameWithTimestamp("repo-from-template");
+            var owner = github.User.Current().Result.Login;
+
+            var newTemplate = new NewRepository(repoTemplateName)
+            {
+                IsTemplate = true
+            };
+
+            var newRepo = new NewRepositoryFromTemplate(repoFromTemplateName);
+
+            using (var templateContext = await github.CreateRepositoryContext(newTemplate))
+            using (var context = await github.CreateRepositoryFromTemplateContext(owner, repoFromTemplateName, newRepo))
+            {
+                var repository = await github.Repository.Get(Helper.UserName, repoFromTemplateName);
+
+                Assert.Equal(repoFromTemplateName, repository.Name);
+            }
+        }
 
         [IntegrationTest]
         public async Task ThrowsInvalidGitIgnoreExceptionForInvalidTemplateNames()

--- a/Octokit.Tests.Integration/Helpers/GithubClientExtensions.cs
+++ b/Octokit.Tests.Integration/Helpers/GithubClientExtensions.cs
@@ -26,6 +26,13 @@ namespace Octokit.Tests.Integration.Helpers
             return new RepositoryContext(client.Connection, repo);
         }
 
+        internal static async Task<RepositoryContext> CreateRepositoryFromTemplateContext(this IGitHubClient client, string owner, string repoName, NewRepositoryFromTemplate newRepository)
+        {
+            var repo = await client.Repository.Generate(owner, repoName, newRepository);
+
+            return new RepositoryContext(client.Connection, repo);
+        }
+
         internal static async Task<TeamContext> CreateTeamContext(this IGitHubClient client, string organization, NewTeam newTeam)
         {
             newTeam.Privacy = TeamPrivacy.Closed;

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -78,6 +78,15 @@ namespace Octokit
         Task<Repository> Create(string organizationLogin, NewRepository newRepository);
 
         /// <summary>
+        /// Creates a new repository using a repository template.
+        /// </summary>
+        /// <param name="owner">The owner of the template</param>
+        /// <param name="repo">The name of the template</param>
+        /// <param name="newRepository"></param>
+        /// <returns></returns>
+        Task<Repository> Generate(string owner, string repo, NewRepositoryFromTemplate newRepository);
+
+        /// <summary>
         /// Deletes the specified repository.
         /// </summary>
         /// <remarks>

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
@@ -50,6 +50,7 @@ namespace Octokit
         /// <param name="newRepository">A <see cref="NewRepository"/> instance describing the new repository to create</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="Repository"/> instance for the created repository.</returns>
+        [Preview(AcceptHeaders.TemplateRepositoryPreviewCodeName)]
         [ManualRoute("POST", "/user/repos")]
         public Task<Repository> Create(NewRepository newRepository)
         {
@@ -68,6 +69,7 @@ namespace Octokit
         /// <param name="newRepository">A <see cref="NewRepository"/> instance describing the new repository to create</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="Repository"/> instance for the created repository</returns>
+        [Preview(AcceptHeaders.TemplateRepositoryPreviewCodeName)]
         [ManualRoute("POST", "/orgs/{org}/repos")]
         public Task<Repository> Create(string organizationLogin, NewRepository newRepository)
         {
@@ -246,6 +248,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="Repository"/></returns>
+        [Preview(AcceptHeaders.TemplateRepositoryPreviewCodeName)]
         [ManualRoute("GET", "/repos/{owner}/{repo}")]
         public Task<Repository> Get(string owner, string name)
         {
@@ -264,6 +267,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="Repository"/></returns>
+        [Preview(AcceptHeaders.TemplateRepositoryPreviewCodeName)]
         [ManualRoute("GET", "/repositories/{id}")]
         public Task<Repository> Get(long repositoryId)
         {

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
@@ -98,7 +98,7 @@ namespace Octokit
         {
             try
             {
-                return await ApiConnection.Post<Repository>(url, newRepository).ConfigureAwait(false);
+                return await ApiConnection.Post<Repository>(url, newRepository, AcceptHeaders.TemplateRepositoryPreview).ConfigureAwait(false);
             }
             catch (ApiValidationException e)
             {

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -81,6 +81,19 @@ namespace Octokit
             return Create(ApiUrls.OrganizationRepositories(organizationLogin), organizationLogin, newRepository);
         }
 
+        [Preview(AcceptHeaders.TemplateRepositoryPreviewCodeName)]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/generate")]
+        public Task<Repository> Generate(string owner, string repo, NewRepositoryFromTemplate newRepository)
+        {
+            Ensure.ArgumentNotNull(owner, nameof(owner));
+            Ensure.ArgumentNotNull(repo, nameof(repo));
+            Ensure.ArgumentNotNull(newRepository, nameof(newRepository));
+            if (string.IsNullOrEmpty(newRepository.Name))
+                throw new ArgumentException("The new repository's name must not be null.");
+
+            return ApiConnection.Post<Repository>(ApiUrls.Repositories(owner, repo), newRepository, AcceptHeaders.TemplateRepositoryPreview);
+        }
+
         async Task<Repository> Create(Uri url, string organizationLogin, NewRepository newRepository)
         {
             try

--- a/Octokit/Helpers/AcceptHeaders.cs
+++ b/Octokit/Helpers/AcceptHeaders.cs
@@ -50,6 +50,9 @@ namespace Octokit
 
         public const string OAuthApplicationsPreview = "application/vnd.github.doctor-strange-preview+json";
 
+        public const string TemplateRepositoryPreview = "application/vnd.github.baptiste-preview+json";
+        public const string TemplateRepositoryPreviewCodeName = "baptiste";
+
         /// <summary>
         /// Combines multiple preview headers. GitHub API supports Accept header with multiple
         /// values separated by comma.

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -59,6 +59,15 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Returns the <see cref="Uri"/> that create a repository using a template.
+        /// </summary>
+        /// <returns></returns>
+        public static Uri Repositories(string owner, string repo)
+        {
+            return "repos/{0}/{1}/generate".FormatUri(owner, repo);
+        }
+
+        /// <summary>
         /// Returns the <see cref="Uri"/> that returns all of the repositories for the specified organization in
         /// response to a GET request. A POST to this URL creates a new repository for the organization.
         /// </summary>

--- a/Octokit/Models/Request/NewRepository.cs
+++ b/Octokit/Models/Request/NewRepository.cs
@@ -47,6 +47,11 @@ namespace Octokit
         public bool? HasWiki { get; set; }
 
         /// <summary>
+        /// Either true to make this repo available as a template repository or false to prevent it. Default: false.
+        /// </summary>
+        public bool? IsTemplate { get; set; }
+
+        /// <summary>
         /// Optional. Gets or sets the new repository's optional website.
         /// </summary>
         public string Homepage { get; set; }

--- a/Octokit/Models/Request/NewRepositoryFromTemplate.cs
+++ b/Octokit/Models/Request/NewRepositoryFromTemplate.cs
@@ -1,0 +1,52 @@
+﻿using System.Diagnostics;
+using System.Globalization;
+
+namespace Octokit
+{
+    /// <summary>
+    /// Describes a new repository to create via the <see cref="IRepositoriesClient.Generate"/> method.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class NewRepositoryFromTemplate
+    {
+        /// <summary>
+        /// Creates an object that describes the repository to create on GitHub.
+        /// </summary>
+        /// <param name="name">The name of the repository. This is the only required parameter.</param>
+        public NewRepositoryFromTemplate(string name)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+
+            Name = name;
+        }
+
+        /// <summary>
+        /// Optional. The organization or person who will own the new repository.
+        /// To create a new repository in an organization, the authenticated user must be a member of the specified organization.
+        /// </summary>
+        public string Owner { get; set; }
+
+        /// <summary>
+        /// Required. The name of the new repository.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Optional. A short description of the new repository.
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Optional. Either true to create a new private repository or false to create a new public one. Default: false
+        /// </summary>
+        public bool Private { get; set; }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format(CultureInfo.InvariantCulture, "Name: {0} Description: {1}", Name, Description);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fix #2148 

Add IsTemplate, add header, add method from https://developer.github.com/v3/repos/#create-a-repository-using-a-template