### PR TITLE
Move the build to .net 5

### DIFF
--- a/.github/workflows/netcore.yml
+++ b/.github/workflows/netcore.yml
@@ -21,7 +21,8 @@ jobs:
     - uses: actions/checkout@v1
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
-
+      with:
+        dotnet-version: 5.0.*
     - name: Build with dotnet
       run: ./build.sh --linksources=true --verbosity=verbose
       shell: bash

--- a/.github/workflows/netcore.yml
+++ b/.github/workflows/netcore.yml
@@ -19,10 +19,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Setup .NET Core
+    - name: Setup .NET 5
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 5.0.*
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.*
     - name: Build with dotnet
       run: ./build.sh --linksources=true --verbosity=verbose
       shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1.4.0
+      uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.201
+        dotnet-version: 5.0.*
 
     - name: Build with dotnet
       run: ./build.sh --linksources=true --verbosity=verbose

--- a/global.json
+++ b/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "3.1.200",
-    "rollForward": "latestMinor"
-  }
-}


### PR DESCRIPTION
.NET 5 is fine for building projects that target older versions of .NET. This also should fix the AppVeyor build which fails because the latest `coverlet.console` only supports .NET 5.