### PR TITLE
ChecksClient constructor should take interface arguments

### DIFF
--- a/Octokit.Tests/GitHubClientTests.cs
+++ b/Octokit.Tests/GitHubClientTests.cs
@@ -4,6 +4,8 @@ using NSubstitute;
 using Octokit.Internal;
 using Xunit;
 using System.Collections.Generic;
+using System.Reflection;
+using System.Linq;
 
 namespace Octokit.Tests
 {
@@ -209,6 +211,55 @@ namespace Octokit.Tests
 
 
                 httpClient.Received(1).SetRequestTimeout(TimeSpan.FromSeconds(15));
+            }
+        }
+
+        public class TheNestedClients
+        {
+            private static void VisitAllClientTypes(Type rootType, HashSet<Type> result)
+            {
+                const BindingFlags ifPropBinding = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+                if (!result.Add(rootType))
+                    return;
+
+                foreach (var pi in rootType.GetProperties(ifPropBinding).Where(pi => pi.CanRead && pi.PropertyType.Name.EndsWith("Client", StringComparison.Ordinal)))
+                {
+                    VisitAllClientTypes(pi.PropertyType, result);
+                }
+            }
+
+            internal static IEnumerable<Type> GetGitHubClientNestedInterfaces()
+            {
+                var visitedTypes = new HashSet<Type>();
+                var rootType = typeof(GitHubClient);
+                VisitAllClientTypes(rootType, visitedTypes);
+                visitedTypes.Remove(rootType);
+                return visitedTypes;
+            }
+
+            public static IEnumerable<object[]> GetGitHubClientNestedInterfacesMemberData() =>
+                GetGitHubClientNestedInterfaces().Select(t => new[] { t });
+
+            [Theory]
+            [MemberData(nameof(GetGitHubClientNestedInterfacesMemberData))]
+            public void HasImplementationClassWithIApiConnectionCtor(Type clientInterface)
+            {
+                var octokitAssembly = typeof(GitHubClient).Assembly;
+
+                var implTypes = octokitAssembly.GetTypes()
+                    .Where(t => t.IsClass && t.IsPublic)
+                    .Where(t => t.GetInterfaces().Contains(clientInterface))
+                    .ToList();
+
+                Assert.Single(implTypes, t =>
+                {
+                    const BindingFlags ctorBinding = BindingFlags.Instance | BindingFlags.Public;
+                    var ctor = t.GetConstructor(ctorBinding, Type.DefaultBinder,
+                        new[] { typeof(IApiConnection) }, null)
+                        ?? t.GetConstructor(ctorBinding, Type.DefaultBinder,
+                        new[] { typeof(IConnection) }, null);
+                    return !(ctor is null);
+                });
             }
         }
     }

--- a/Octokit/Clients/ChecksClient.cs
+++ b/Octokit/Clients/ChecksClient.cs
@@ -12,7 +12,7 @@
         /// Initializes a new GitHub Checks API client.
         /// </summary>
         /// <param name="apiConnection">An API connection</param>
-        public ChecksClient(ApiConnection apiConnection)
+        public ChecksClient(IApiConnection apiConnection)
         {
             Run = new CheckRunsClient(apiConnection);
             Suite = new CheckSuitesClient(apiConnection);


### PR DESCRIPTION
The `ChecksClient` constructor originally took a concrete `ApiConnection` object as an argument. This PR changes the constructor to match all other clients in the library that take an `IApiConnection` argument.

This PR also adds a unit test theory, that asserts that all clients nested under `GitHubClient` follow this behaviour.

The assertion ensures
* All client interfaces have a publically visible concrete implementation type
* The Implementation type has a publically visible constructor that takes either `IConnection` or `IApiConnection` as its single argument.