### PR TITLE
(build) Updated Cake Frosting to version 1.0.0

### DIFF
--- a/.github/workflows/netcore.yml
+++ b/.github/workflows/netcore.yml
@@ -20,9 +20,8 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1.4.0
-      with:
-        dotnet-version: 3.1.201
+      uses: actions/setup-dotnet@v1
+
     - name: Build with dotnet
       run: ./build.sh --linksources=true --verbosity=verbose
       shell: bash

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,6 @@ init:
 
 build_script:
   - dotnet --info
-  - dotnet tool install --global coverlet.console
   - ps: .\build.ps1 -LinkSources -Verbosity Verbose
 
 test: off

--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -3,11 +3,12 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RunWorkingDirectory>$(MSBuildProjectDirectory)/..</RunWorkingDirectory>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Cake.Coverlet" Version="2.5.1" />
-    <PackageReference Include="Cake.Frosting" Version="0.38.5" />
+    <PackageReference Include="Cake.Frosting" Version="1.0.0" />
     <PackageReference Include="Cake.Codecov" Version="0.9.1" />
     <PackageReference Include="Codecov" Version="1.12.3" />
   </ItemGroup>

--- a/build/Lifetime.cs
+++ b/build/Lifetime.cs
@@ -4,6 +4,7 @@ using Cake.Common.Build;
 using Cake.Common.Diagnostics;
 using Cake.Frosting;
 using Cake.Core.Diagnostics;
+using Cake.Core;
 
 public class Lifetime : FrostingLifetime<Context>
 {
@@ -81,5 +82,9 @@ public class Lifetime : FrostingLifetime<Context>
             arg = context.Argument<string>(argumentName, null);
         }
         return arg;
+    }
+
+    public override void Teardown(Context context, ITeardownContext info)
+    {
     }
 }

--- a/build/Lifetime.cs
+++ b/build/Lifetime.cs
@@ -52,7 +52,7 @@ public class Lifetime : FrostingLifetime<Context>
             new Project { Name = "Octokit.Tests.Integration", Path = "./Octokit.Tests.Integration/Octokit.Tests.Integration.csproj", IntegrationTests = true }
         };
 
-        context.GitVersionToolPath = ToolInstaller.DotNetCoreToolInstall(context, "GitVersion.Tool", "5.1.3", "dotnet-gitversion");
+        context.GitVersionToolPath = ToolInstaller.DotNetCoreToolInstall(context, "GitVersion.Tool", "5.6.5", "dotnet-gitversion");
         ToolInstaller.DotNetCoreToolInstall(context, "coverlet.console", "1.7.2", "coverlet");
 
         // Calculate semantic version.

--- a/build/Lifetime.cs
+++ b/build/Lifetime.cs
@@ -53,6 +53,7 @@ public class Lifetime : FrostingLifetime<Context>
         };
 
         context.GitVersionToolPath = ToolInstaller.DotNetCoreToolInstall(context, "GitVersion.Tool", "5.1.3", "dotnet-gitversion");
+        ToolInstaller.DotNetCoreToolInstall(context, "coverlet.console", "1.7.2", "coverlet");
 
         // Calculate semantic version.
         context.Version = BuildVersion.Calculate(context);

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -1,24 +1,13 @@
-using Cake.Core;
 using Cake.Frosting;
 
-public class Program : IFrostingStartup
+public class Program
 {
     public static int Main(string[] args)
     {
-        // Create the host.
-        var host = new CakeHostBuilder()
-            .WithArguments(args)
-            .UseStartup<Program>()
-            .Build();
-
-        // Run the host.
-        return host.Run();
-    }
-
-    public void Configure(ICakeServices services)
-    {
-        services.UseContext<Context>();
-        services.UseLifetime<Lifetime>();
-        services.UseWorkingDirectory("..");
+        return new CakeHost()
+            .UseContext<Context>()
+            .UseLifetime<Lifetime>()
+            .Run(args);
+;
     }
 }


### PR DESCRIPTION
This PR updates Cake Frosting to 1.0 and addresses breaking changes introduced with that release.

**Additional**
* Pinned coverlet version as latest not compact with 3.1
* Updated GitVersion as previous not compatible with GitHub actions
* Updated GitHub actions setup .NET to supported version