### PR TITLE
Fix documentation: change all master branch references to main

### DIFF
--- a/docs/demos/exploring-pull-requests.md
+++ b/docs/demos/exploring-pull-requests.md
@@ -1,8 +1,8 @@
 ### Creating new pull request from a fork
 **Scenario:**  
-Creating a pull request from a fork/branch (head) and pulling into octokit.net/master (base)  
+Creating a pull request from a fork/branch (head) and pulling into octokit.net/main (base)  
 When you are opening a PR against a repository within an organization, owner is the name of the organization
-In this scenario as we are merging to octokit/octokit.net:master, owner=octokit
+In this scenario as we are merging to octokit/octokit.net:main, owner=octokit
 
 ```csharp
 public async Task CreatePullRequestFromFork()
@@ -10,7 +10,7 @@ public async Task CreatePullRequestFromFork()
     GitHubClient ghClient = new GitHubClient(new ProductHeaderValue("MyLib", "v2.0.0"));
     ghClient.Credentials = new Credentials("apiToken");
 
-    NewPullRequest newPr = new NewPullRequest("PrTitle", "forkName:branchName", "master");
+    NewPullRequest newPr = new NewPullRequest("PrTitle", "forkName:branchName", "main");
     var octokitRepo = await ghClient.Repository.Get("octokit", "ocktokit.net");
 
     var pullRequest = await ghClient.PullRequest.Create("octokit", "octokit.net", newPr);

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,7 +28,7 @@ var tokenAuth = new Credentials("token"); // NOTE: not real token
 client.Credentials = tokenAuth;
 ```
 
-It is **strongly recommended** to use the [OAuth Flow](https://github.com/octokit/octokit.net/blob/master/docs/oauth-flow.md) for interactions on behalf of a user, as this gives two significant benefits:
+It is **strongly recommended** to use the [OAuth Flow](https://github.com/octokit/octokit.net/blob/main/docs/oauth-flow.md) for interactions on behalf of a user, as this gives two significant benefits:
 
  - the application owner never needs to store a user's password
  - the token can be revoked by the user at a later date

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # Octokit.net
 
 If you are new to Octokit, I recommend reading the
-[Getting Started](https://github.com/octokit/octokit.net/blob/master/docs/getting-started.md)
+[Getting Started](https://github.com/octokit/octokit.net/blob/main/docs/getting-started.md)
 guide, which walks through configuring the basics.
 
 When you're done with that, have a look at the topics listed under **Features** to get
@@ -13,6 +13,6 @@ There's also some advanced topics which require familiarity with the internals o
 You shouldn't need to know these well, but they're there if there comes a day when you do.
 
 If we still haven't covered a topic you're interested in,  check out the suite of 
-[integration tests](https://github.com/octokit/octokit.net/tree/master/Octokit.Tests.Integration/Clients)
+[integration tests](https://github.com/octokit/octokit.net/tree/main/Octokit.Tests.Integration/Clients)
 which can help you to get familiar with how things currently work. Then open an issue
 against the repository, so we can properly document things.

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -90,8 +90,8 @@ There's also a number of additional fields:
  - `Labels` - a collection of labels to assign to the issue
 
 Note that `Milestones` and `Labels` need to exist in the repository before
-creating the issue. Refer to the [Milestones](https://github.com/octokit/octokit.net/blob/master/docs/milestones.md)
-and [Labels](https://github.com/octokit/octokit.net/blob/master/docs/labels.md)
+creating the issue. Refer to the [Milestones](https://github.com/octokit/octokit.net/blob/main/docs/milestones.md)
+and [Labels](https://github.com/octokit/octokit.net/blob/main/docs/labels.md)
 sections for more details.
 
 ### Update


### PR DESCRIPTION
Documentation was still refering to files on the master branch