### PR TITLE
Add cancellation token support for release assets uploading

### DIFF
--- a/Octokit.Reactive/Clients/IObservableReleasesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableReleasesClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reactive;
+using System.Threading;
 
 namespace Octokit.Reactive
 {
@@ -250,8 +251,9 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="release">The <see cref="Release"/> to attach the uploaded asset to</param>
         /// <param name="data">Description of the asset with its data</param>
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<ReleaseAsset> UploadAsset(Release release, ReleaseAssetUpload data);
+        IObservable<ReleaseAsset> UploadAsset(Release release, ReleaseAssetUpload data, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets the specified <see cref="ReleaseAsset"/> for the specified release of the specified repository.

--- a/Octokit.Reactive/Clients/ObservableReleasesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableReleasesClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reactive;
 using System.Reactive.Threading.Tasks;
+using System.Threading;
 using Octokit.Reactive.Internal;
 
 namespace Octokit.Reactive
@@ -400,13 +401,14 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="release">The <see cref="Release"/> to attach the uploaded asset to</param>
         /// <param name="data">Description of the asset with its data</param>
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public IObservable<ReleaseAsset> UploadAsset(Release release, ReleaseAssetUpload data)
+        public IObservable<ReleaseAsset> UploadAsset(Release release, ReleaseAssetUpload data, CancellationToken cancellationToken = default)
         {
             Ensure.ArgumentNotNull(release, nameof(release));
             Ensure.ArgumentNotNull(data, nameof(data));
 
-            return _client.UploadAsset(release, data).ToObservable();
+            return _client.UploadAsset(release, data, cancellationToken).ToObservable();
         }
 
         /// <summary>

--- a/Octokit/Clients/IReleasesClient.cs
+++ b/Octokit/Clients/IReleasesClient.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Octokit
@@ -250,8 +251,9 @@ namespace Octokit
         /// </remarks>
         /// <param name="release">The <see cref="Release"/> to attach the uploaded asset to</param>
         /// <param name="data">Description of the asset with its data</param>
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<ReleaseAsset> UploadAsset(Release release, ReleaseAssetUpload data);
+        Task<ReleaseAsset> UploadAsset(Release release, ReleaseAssetUpload data, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets the specified <see cref="ReleaseAsset"/> for the specified release of the specified repository.

--- a/Octokit/Clients/ReleasesClient.cs
+++ b/Octokit/Clients/ReleasesClient.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace Octokit
 {
@@ -398,9 +399,10 @@ namespace Octokit
         /// </remarks>
         /// <param name="release">The <see cref="Release"/> to attach the uploaded asset to</param>
         /// <param name="data">Description of the asset with its data</param>
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         [ManualRoute("POST", "{server}/repos/{owner}/{repo}/releases/{release_id}/assets")]
-        public Task<ReleaseAsset> UploadAsset(Release release, ReleaseAssetUpload data)
+        public Task<ReleaseAsset> UploadAsset(Release release, ReleaseAssetUpload data, CancellationToken cancellationToken = default)
         {
             Ensure.ArgumentNotNull(release, nameof(release));
             Ensure.ArgumentNotNull(data, nameof(data));
@@ -414,14 +416,16 @@ namespace Octokit
                     data.RawData,
                     AcceptHeaders.StableVersion,
                     data.ContentType,
-                    data.Timeout.GetValueOrDefault());
+                    data.Timeout.GetValueOrDefault(),
+                    cancellationToken);
             }
 
             return ApiConnection.Post<ReleaseAsset>(
                 endpoint,
                 data.RawData,
                 AcceptHeaders.StableVersion,
-                data.ContentType);
+                data.ContentType,
+                cancellationToken);
         }
 
         /// <summary>

--- a/Octokit/Http/ApiConnection.cs
+++ b/Octokit/Http/ApiConnection.cs
@@ -216,13 +216,14 @@ namespace Octokit
         /// Creates a new API resource in the list at the specified URI.
         /// </summary>
         /// <param name="uri">URI endpoint to send request to</param>
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
         /// <returns><seealso cref="HttpStatusCode"/>Representing the received HTTP response</returns>
         /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
