### PR TITLE
Add Server Time Difference to ApiInfo

### DIFF
--- a/Octokit.Tests/Exceptions/RateLimitExceededExceptionTests.cs
+++ b/Octokit.Tests/Exceptions/RateLimitExceededExceptionTests.cs
@@ -50,7 +50,9 @@ namespace Octokit.Tests.Exceptions
                 {
                     {"X-RateLimit-Limit", "XXX"},
                     {"X-RateLimit-Remaining", "XXXX"},
-                    {"X-RateLimit-Reset", "XXXX"}
+                    {"X-RateLimit-Reset", "XXXX"},
+                    {"Date", "XXX"},
+                    {ApiInfoParser.ReceivedTimeHeaderName, "XXX"},
                 };
                 var response = CreateResponse(HttpStatusCode.Forbidden, headers);
 
@@ -64,6 +66,7 @@ namespace Octokit.Tests.Exceptions
                     "ddd dd MMM yyyy h:mm:ss tt zzz",
                     CultureInfo.InvariantCulture);
                 Assert.Equal(expectedReset, exception.Reset);
+                Assert.Equal(TimeSpan.Zero, exception.GetRetryAfterTimeSpan());
             }
 
             [Fact]
@@ -80,6 +83,7 @@ namespace Octokit.Tests.Exceptions
                     "ddd dd MMM yyyy h:mm:ss tt zzz",
                     CultureInfo.InvariantCulture);
                 Assert.Equal(expectedReset, exception.Reset);
+                Assert.Equal(TimeSpan.Zero, exception.GetRetryAfterTimeSpan());
             }
 
 #if !NO_SERIALIZABLE

--- a/Octokit.Tests/Http/ApiInfoParserTests.cs
+++ b/Octokit.Tests/Http/ApiInfoParserTests.cs
@@ -103,6 +103,72 @@ namespace Octokit.Tests
                 Assert.Equal(new Uri("https://api.github.com/repos/rails/rails/issues?page=131&per_page=5"),
                     apiInfo.Links["last"]);
             }
+
+            [Fact]
+            public void ParsesServerTimeDifference()
+            {
+                var serverDate = new DateTimeOffset(2020, 06, 07, 12, 00, 00, TimeSpan.Zero);
+                var receivedDate = new DateTimeOffset(2020, 06, 07, 14, 00, 00, TimeSpan.Zero);
+                var diff = serverDate - receivedDate;
+
+                var headers = new Dictionary<string, string>
+                {
+                    ["Date"] = serverDate.ToString("r"), // Format string r: RFC1123 HTTP Round-tripping time format
+                    [ApiInfoParser.ReceivedTimeHeaderName] = receivedDate.ToString("r")
+                };
+
+                var apiInfo = ApiInfoParser.ParseResponseHeaders(headers);
+
+                Assert.NotNull(apiInfo);
+                Assert.Equal(diff, apiInfo.ServerTimeDifference);
+            }
+
+            [Fact]
+            public void ParsesServerTimeDifferenceAsZeroWhenDateHeaderIsMissing()
+            {
+                var receivedDate = new DateTimeOffset(2020, 06, 07, 14, 00, 00, TimeSpan.Zero);
+                var headers = new Dictionary<string, string>
+                {
+                    // Format string r: RFC1123 HTTP Round-tripping time format
+                    [ApiInfoParser.ReceivedTimeHeaderName] = receivedDate.ToString("r")
+                };
+
+                var apiInfo = ApiInfoParser.ParseResponseHeaders(headers);
+
+                Assert.NotNull(apiInfo);
+                Assert.Equal(TimeSpan.Zero, apiInfo.ServerTimeDifference);
+            }
+
+            [Fact]
+            public void ParsesServerTimeDifferenceAsZeroWhenReceiveDateHeaderIsNonesense()
+            {
+                var headers = new Dictionary<string, string>
+                {
+                    // Format string r: RFC1123 HTTP Round-tripping time format
+                    ["Date"] = DateTimeOffset.Now.ToString("r"),
+                    [ApiInfoParser.ReceivedTimeHeaderName] = "abfhjsdkhfjkldhf"
+                };
+
+                var apiInfo = ApiInfoParser.ParseResponseHeaders(headers);
+
+                Assert.NotNull(apiInfo);
+                Assert.Equal(TimeSpan.Zero, apiInfo.ServerTimeDifference);
+            }
+
+            [Fact]
+            public void ParsesServerTimeDifferenceAsZeroWhenReceiveDateHeaderIsMissing()
+            {
+                var serverDate = new DateTimeOffset(2020, 06, 07, 12, 00, 00, TimeSpan.Zero);
+                var headers = new Dictionary<string, string>
+                {
+                    ["Date"] = serverDate.ToString("r"), // Format string r: RFC1123 HTTP Round-tripping time format
+                };
+
+                var apiInfo = ApiInfoParser.ParseResponseHeaders(headers);
+
+                Assert.NotNull(apiInfo);
+                Assert.Equal(TimeSpan.Zero, apiInfo.ServerTimeDifference);
+            }
         }
 
         public class ThePageUrlMethods

