### PR TITLE
allow request run overrides

### DIFF
--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -658,6 +658,11 @@ namespace Octokit
         {
             request.Headers.Add("User-Agent", UserAgent);
             await _authenticator.Apply(request).ConfigureAwait(false);
+            return await Run(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        protected virtual async Task<IResponse> Run(IRequest request, CancellationToken cancellationToken)
+        {
             var response = await _httpClient.Send(request, cancellationToken).ConfigureAwait(false);
             if (response != null)
             {


### PR DESCRIPTION
I've no idea if this idea will be entertained, but it's a conversation starter at least. 🙂 

I've seen a few requests to add wrappers around the rate limits and abuse detection, etc. to prevent the client throwing exceptions and, understandably, those requests have been denied, since the best policy for retries, etc. may vary wildly depending on the use case.

However, if the method that sends the request and throws the exceptions is overridable, then I can do things like this:

```C#
protected override async Task<IResponse> Run(IRequest request, CancellationToken cancellationToken)
{
    try
    {
        return await base.Run(request, cancellationToken);
    }
    catch (RateLimitExceededException ex)
    {
        // apply my policy here
    }
    catch (AbuseException ex)
    {
        // apply my policy here
    }
}
```