-        public Task Post(Uri uri)
+        public Task Post(Uri uri, CancellationToken cancellationToken = default)
         {
             Ensure.ArgumentNotNull(uri, nameof(uri));
 
-            return Connection.Post(uri);
+            return Connection.Post(uri, cancellationToken);
         }
 
         /// <summary>
@@ -230,13 +231,14 @@ namespace Octokit
         /// </summary>
         /// <typeparam name="T">The API resource's type.</typeparam>
         /// <param name="uri">URI of the API resource to get</param>
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
         /// <returns>The created API resource.</returns>
         /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
-        public async Task<T> Post<T>(Uri uri)
+        public async Task<T> Post<T>(Uri uri, CancellationToken cancellationToken = default)
         {
             Ensure.ArgumentNotNull(uri, nameof(uri));
 
-            var response = await Connection.Post<T>(uri).ConfigureAwait(false);
+            var response = await Connection.Post<T>(uri, cancellationToken).ConfigureAwait(false);
             return response.Body;
         }
 
@@ -246,14 +248,15 @@ namespace Octokit
         /// <typeparam name="T">The API resource's type.</typeparam>
         /// <param name="uri">URI of the API resource to get</param>
         /// <param name="data">Object that describes the new API resource; this will be serialized and used as the request's body</param>
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
         /// <returns>The created API resource.</returns>
         /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
-        public Task<T> Post<T>(Uri uri, object data)
+        public Task<T> Post<T>(Uri uri, object data, CancellationToken cancellationToken = default)
         {
             Ensure.ArgumentNotNull(uri, nameof(uri));
             Ensure.ArgumentNotNull(data, nameof(data));
 
-            return Post<T>(uri, data, null, null);
+            return Post<T>(uri, data, null, null, cancellationToken);
         }
 
         /// <summary>
@@ -263,11 +266,12 @@ namespace Octokit
         /// <param name="uri">URI of the API resource to get</param>
         /// <param name="data">Object that describes the new API resource; this will be serialized and used as the request's body</param>
         /// <param name="accepts">Accept header to use for the API request</param>
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
         /// <returns>The created API resource.</returns>
         /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
-        public Task<T> Post<T>(Uri uri, object data, string accepts)
+        public Task<T> Post<T>(Uri uri, object data, string accepts, CancellationToken cancellationToken = default)
         {
-            return Post<T>(uri, data, accepts, null);
+            return Post<T>(uri, data, accepts, null, cancellationToken);
         }
 
         /// <summary>
@@ -278,14 +282,15 @@ namespace Octokit
         /// <param name="data">Object that describes the new API resource; this will be serialized and used as the request's body</param>
         /// <param name="accepts">Accept header to use for the API request</param>
         /// <param name="contentType">Content type of the API request</param>
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
         /// <returns>The created API resource.</returns>
         /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
-        public async Task<T> Post<T>(Uri uri, object data, string accepts, string contentType)
+        public async Task<T> Post<T>(Uri uri, object data, string accepts, string contentType, CancellationToken cancellationToken = default)
         {
             Ensure.ArgumentNotNull(uri, nameof(uri));
             Ensure.ArgumentNotNull(data, nameof(data));
 
-            var response = await Connection.Post<T>(uri, data, accepts, contentType).ConfigureAwait(false);
+            var response = await Connection.Post<T>(uri, data, accepts, contentType, cancellationToken: cancellationToken).ConfigureAwait(false);
             return response.Body;
         }
 
@@ -298,25 +303,26 @@ namespace Octokit
         /// <param name="accepts">Accept header to use for the API request</param>
         /// <param name="contentType">Content type of the API request</param>
         /// <param name="twoFactorAuthenticationCode">Two Factor Authentication Code</param>
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
         /// <returns>The created API resource.</returns>
         /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
