### PR TITLE
Deserialize requested_action field on check_run events.

### DIFF
--- a/Octokit.Tests/Models/CheckRunEventTests.cs
+++ b/Octokit.Tests/Models/CheckRunEventTests.cs
@@ -107,6 +107,9 @@ namespace Octokit.Tests.Models
 
     ]
   },
+  ""requested_action"": {
+    ""identifier"": ""dosomeaction""
+  },
   ""repository"": {
     ""id"": 526,
     ""node_id"": ""MDEwOlJlcG9zaXRvcnkxMzU0OTMyMzM="",
@@ -248,6 +251,7 @@ namespace Octokit.Tests.Models
             Assert.Equal(4, payload.CheckRun.Id);
             Assert.Equal(CheckStatus.Completed, payload.CheckRun.Status);
             Assert.Equal(CheckConclusion.Neutral, payload.CheckRun.Conclusion);
+            Assert.Equal("dosomeaction", payload.RequestedAction.Identifier);
             Assert.Equal(5, payload.CheckRun.CheckSuite.Id);
             Assert.Equal(CheckStatus.Completed, payload.CheckRun.CheckSuite.Status.Value);
             Assert.Equal(CheckConclusion.Neutral, payload.CheckRun.CheckSuite.Conclusion);

--- a/Octokit/Models/Response/ActivityPayloads/CheckRunEventPayload.cs
+++ b/Octokit/Models/Response/ActivityPayloads/CheckRunEventPayload.cs
@@ -7,5 +7,6 @@ namespace Octokit
     {
         public string Action { get; protected set; }
         public CheckRun CheckRun { get; protected set; }
+        public CheckRunRequestedAction RequestedAction { get; protected set; }
     }
 }

--- a/Octokit/Models/Response/CheckRunRequestedAction.cs
+++ b/Octokit/Models/Response/CheckRunRequestedAction.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace Octokit
+{
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class CheckRunRequestedAction
+    {
+        public CheckRunRequestedAction()
+        {
+        }
+
+        public CheckRunRequestedAction(string identifier)
+        {
+            Identifier = identifier;
+        }
+
+        /// <summary>
+        /// The Identifier of the check run requested action.
+        /// </summary>
+        public string Identifier { get; protected set; }
+
+        internal string DebuggerDisplay => string.Format(CultureInfo.InvariantCulture, "Identifier: {0}", Identifier);
+    }
+}


### PR DESCRIPTION
This PR closes #2195. It adds support for handling the ```requested_action``` field when present on Check Run event payloads. This field is documented in the developer docs, but wasn't exposed in Octokit for .NET:

https://developer.github.com/webhooks/event-payloads/#check_run

- [x] New type defined
- [x] Type exposed on existing check run event payload
- [x] Test JSON updated and assertion added