--- a/Octokit/Exceptions/RateLimitExceededException.cs
+++ b/Octokit/Exceptions/RateLimitExceededException.cs
@@ -26,7 +26,7 @@ namespace Octokit
     public class RateLimitExceededException : ForbiddenException
     {
         readonly RateLimit _rateLimit;
-        private readonly TimeSpan _severTimeDiff = TimeSpan.Zero;
+        readonly TimeSpan _severTimeDiff = TimeSpan.Zero;
 
         /// <summary>
         /// Constructs an instance of RateLimitExceededException

--- a/Octokit/Exceptions/RateLimitExceededException.cs
+++ b/Octokit/Exceptions/RateLimitExceededException.cs
@@ -26,6 +26,7 @@ namespace Octokit
     public class RateLimitExceededException : ForbiddenException
     {
         readonly RateLimit _rateLimit;
+        private readonly TimeSpan _severTimeDiff = TimeSpan.Zero;
 
         /// <summary>
         /// Constructs an instance of RateLimitExceededException
@@ -45,6 +46,8 @@ namespace Octokit
             Ensure.ArgumentNotNull(response, nameof(response));
 
             _rateLimit = response.ApiInfo.RateLimit;
+
+            _severTimeDiff = response.ApiInfo.ServerTimeDifference;
         }
 
         /// <summary>
@@ -78,6 +81,27 @@ namespace Octokit
             get { return ApiErrorMessageSafe ?? "API Rate Limit exceeded"; }
         }
 
+        /// <summary>
+        /// Calculates the time from now to wait until the next request can be
+        /// attempted.
+        /// </summary>
+        /// <returns>
+        /// A non-negative <see cref="TimeSpan"/> value. Returns
+        /// <see cref="TimeSpan.Zero"/> if the next Rate Limit window has
+        /// started and the next request can be attempted immediately.
+        /// </returns>
+        /// <remarks>
+        /// The return value is calculated using server time data from the 
+        /// response in order to provide a best-effort estimate that is 
+        /// independant from eventual inaccuracies in the client's clock.
+        /// </remarks>
+        public TimeSpan GetRetryAfterTimeSpan()
+        {
+            var skewedResetTime = Reset + _severTimeDiff;
+            var ts = skewedResetTime - DateTimeOffset.Now;
+            return ts > TimeSpan.Zero ? ts : TimeSpan.Zero;
+        }
+
 #if !NO_SERIALIZABLE
         /// <summary>
         /// Constructs an instance of RateLimitExceededException
@@ -95,6 +119,8 @@ namespace Octokit
         {
             _rateLimit = info.GetValue("RateLimit", typeof(RateLimit)) as RateLimit
                          ?? new RateLimit(new Dictionary<string, string>());
+            if (info.GetValue(nameof(ApiInfo.ServerTimeDifference), typeof(TimeSpan)) is TimeSpan serverTimeDiff)
+                _severTimeDiff = serverTimeDiff;
         }
 
         [SecurityCritical]
@@ -103,6 +129,7 @@ namespace Octokit
             base.GetObjectData(info, context);
 
             info.AddValue("RateLimit", _rateLimit);
+            info.AddValue(nameof(ApiInfo.ServerTimeDifference), _severTimeDiff);
         }
 #endif
     }

