### PR TITLE
feat: add missed props for organization

### DIFF
--- a/Octokit/Models/Response/Organization.cs
+++ b/Octokit/Models/Response/Organization.cs
@@ -21,6 +21,18 @@ namespace Octokit
         /// an organization.
         /// </summary>
         public string BillingAddress { get; protected set; }
+        public string ReposUrl { get; protected set; }
+        public string EventsUrl { get; protected set; }
+        public string HooksUrl { get; protected set; }
+        public string IssuesUrl { get; protected set; }
+        public string MembersUrl { get; protected set; }
+        public string PublicMembersUrl { get; protected set; }
+        public string Description { get; protected set; }
+        public bool IsVerified { get; protected set; }
+        public bool HasOrganizationProjects { get; protected set; }
+        public bool HasRepositoryProjects { get; protected set; }
+        public DateTimeOffset UpdatedAt { get; protected set; }
+
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/Organization.cs
+++ b/Octokit/Models/Response/Organization.cs
@@ -10,10 +10,21 @@ namespace Octokit
     {
         public Organization() { }
 
-        public Organization(string avatarUrl, string bio, string blog, int collaborators, string company, DateTimeOffset createdAt, int diskUsage, string email, int followers, int following, bool? hireable, string htmlUrl, int totalPrivateRepos, int id, string nodeId, string location, string login, string name, int ownedPrivateRepos, Plan plan, int privateGists, int publicGists, int publicRepos, string url, string billingAddress)
+        public Organization(string avatarUrl, string bio, string blog, int collaborators, string company, DateTimeOffset createdAt, int diskUsage, string email, int followers, int following, bool? hireable, string htmlUrl, int totalPrivateRepos, int id, string nodeId, string location, string login, string name, int ownedPrivateRepos, Plan plan, int privateGists, int publicGists, int publicRepos, string url, string billingAddress, string reposUrl, string eventsUrl, string hooksUrl, string issuesUrl, string membersUrl, string publicMembersUrl, string description, bool isVerified, bool hasOrganizationProjects, bool hasRepositoryProjects, DateTimeOffset updatedAt)
             : base(avatarUrl, bio, blog, collaborators, company, createdAt, diskUsage, email, followers, following, hireable, htmlUrl, totalPrivateRepos, id, location, login, name, nodeId, ownedPrivateRepos, plan, privateGists, publicGists, publicRepos, AccountType.Organization, url)
         {
             BillingAddress = billingAddress;
+            ReposUrl = reposUrl;
+            EventsUrl = eventsUrl;
+            HooksUrl = hooksUrl;
+            IssuesUrl = issuesUrl;
+            MembersUrl = membersUrl;
+            PublicMembersUrl = publicMembersUrl;
+            Description = description;
+            IsVerified = isVerified;
+            HasOrganizationProjects = hasOrganizationProjects;
+            HasRepositoryProjects = hasRepositoryProjects;
+            UpdatedAt = updatedAt;
         }
 
         /// <summary>


### PR DESCRIPTION
Organizations do not have some properties from https://developer.github.com/v3/orgs/ like description. Add missed properties for correct result parsing.