-        public async Task<T> Post<T>(Uri uri, object data, string accepts, string contentType, string twoFactorAuthenticationCode)
+        public async Task<T> Post<T>(Uri uri, object data, string accepts, string contentType, string twoFactorAuthenticationCode, CancellationToken cancellationToken = default)
         {
             Ensure.ArgumentNotNull(uri, nameof(uri));
             Ensure.ArgumentNotNull(data, nameof(data));
             Ensure.ArgumentNotNull(twoFactorAuthenticationCode, nameof(twoFactorAuthenticationCode));
 
-            var response = await Connection.Post<T>(uri, data, accepts, contentType, twoFactorAuthenticationCode).ConfigureAwait(false);
+            var response = await Connection.Post<T>(uri, data, accepts, contentType, twoFactorAuthenticationCode, cancellationToken).ConfigureAwait(false);
             return response.Body;
         }
 
 
-        public async Task<T> Post<T>(Uri uri, object data, string accepts, string contentType, TimeSpan timeout)
+        public async Task<T> Post<T>(Uri uri, object data, string accepts, string contentType, TimeSpan timeout, CancellationToken cancellationToken = default)
         {
             Ensure.ArgumentNotNull(uri, nameof(uri));
             Ensure.ArgumentNotNull(data, nameof(data));
 
-            var response = await Connection.Post<T>(uri, data, accepts, contentType, timeout).ConfigureAwait(false);
+            var response = await Connection.Post<T>(uri, data, accepts, contentType, timeout, cancellationToken).ConfigureAwait(false);
             return response.Body;
         }
 

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -251,44 +251,51 @@ namespace Octokit
         /// Performs an asynchronous HTTP POST request.
         /// </summary>
         /// <param name="uri">URI endpoint to send request to</param>
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
         /// <returns><seealso cref="IResponse"/> representing the received HTTP response</returns>
-        public async Task<HttpStatusCode> Post(Uri uri)
+        public async Task<HttpStatusCode> Post(Uri uri, CancellationToken cancellationToken = default)
         {
             Ensure.ArgumentNotNull(uri, nameof(uri));
 
-            var response = await SendData<object>(uri, HttpMethod.Post, null, null, null, CancellationToken.None).ConfigureAwait(false);
+            var response = await SendData<object>(uri, HttpMethod.Post, null, null, null, cancellationToken).ConfigureAwait(false);
             return response.HttpResponse.StatusCode;
         }
 
-        public async Task<HttpStatusCode> Post(Uri uri, object body, string accepts)
+        public async Task<HttpStatusCode> Post(Uri uri, object body, string accepts, CancellationToken cancellationToken = default)
         {
             Ensure.ArgumentNotNull(uri, nameof(uri));
 
-            var response = await SendData<object>(uri, HttpMethod.Post, body, accepts, null, CancellationToken.None).ConfigureAwait(false);
+            var response = await SendData<object>(uri, HttpMethod.Post, body, accepts, null, cancellationToken).ConfigureAwait(false);
             return response.HttpResponse.StatusCode;
         }
 
-        public Task<IApiResponse<T>> Post<T>(Uri uri)
+        public Task<IApiResponse<T>> Post<T>(Uri uri, CancellationToken cancellationToken = default)
         {
             Ensure.ArgumentNotNull(uri, nameof(uri));
 
-            return SendData<T>(uri, HttpMethod.Post, null, null, null, CancellationToken.None);
+            return SendData<T>(uri, HttpMethod.Post, null, null, null, cancellationToken);
         }
 
-        public Task<IApiResponse<T>> Post<T>(Uri uri, object body, string accepts, string contentType)
+        public Task<IApiResponse<T>> Post<T>(Uri uri, object body, string accepts, string contentType, CancellationToken cancellationToken = default)
         {
             Ensure.ArgumentNotNull(uri, nameof(uri));
             Ensure.ArgumentNotNull(body, nameof(body));
 
-            return SendData<T>(uri, HttpMethod.Post, body, accepts, contentType, CancellationToken.None);
+            return SendData<T>(uri, HttpMethod.Post, body, accepts, contentType, cancellationToken);
         }
 