--- a/Octokit/Http/ApiInfo.cs
+++ b/Octokit/Http/ApiInfo.cs
@@ -13,7 +13,8 @@ namespace Octokit
             IList<string> oauthScopes,
             IList<string> acceptedOauthScopes,
             string etag,
-            RateLimit rateLimit)
+            RateLimit rateLimit,
+            TimeSpan serverTimeDifference = default)
         {
             Ensure.ArgumentNotNull(links, nameof(links));
             Ensure.ArgumentNotNull(oauthScopes, nameof(oauthScopes));
@@ -24,6 +25,7 @@ namespace Octokit
             AcceptedOauthScopes = new ReadOnlyCollection<string>(acceptedOauthScopes);
             Etag = etag;
             RateLimit = rateLimit;
+            ServerTimeDifference = serverTimeDifference;
         }
 
         /// <summary>
@@ -52,6 +54,17 @@ namespace Octokit
         public RateLimit RateLimit { get; private set; }
 
         /// <summary>
+        /// The best-effort time difference between the server and the client.
+        /// </summary>
+        /// <remarks>
+        /// If both the server and the client have reasonably accurate clocks,
+        /// the value of this property will be close to <see cref="TimeSpan.Zero"/>.
+        /// The actual value is sensitive to network transmission and processing 
+        /// delays.
+        /// </remarks>
+        public TimeSpan ServerTimeDifference { get; }
+
+        /// <summary>
         /// Allows you to clone ApiInfo 
         /// </summary>
         /// <returns>A clone of <seealso cref="ApiInfo"/></returns>
@@ -61,7 +74,8 @@ namespace Octokit
                                OauthScopes.Clone(),
                                AcceptedOauthScopes.Clone(),
                                Etag != null ? new string(Etag.ToCharArray()) : null,
-                               RateLimit != null ? RateLimit.Clone() : null);
+                               RateLimit != null ? RateLimit.Clone() : null,
+                               ServerTimeDifference);
         }
     }
 }

--- a/Octokit/Http/HttpClientAdapter.cs
+++ b/Octokit/Http/HttpClientAdapter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -123,10 +124,21 @@ namespace Octokit.Internal
                 }
             }
 
+            var responseHeaders = responseMessage.Headers.ToDictionary(h => h.Key, h => h.Value.First());
+
+            // Add Client response received time as a synthetic header
+            const string receivedTimeHeaderName = ApiInfoParser.ReceivedTimeHeaderName;
+            if (responseMessage.RequestMessage.Properties.TryGetValue(receivedTimeHeaderName, out object receivedTimeObj)
+                && receivedTimeObj is string receivedTimeString
+                && !responseHeaders.ContainsKey(receivedTimeHeaderName))
+            {
+                responseHeaders[receivedTimeHeaderName] = receivedTimeString;
+            }
+
             return new Response(
                 responseMessage.StatusCode,
                 responseBody,
-                responseMessage.Headers.ToDictionary(h => h.Key, h => h.Value.First()),
+                responseHeaders,
                 contentType);
         }
 
@@ -203,7 +215,13 @@ namespace Octokit.Internal
             var clonedRequest = await CloneHttpRequestMessageAsync(request).ConfigureAwait(false);
 
             // Send initial response
-            var response = await _http.SendAsync(request, HttpCompletionOption.ResponseContentRead, cancellationToken).ConfigureAwait(false);
+            var response = await _http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            // Need to determine time on client computer as soon as possible.
+            var receivedTime = DateTimeOffset.Now;
+            // Since Properties are stored as objects, serialize to HTTP round-tripping string (Format: r)
+            // Resolution is limited to one-second, matching the resolution of the HTTP Date header
+            request.Properties[ApiInfoParser.ReceivedTimeHeaderName] = 
+                receivedTime.ToString("r", CultureInfo.InvariantCulture);
 
             // Can't redirect without somewhere to redirect to.
             if (response.Headers.Location == null)

--- a/Octokit/Http/HttpClientAdapter.cs
+++ b/Octokit/Http/HttpClientAdapter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
@@ -128,7 +129,8 @@ namespace Octokit.Internal
 
             // Add Client response received time as a synthetic header
             const string receivedTimeHeaderName = ApiInfoParser.ReceivedTimeHeaderName;
