### PR TITLE
Update 'up-for-grabs' link in CONSTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ to ensure everything builds and the tests pass.
 
 ## How can I get involved?
 
-We have an [`up-for-grabs`](https://github.com/octokit/octokit.net/issues/labels/up-for-grabs)
+We have an [`up-for-grabs`](https://github.com/octokit/octokit.net/labels/up-for-grabs)
 tag on our issue tracker to indicate tasks which contributors can pick up.
 
 If you've found something you'd like to contribute to, leave a comment in the issue


### PR DESCRIPTION
The previous link redirected to https://github.com/octokit/octokit.net/issues?q=label%3Aup-for-grabs, which would also show closed issues; the new link only shows open issues.