-        public Task<IApiResponse<T>> Post<T>(Uri uri, object body, string accepts, string contentType, IDictionary<string, string> parameters)
+        public Task<IApiResponse<T>> Post<T>(
+            Uri uri,
+            object body,
+            string accepts,
+            string contentType,
+            IDictionary<string, string> parameters,
+            CancellationToken cancellationToken = default)
         {
             Ensure.ArgumentNotNull(uri, nameof(uri));
             Ensure.ArgumentNotNull(body, nameof(body));
 
-            return SendData<T>(uri.ApplyParameters(parameters), HttpMethod.Post, body, accepts, contentType, CancellationToken.None);
+            return SendData<T>(uri.ApplyParameters(parameters), HttpMethod.Post, body, accepts, contentType, cancellationToken);
         }
 
         /// <summary>
@@ -301,30 +308,37 @@ namespace Octokit
         /// <param name="accepts">Specifies accepted response media types.</param>
         /// <param name="contentType">Specifies the media type of the request body</param>
         /// <param name="twoFactorAuthenticationCode">Two Factor Authentication Code</param>
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
         /// <returns><seealso cref="IResponse"/> representing the received HTTP response</returns>
-        public Task<IApiResponse<T>> Post<T>(Uri uri, object body, string accepts, string contentType, string twoFactorAuthenticationCode)
+        public Task<IApiResponse<T>> Post<T>(
+            Uri uri,
+            object body,
+            string accepts,
+            string contentType,
+            string twoFactorAuthenticationCode,
+            CancellationToken cancellationToken = default)
         {
             Ensure.ArgumentNotNull(uri, nameof(uri));
             Ensure.ArgumentNotNull(body, nameof(body));
             Ensure.ArgumentNotNullOrEmptyString(twoFactorAuthenticationCode, nameof(twoFactorAuthenticationCode));
 
-            return SendData<T>(uri, HttpMethod.Post, body, accepts, contentType, CancellationToken.None, twoFactorAuthenticationCode);
+            return SendData<T>(uri, HttpMethod.Post, body, accepts, contentType, cancellationToken, twoFactorAuthenticationCode);
         }
 
-        public Task<IApiResponse<T>> Post<T>(Uri uri, object body, string accepts, string contentType, TimeSpan timeout)
+        public Task<IApiResponse<T>> Post<T>(Uri uri, object body, string accepts, string contentType, TimeSpan timeout, CancellationToken cancellationToken = default)
         {
             Ensure.ArgumentNotNull(uri, nameof(uri));
             Ensure.ArgumentNotNull(body, nameof(body));
 
-            return SendData<T>(uri, HttpMethod.Post, body, accepts, contentType, timeout, CancellationToken.None);
+            return SendData<T>(uri, HttpMethod.Post, body, accepts, contentType, timeout, cancellationToken);
         }
 
-        public Task<IApiResponse<T>> Post<T>(Uri uri, object body, string accepts, string contentType, Uri baseAddress)
+        public Task<IApiResponse<T>> Post<T>(Uri uri, object body, string accepts, string contentType, Uri baseAddress, CancellationToken cancellationToken = default)
         {
             Ensure.ArgumentNotNull(uri, nameof(uri));
             Ensure.ArgumentNotNull(body, nameof(body));
 
-            return SendData<T>(uri, HttpMethod.Post, body, accepts, contentType, CancellationToken.None, baseAddress: baseAddress);
+            return SendData<T>(uri, HttpMethod.Post, body, accepts, contentType, cancellationToken, baseAddress: baseAddress);
         }
 
         public Task<IApiResponse<T>> Put<T>(Uri uri, object body)

--- a/Octokit/Http/IApiConnection.cs
+++ b/Octokit/Http/IApiConnection.cs
@@ -148,18 +148,20 @@ namespace Octokit
         /// Creates a new API resource in the list at the specified URI.
         /// </summary>
         /// <param name="uri">URI endpoint to send request to</param>
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
         /// <returns><seealso cref="HttpStatusCode"/>Representing the received HTTP response</returns>
         /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
