### PR TITLE
Change Payload to a Dictionary<string, string>

### DIFF
--- a/Octokit.Tests/Models/DeploymentTests.cs
+++ b/Octokit.Tests/Models/DeploymentTests.cs
@@ -9,6 +9,18 @@ namespace Octokit.Tests.Models
     public class DeploymentTests
     {
         [Fact]
+        public void CanSerialize()
+        {
+            var deployment = new NewDeployment("ref")
+            {
+                Payload = new Dictionary<string, string> {{"environment", "production"}}
+            };
+            var deserialized = new SimpleJsonSerializer().Serialize(deployment);
+            
+            Assert.Equal(@"{""ref"":""ref"",""task"":""deploy"",""payload"":{""environment"":""production""}}", deserialized);
+        }
+
+        [Fact]
         public void CanDeserialize()
         {
             const string json = @"{

--- a/Octokit/Models/Request/NewDeployment.cs
+++ b/Octokit/Models/Request/NewDeployment.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -59,7 +60,7 @@ namespace Octokit
         /// <summary>
         /// JSON payload with extra information about the deployment.
         /// </summary>
-        public string Payload { get; set; }
+        public Dictionary<string, string> Payload { get; set; }
 
         /// <summary>
         /// Optional name for the target deployment environment (e.g., production, staging, qa). Default: "production"


### PR DESCRIPTION
When serializing the `NewDeployment` type, the `Payload` is serialized as an escaped string because JSON.NET doesn't know it's meant to be JSON.

This causes a problem when you call the API because the Payload is supposed to be a JSON dictionary that's just part of the overall payload. It's not supposed to be an escaped string.

That's why the JSON deserializer fails on it. Not only that, any deployments created using the current Octokit.net will create an invalid payload.

This PR fixes it by changing the type of `Payload` to a dictionary. THIS IS A BREAKING CHANGE, but the old behavior was broken so it forces a new correct behavior.

Fixes #2250