-            if (responseMessage.RequestMessage.Properties.TryGetValue(receivedTimeHeaderName, out object receivedTimeObj)
+            if (responseMessage.RequestMessage?.Properties is IDictionary<string, object> reqProperties
+                && reqProperties.TryGetValue(receivedTimeHeaderName, out object receivedTimeObj)
                 && receivedTimeObj is string receivedTimeString
                 && !responseHeaders.ContainsKey(receivedTimeHeaderName))
             {


### PR DESCRIPTION
# TL;DR

* Adds new read-only property `ServerTimeDifference` of type `TimeSpan` to the `ApiInfo` class. An optional argument is added to the existing contructor.
* The `HttpClientAdapter` will inject a synthetic header named `X-Octokit-ReceivedDate` into the response headers providing an RFC1123 date-time-string specifying the time as obsoverved locally on the client when the response was received. The synthetic header name is added as a publically visible constant on the `ApiInfoParser` class.
* Adds a new instance method `GetRetryAfterTimeSpan` to `RateLimitExceededException` that allows clients to obtain the amount of time to wait until the RateLimit-Window resets.

# Description

In some scenarios it is useful to be able to calculate the appearent difference between the clock on a client computer and the clock on the server. While it is probably safe to assume that GitHub's server have a reasonable accurate clock, the same cannot be assumed for a client.

As part of the standard HTTP response headers, the GitHub API server responds with a `Date` response header that gives a best-effort estimate for the current server with a 1-second accuracy.
By storing the current time at the client as soon as possible after a response is received, these two times can be compared to calculate a reasonable estimate for the difference between the client and the server clocks.

The server time difference is useful whenever the client deals with point-in-time information provided by the server and needs to perfom calculations on that time.

An example of this is when dealing with `RateLimitExceededException`s. The exception instance as well as the `ApiInfo.RateLimit` instance for the last request both provide the time when the next Rate-Limit window starts. If a client does not have an accurate clock, it will not be able to calculate how long it needs to wait until the next rate-limit-window starts.

By exposing the server time difference in the `ApiInfo` class, clients can easily use that information in other scenarios as well.

# Details

In order to keep fluctuations of response processing as small as possible, the received time must be captured as early as possible, preferably immediately after the HTTP headers have been received.

In order to keep the changes to existing types and methods as small as possible, the information is stored as a synthetic HTTP header in the response.

If for some reason the new synthetic header value does not exist, or if the server did not repost a server time (by omitting the `Date` header), the server time difference is assumed to be 0.

If both the client and the server have reasonably accurate clocks and agree on the current time, the server time difference will be close to or exactly equal to `TimeSpan.Zero`. In such cases, the only deviations are caused by network processing and propagation delays.

# Example

For the following examples, both the server and the client are assumed to observe their local time in the UTC-timezone. All calculations use round-tripping time formats, automatically accounting for differences in time zones. Furthermore, this example assumes a network request to be instantaneous.

The current time as observed by the sever `api.github.com` is `2020-06-01T12:00:00Z`. The client currently observes the time `2020-06-01T08:00:00Z` (being 4 hours behind GitHub).

The client receives a rate-limit exceeded response GitHub states that the window will reset at `2020-06-01T13:00:00Z`.

If the client uses its own clock, it will now have to assume that it needs to wait for 5 hours until the next request can be made.
Instead the client can extract the server time from the HTTP response (the `Date` reponse header) and compare that time against its own clock. The result of the comparison will result in the time-span value `-04:00:00`. This difference can now be added to the Reset time of the exception, resulting in `2020-06-01T09:00:00Z`. Using that time, the client will correctly assume that it needs to wait 1 hour until the next requst can be made.

## Code Example

``` csharp
var client = new GitHubClient();
while (true)
{
    try
    {
        var meta = await client.Miscellaneous.GetMetadata();
        break;
    }
    catch (RateLimitExceededException rateLimitExcept)
    {
        var retryAfter = rateLimitExcept.GetRetryAfterTimeSpan();
        await Task.Delay(retryAfter);
    }
}
```