-        Task Post(Uri uri);
+        Task Post(Uri uri, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Creates a new API resource in the list at the specified URI.
         /// </summary>
         /// <typeparam name="T">The API resource's type.</typeparam>
         /// <param name="uri">URI endpoint to send request to</param>
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
         /// <returns>The created API resource.</returns>
         /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
-        Task<T> Post<T>(Uri uri);
+        Task<T> Post<T>(Uri uri, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Creates a new API resource in the list at the specified URI.
@@ -167,9 +169,10 @@ namespace Octokit
         /// <typeparam name="T">The API resource's type.</typeparam>
         /// <param name="uri">URI of the API resource to get</param>
         /// <param name="data">Object that describes the new API resource; this will be serialized and used as the request's body</param>
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
         /// <returns>The created API resource.</returns>
         /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
-        Task<T> Post<T>(Uri uri, object data);
+        Task<T> Post<T>(Uri uri, object data, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Creates a new API resource in the list at the specified URI.
@@ -178,9 +181,10 @@ namespace Octokit
         /// <param name="uri">URI of the API resource to get</param>
         /// <param name="data">Object that describes the new API resource; this will be serialized and used as the request's body</param>
         /// <param name="accepts">Accept header to use for the API request</param>
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
         /// <returns>The created API resource.</returns>
         /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
-        Task<T> Post<T>(Uri uri, object data, string accepts);
+        Task<T> Post<T>(Uri uri, object data, string accepts, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Creates a new API resource in the list at the specified URI.
@@ -190,9 +194,10 @@ namespace Octokit
         /// <param name="data">Object that describes the new API resource; this will be serialized and used as the request's body</param>
         /// <param name="accepts">Accept header to use for the API request</param>
         /// <param name="contentType">Content type of the API request</param>
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
         /// <returns>The created API resource.</returns>
         /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
-        Task<T> Post<T>(Uri uri, object data, string accepts, string contentType);
+        Task<T> Post<T>(Uri uri, object data, string accepts, string contentType, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Creates a new API resource in the list at the specified URI.
@@ -203,9 +208,10 @@ namespace Octokit
         /// <param name="accepts">Accept header to use for the API request</param>
         /// <param name="contentType">Content type of the API request</param>
         /// <param name="twoFactorAuthenticationCode">Two Factor Authentication Code</param>
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
         /// <returns>The created API resource.</returns>
         /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
-        Task<T> Post<T>(Uri uri, object data, string accepts, string contentType, string twoFactorAuthenticationCode);
+        Task<T> Post<T>(Uri uri, object data, string accepts, string contentType, string twoFactorAuthenticationCode, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Creates a new API resource in the list at the specified URI.
@@ -216,9 +222,10 @@ namespace Octokit
         /// <param name="accepts">Accept header to use for the API request</param>
         /// <param name="contentType">Content type of the API request</param>
         /// <param name="timeout">Timeout for the request</param>
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
         /// <returns>The created API resource.</returns>
         /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
-        Task<T> Post<T>(Uri uri, object data, string accepts, string contentType, TimeSpan timeout);
+        Task<T> Post<T>(Uri uri, object data, string accepts, string contentType, TimeSpan timeout, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Creates or replaces the API resource at the specified URI

--- a/Octokit/Http/IConnection.cs
+++ b/Octokit/Http/IConnection.cs
@@ -105,8 +105,9 @@ namespace Octokit
         /// Performs an asynchronous HTTP POST request.
         /// </summary>
         /// <param name="uri">URI endpoint to send request to</param>
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
         /// <returns>The returned <seealso cref="HttpStatusCode"/></returns>
-        Task<HttpStatusCode> Post(Uri uri);
+        Task<HttpStatusCode> Post(Uri uri, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Performs an asynchronous HTTP POST request.
@@ -114,8 +115,9 @@ namespace Octokit
         /// <param name="uri">URI endpoint to send request to</param>
         /// <param name="body">The object to serialize as the body of the request</param>
         /// <param name="accepts">Specifies accepted response media types.</param>
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
         /// <returns>The returned <seealso cref="HttpStatusCode"/></returns>
-        Task<HttpStatusCode> Post(Uri uri, object body, string accepts);
+        Task<HttpStatusCode> Post(Uri uri, object body, string accepts, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Performs an asynchronous HTTP POST request.
@@ -123,8 +125,9 @@ namespace Octokit
         /// </summary>
         /// <typeparam name="T">The type to map the response to</typeparam>
         /// <param name="uri">URI endpoint to send request to</param>
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
         /// <returns><seealso cref="IResponse"/> representing the received HTTP response</returns>
-        Task<IApiResponse<T>> Post<T>(Uri uri);
+        Task<IApiResponse<T>> Post<T>(Uri uri, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Performs an asynchronous HTTP POST request.
@@ -136,8 +139,15 @@ namespace Octokit
         /// <param name="accepts">Specifies accepted response media types.</param>
         /// <param name="contentType">Specifies the media type of the request body</param>
         /// <param name="parameters">Extra parameters for authentication.</param>
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
         /// <returns><seealso cref="IResponse"/> representing the received HTTP response</returns>
-        Task<IApiResponse<T>> Post<T>(Uri uri, object body, string accepts, string contentType, IDictionary<string, string> parameters = null);
+        Task<IApiResponse<T>> Post<T>(
+            Uri uri,
+            object body,
+            string accepts,
+            string contentType,
+            IDictionary<string, string> parameters = null,
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Performs an asynchronous HTTP POST request.
@@ -149,8 +159,9 @@ namespace Octokit
         /// <param name="accepts">Specifies accepted response media types.</param>
         /// <param name="contentType">Specifies the media type of the request body</param>
         /// <param name="twoFactorAuthenticationCode">Two Factor Authentication Code</param>
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
         /// <returns><seealso cref="IResponse"/> representing the received HTTP response</returns>
-        Task<IApiResponse<T>> Post<T>(Uri uri, object body, string accepts, string contentType, string twoFactorAuthenticationCode);
+        Task<IApiResponse<T>> Post<T>(Uri uri, object body, string accepts, string contentType, string twoFactorAuthenticationCode, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Performs an asynchronous HTTP POST request.
@@ -162,8 +173,9 @@ namespace Octokit
         /// <param name="accepts">Specifies accepted response media types.</param>
         /// <param name="contentType">Specifies the media type of the request body</param>
         /// <param name="timeout"></param>
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
         /// <returns><seealso cref="IResponse"/> representing the received HTTP response</returns>
-        Task<IApiResponse<T>> Post<T>(Uri uri, object body, string accepts, string contentType, TimeSpan timeout);
+        Task<IApiResponse<T>> Post<T>(Uri uri, object body, string accepts, string contentType, TimeSpan timeout, CancellationToken cancellationToken = default);
 
 
         /// <summary>
@@ -180,8 +192,9 @@ namespace Octokit
         /// <param name="accepts">Specifies accepted response media types.</param>
         /// <param name="contentType">Specifies the media type of the request body</param>
         /// <param name="baseAddress">Allows overriding the base address for a post.</param>
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
         /// <returns><seealso cref="IResponse"/> representing the received HTTP response</returns>
-        Task<IApiResponse<T>> Post<T>(Uri uri, object body, string accepts, string contentType, Uri baseAddress);
+        Task<IApiResponse<T>> Post<T>(Uri uri, object body, string accepts, string contentType, Uri baseAddress, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Performs an asynchronous HTTP PUT request.


### PR DESCRIPTION
Small spike for #1840 

Added an optional cancellation token to `IReleasesClient.UploadAsset(...)`.

To make it easier to continue this work, I did the same for all the `Post` methods in `IApiConnection` and `IConnection` as well.