### PR TITLE
Add license to repository search

### DIFF
--- a/Octokit.Tests/Models/SearchRepositoryRequestTests.cs
+++ b/Octokit.Tests/Models/SearchRepositoryRequestTests.cs
@@ -33,5 +33,13 @@ public class SearchRepositoryRequestTests
             var result = request.MergedQualifiers();
             Assert.Contains(result, x => string.Equals(x, "language:\"cpp\""));
         }
+
+        [Fact]
+        public void LicenseUsesParameterTranslation()
+        {
+            var request = new SearchRepositoriesRequest() { License = RepoSearchLicense.Apache_2_0 };
+            var result = request.MergedQualifiers();
+            Assert.Contains(result, x => string.Equals(x, "license:apache-2.0"));
+        }
     }
 }

--- a/Octokit/Models/Request/SearchRepositoriesRequest.cs
+++ b/Octokit/Models/Request/SearchRepositoriesRequest.cs
@@ -113,6 +113,12 @@ namespace Octokit
         public DateRange Updated { get; set; }
 
         /// <summary>
+        /// Filters repositoreis based on license
+        /// https://help.github.com/articles/searching-repositories#search-by-license
+        /// </summary>
+        public RepoSearchLicense? License { get; set; }
+
+        /// <summary>
         /// Filters whether archived repositories should be included (true) or not (false).
         /// </summary>
         public bool? Archived { get; set; }
@@ -169,6 +175,11 @@ namespace Octokit
             if (Archived != null)
             {
                 parameters.Add(string.Format(CultureInfo.InvariantCulture, "archived:{0}", Archived.ToString().ToLower()));
+            }
+
+            if (License != null)
+            {
+                parameters.Add(string.Format(CultureInfo.InvariantCulture, "license:{0}", License.ToParameter()));
             }
 
             return parameters;
@@ -861,6 +872,97 @@ namespace Octokit
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Yaml")]
         Yaml
 #pragma warning restore 1591
+    }
+
+    /// <summary>
+    /// Licenses than can be searched on GitHub
+    /// </summary>
+    public enum RepoSearchLicense
+    {
+        [Parameter(Value = "afl-3.0")]
+        AcademicFree_3_0,
+        [Parameter(Value = "apache-2.0")]
+        Apache_2_0,
+        [Parameter(Value = "artistic-2.0")]
+        Artistic_2_0,
+        [Parameter(Value = "bsl-1.0")]
+        BoostSoftware_1_0,
+        [Parameter(Value = "0bsd")]
+        BSD0Clause,
+        [Parameter(Value = "bsd-2-clause")]
+        BSD2Clause,
+        [Parameter(Value = "bsd-3-clause")]
+        BSD3Clause,
+        [Parameter(Value = "bsd-3-clause-clear")]
+        BSD3ClauseClear,
+        [Parameter(Value = "bsd-4-clause")]
+        BSD4Clause,
+        [Parameter(Value = "cc")]
+        CreativeCommons,
+        [Parameter(Value = "cc0-1.0")]
+        CreativeCommonsZero_1_0,
+        [Parameter(Value = "cc-by-4.0")]
+        CreativeCommonsAtrribution_4_0,
+        [Parameter(Value = "cc-by-sa-4.0")]
+        CreativeCommonsAttributionShareAlike_4_0,
+        [Parameter(Value = "cecill-2.1")]
+        CeCILL_2_1,
+        [Parameter(Value = "wtfpl")]
+        DoWhatTheFYouWant,
+        [Parameter(Value = "ecl-2.0")]
+        EducationalCommunity_2_0,
+        [Parameter(Value = "epl-1.0")]
+        EclipsePublic_1_0,
+        [Parameter(Value = "epl-2.0")]
+        EclipsePublic_2_0,
+        [Parameter(Value = "eupl-1.1")]
+        EuropeanUnionPublic_1_1,
+        [Parameter(Value = "eupl-1.2")]
+        EuropeanUnionPublic_1_2,
+        [Parameter(Value = "agpl-3.0")]
+        GNUAfferoGeneralPublic_3_0,
+        [Parameter(Value = "gpl")]
+        GNUGeneralPublic,
+        [Parameter(Value = "gpl-2.0")]
+        GNUGeneralPublic_2_0,
+        [Parameter(Value = "gpl-3.0")]
+        GNUGeneralPublic_3_0,
+        [Parameter(Value = "lgpl")]
+        GNULesserGeneralPublic,
+        [Parameter(Value = "lgpl-2.1")]
+        GNULesserGeneralPublic_2_1,
+        [Parameter(Value = "lgpl-3.0")]
+        GNULesserGeneralPublic_3_0,
+        [Parameter(Value = "isc")]
+        ISC,
+        [Parameter(Value = "lppl-1.3c")]
+        LatexProjectPublic,
+        [Parameter(Value = "ms-pl")]
+        MicrosoftPublic,
+        [Parameter(Value = "ms-rl")]
+        MicrosoftReciprocal,
+        [Parameter(Value = "mit")]
+        MIT,
+        [Parameter(Value = "mpl-2.0")]
+        MozillaPublic_2_0,
+        [Parameter(Value = "odbl-1.0")]
+        ODCOpenDatabase,
+        [Parameter(Value = "osl-3.0")]
+        OpenSoftware_3_0,
+        [Parameter(Value = "postgresql")]
+        PostgreseSQL,
+        [Parameter(Value = "ofl-1.1")]
+        SILOpenFont,
+        [Parameter(Value = "upl-1.0")]
+        UniversalPermissive,
+        [Parameter(Value = "ncsa")]
+        NSCAOpenSource,
+        [Parameter(Value = "unlicense")]
+        TheUnlicense,
+        [Parameter(Value = "vim")]
+        Vim,
+        [Parameter(Value = "zlib")]
+        ZLib
     }
 
     /// <summary>

--- a/Octokit/Models/Request/SearchRepositoriesRequest.cs
+++ b/Octokit/Models/Request/SearchRepositoriesRequest.cs
@@ -113,7 +113,7 @@ namespace Octokit
         public DateRange Updated { get; set; }
 
         /// <summary>
-        /// Filters repositoreis based on license
+        /// Filters repositories based on license
         /// https://help.github.com/articles/searching-repositories#search-by-license
         /// </summary>
         public RepoSearchLicense? License { get; set; }
@@ -512,7 +512,7 @@ namespace Octokit
     }
 
     /// <summary>
-    /// lanuages that can be searched on in github
+    /// Languages that can be searched on in GitHub
     /// https://help.github.com/articles/searching-repositories#languages
     /// </summary>
     public enum Language
@@ -876,6 +876,7 @@ namespace Octokit
 
     /// <summary>
     /// Licenses than can be searched on GitHub
+    /// https://help.github.com/articles/searching-repositories#search-by-license
     /// </summary>
     public enum RepoSearchLicense
     {


### PR DESCRIPTION
Search Repositories by license is supported by github api:
https://help.github.com/articles/searching-repositories#search-by-license

Currently only a list of licenses is supported as stated in : 
https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/licensing-a-repository#searching-github-by-license-type.

But using GitHub search I was able to find more licenses types keys.
https://github.com/search/advanced

This PR, adds all licenses found right now on GitHub.

One of the issues found while developing is that Octokit.License class does exist, while Octokit.Langues exist inside SearchRepositoriesRequest.cs and is also used on different classes I think we should move it later, for this PR I named the enum that has the licenses as : Octokit.RepoSearchLicense, the name can change, also I took the "license" word of the description of the enum, but I can put it back if needed.

Also test were added :)

