### PR TITLE
[Ready for review] Add DeleteBranchOnMerge option for repositories

### DIFF
--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -219,6 +219,21 @@ public class RepositoriesClientTests
             }
         }
 
+        [IntegrationTest]
+        public async Task CreatesARepositoryWithDeleteBranchOnMergeEnabled()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var repoName = Helper.MakeNameWithTimestamp("repo-with-delete-branch-on-merge");
+
+            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName) { DeleteBranchOnMerge = true }))
+            {
+                var createdRepository = context.Repository;
+
+                Assert.True(createdRepository.DeleteBranchOnMerge);
+                var repository = await github.Repository.Get(Helper.UserName, repoName);
+                Assert.True(repository.DeleteBranchOnMerge);
+            }
+        }
 
         [IntegrationTest]
         public async Task ThrowsInvalidGitIgnoreExceptionForInvalidTemplateNames()
@@ -612,6 +627,46 @@ public class RepositoriesClientTests
                 Assert.False(repository.AllowRebaseMerge);
             }
         }
+        
+        [IntegrationTest]
+        public async Task UpdatesDeleteBranchOnMergeMethod()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            using (var context = await github.CreateRepositoryContext("public-repo"))
+            {
+                var updateRepository = new RepositoryUpdate(context.RepositoryName)
+                {
+                    DeleteBranchOnMerge = true
+                };
+
+                var editedRepository = await github.Repository.Edit(context.RepositoryOwner, context.RepositoryName, updateRepository);
+                Assert.True(editedRepository.DeleteBranchOnMerge);
+
+                var repository = await github.Repository.Get(context.RepositoryOwner, context.RepositoryName);
+                Assert.True(repository.DeleteBranchOnMerge);
+            }
+        }
+        
+        [IntegrationTest]
+        public async Task UpdatesDeleteBranchOnMergeMethodWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            using (var context = await github.CreateRepositoryContext("public-repo"))
+            {
+                var updateRepository = new RepositoryUpdate(context.RepositoryName)
+                {
+                    DeleteBranchOnMerge = true
+                };
+
+                var editedRepository = await github.Repository.Edit(context.RepositoryId, updateRepository);
+                Assert.True(editedRepository.DeleteBranchOnMerge);
+
+                var repository = await github.Repository.Get(context.RepositoryId);
+                Assert.True(repository.DeleteBranchOnMerge);
+            }
+        }
 
         public void Dispose()
         {
@@ -789,6 +844,32 @@ public class RepositoriesClientTests
             Assert.NotNull(repository.License);
             Assert.Equal("mit", repository.License.Key);
             Assert.Equal("MIT License", repository.License.Name);
+        }
+        
+        [IntegrationTest]
+        public async Task ReturnsRepositoryDeleteBranchOnMergeOptions()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            using (var context = await github.CreateRepositoryContext(Helper.MakeNameWithTimestamp("public-repo")))
+            {
+                var repository = await github.Repository.Get(context.RepositoryOwner, context.RepositoryName);
+
+                Assert.NotNull(repository.DeleteBranchOnMerge);
+            }
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsRepositoryDeleteBranchOnMergeOptionsWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            using (var context = await github.CreateRepositoryContext(Helper.MakeNameWithTimestamp("public-repo")))
+            {
+                var repository = await github.Repository.Get(context.RepositoryId);
+
+                Assert.NotNull(repository.DeleteBranchOnMerge);
+            }
         }
     }
 

--- a/Octokit/Models/Request/NewRepository.cs
+++ b/Octokit/Models/Request/NewRepository.cs
@@ -81,6 +81,8 @@ namespace Octokit
         /// Optional. Gets or sets the Id of the team to grant access to this repository. This is only valid when creating a repository for an organization.
         /// </summary>
         public int? TeamId { get; set; }
+        
+        public bool? DeleteBranchOnMerge { get; set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Request/RepositoryUpdate.cs
+++ b/Octokit/Models/Request/RepositoryUpdate.cs
@@ -77,6 +77,8 @@ namespace Octokit
         /// Optional. Allows the "Create a merge commit" merge method to be used.
         /// </summary>
         public bool? AllowMergeCommit { get; set; }
+        
+        public bool? DeleteBranchOnMerge { get; set; }
 
         /// <summary>
         /// Optional. True to archive this repository.  Note: you cannot unarchive repositories through the API.

--- a/Octokit/Models/Response/Repository.cs
+++ b/Octokit/Models/Response/Repository.cs
@@ -14,7 +14,7 @@ namespace Octokit
             Id = id;
         }
 
-        public Repository(string url, string htmlUrl, string cloneUrl, string gitUrl, string sshUrl, string svnUrl, string mirrorUrl, long id, string nodeId, User owner, string name, string fullName, bool isTemplate, string description, string homepage, string language, bool @private, bool fork, int forksCount, int stargazersCount, string defaultBranch, int openIssuesCount, DateTimeOffset? pushedAt, DateTimeOffset createdAt, DateTimeOffset updatedAt, RepositoryPermissions permissions, Repository parent, Repository source, LicenseMetadata license, bool hasIssues, bool hasWiki, bool hasDownloads, bool hasPages, int subscribersCount, long size, bool? allowRebaseMerge, bool? allowSquashMerge, bool? allowMergeCommit, bool archived, int watchersCount)
+        public Repository(string url, string htmlUrl, string cloneUrl, string gitUrl, string sshUrl, string svnUrl, string mirrorUrl, long id, string nodeId, User owner, string name, string fullName, bool isTemplate, string description, string homepage, string language, bool @private, bool fork, int forksCount, int stargazersCount, string defaultBranch, int openIssuesCount, DateTimeOffset? pushedAt, DateTimeOffset createdAt, DateTimeOffset updatedAt, RepositoryPermissions permissions, Repository parent, Repository source, LicenseMetadata license, bool hasIssues, bool hasWiki, bool hasDownloads, bool hasPages, int subscribersCount, long size, bool? allowRebaseMerge, bool? allowSquashMerge, bool? allowMergeCommit, bool archived, int watchersCount, bool? deleteBranchOnMerge)
         {
             Url = url;
             HtmlUrl = htmlUrl;
@@ -56,6 +56,7 @@ namespace Octokit
             AllowMergeCommit = allowMergeCommit;
             Archived = archived;
             WatchersCount = watchersCount;
+            DeleteBranchOnMerge = deleteBranchOnMerge;
         }
 
         public string Url { get; protected set; }
@@ -141,6 +142,8 @@ namespace Octokit
         public long Size { get; protected set; }
 
         public bool Archived { get; protected set; }
+
+        public bool? DeleteBranchOnMerge { get; protected set; }
 
         internal string DebuggerDisplay
         {


### PR DESCRIPTION
Hello, hopefully this is a simple change, I just wanted to add the `DeleteBranchOnMerge`option when creating or updating repositories. This is supported by the [Github v3 API](https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#create-an-organization-repository). 

I couldn't find any open issues for it to link to (should I create one?). 

I've added all the tests I think I need to, but I haven't run the integration tests (I assume you have some CI setup to run these but if not let me know and I'll go through the pain of setting them up).

This is my first time contributing so please tell me if I've done anything incorrectly. I did read the contributions guide but I didn't see the point in adding a checklist as this is such a simple change. 