### PR TITLE
Adding support for the Device Flow Oauth authentication pattern

### DIFF
--- a/Octokit.Reactive/Clients/IObservableOauthClient.cs
+++ b/Octokit.Reactive/Clients/IObservableOauthClient.cs
@@ -24,5 +24,27 @@ namespace Octokit.Reactive
         /// <param name="request"></param>
         /// <returns></returns>
         IObservable<OauthToken> CreateAccessToken(OauthTokenRequest request);
+
+        /// <summary>
+        /// Makes a request to initiate the device flow authentication.
+        /// </summary>
+        /// <remarks>
+        /// Returns a user verification code and verification URL that the you will use to prompt the user to authenticate.
+        /// This request also returns a device verification code that you must use to receive an access token to check the status of user authentication.
+        /// </remarks>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        IObservable<OauthDeviceFlowResponse> InitiateDeviceFlow(OauthDeviceFlowRequest request);
+
+        /// <summary>
+        /// Makes a request to get an access token using the response from <see cref="InitiateDeviceFlow(OauthDeviceFlowRequest)"/>.
+        /// </summary>
+        /// <remarks>
+        /// Will poll the access token endpoint, until the device and user codes expire or the user has successfully authorized the app with a valid user code.
+        /// </remarks>
+        /// <param name="clientId">The client Id you received from GitHub when you registered the application.</param>
+        /// <param name="deviceFlowResponse">The response you received from <see cref="InitiateDeviceFlow(OauthDeviceFlowRequest)"/></param>
+        /// <returns></returns>
+        IObservable<OauthToken> CreateAccessTokenForDeviceFlow(string clientId, OauthDeviceFlowResponse deviceFlowResponse);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableOauthClient.cs
+++ b/Octokit.Reactive/Clients/ObservableOauthClient.cs
@@ -40,5 +40,33 @@ namespace Octokit.Reactive
         {
             return _client.Oauth.CreateAccessToken(request).ToObservable();
         }
+
+        /// <summary>
+        /// Makes a request to initiate the device flow authentication.
+        /// </summary>
+        /// <remarks>
+        /// Returns a user verification code and verification URL that the you will use to prompt the user to authenticate.
+        /// This request also returns a device verification code that you must use to receive an access token to check the status of user authentication.
+        /// </remarks>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        public IObservable<OauthDeviceFlowResponse> InitiateDeviceFlow(OauthDeviceFlowRequest request)
+        {
+            return _client.Oauth.InitiateDeviceFlow(request).ToObservable();
+        }
+
+        /// <summary>
+        /// Makes a request to get an access token using the response from <see cref="InitiateDeviceFlow(OauthDeviceFlowRequest)"/>.
+        /// </summary>
+        /// <remarks>
+        /// Will poll the access token endpoint, until the device and user codes expire or the user has successfully authorized the app with a valid user code.
+        /// </remarks>
+        /// <param name="clientId">The client Id you received from GitHub when you registered the application.</param>
+        /// <param name="deviceFlowResponse">The response you received from <see cref="InitiateDeviceFlow(OauthDeviceFlowRequest)"/></param>
+        /// <returns></returns>
+        public IObservable<OauthToken> CreateAccessTokenForDeviceFlow(string clientId, OauthDeviceFlowResponse deviceFlowResponse)
+        {
+            return _client.Oauth.CreateAccessTokenForDeviceFlow(clientId, deviceFlowResponse).ToObservable();
+        }
     }
 }

--- a/Octokit.Tests/Clients/OauthClientTests.cs
+++ b/Octokit.Tests/Clients/OauthClientTests.cs
@@ -65,7 +65,7 @@ public class OauthClientTests
         [Fact]
         public async Task PostsWithCorrectBodyAndContentType()
         {
-            var responseToken = new OauthToken(null, null, null);
+            var responseToken = new OauthToken(null, null, null, null, null, null);
             var response = Substitute.For<IApiResponse<OauthToken>>();
             response.Body.Returns(responseToken);
             var connection = Substitute.For<IConnection>();
@@ -99,7 +99,7 @@ public class OauthClientTests
         [Fact]
         public async Task PostsWithCorrectBodyAndContentTypeForGHE()
         {
-            var responseToken = new OauthToken(null, null, null);
+            var responseToken = new OauthToken(null, null, null, null, null, null);
             var response = Substitute.For<IApiResponse<OauthToken>>();
             response.Body.Returns(responseToken);
             var connection = Substitute.For<IConnection>();
@@ -164,7 +164,7 @@ public class OauthClientTests
         [Fact]
         public async Task CreateAccessTokenForDeviceFlowPostsWithCorrectBodyAndContentType()
         {
-            var responseToken = new OauthToken(null, null, null);
+            var responseToken = new OauthToken(null, null, null, null, null, null);
             var response = Substitute.For<IApiResponse<OauthToken>>();
             response.Body.Returns(responseToken);
             var connection = Substitute.For<IConnection>();

--- a/Octokit/Clients/IOAuthClient.cs
+++ b/Octokit/Clients/IOAuthClient.cs
@@ -28,5 +28,27 @@ namespace Octokit
         /// <param name="request"></param>
         /// <returns></returns>
         Task<OauthToken> CreateAccessToken(OauthTokenRequest request);
+
+        /// <summary>
+        /// Makes a request to initiate the device flow authentication.
+        /// </summary>
+        /// <remarks>
+        /// Returns a user verification code and verification URL that the you will use to prompt the user to authenticate.
+        /// This request also returns a device verification code that you must use to receive an access token to check the status of user authentication.
+        /// </remarks>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        Task<OauthDeviceFlowResponse> InitiateDeviceFlow(OauthDeviceFlowRequest request);
+
+        /// <summary>
+        /// Makes a request to get an access token using the response from <see cref="InitiateDeviceFlow(OauthDeviceFlowRequest)"/>.
+        /// </summary>
+        /// <remarks>
+        /// Will poll the access token endpoint, until the device and user codes expire or the user has successfully authorized the app with a valid user code.
+        /// </remarks>
+        /// <param name="clientId">The client Id you received from GitHub when you registered the application.</param>
+        /// <param name="deviceFlowResponse">The response you received from <see cref="InitiateDeviceFlow(OauthDeviceFlowRequest)"/></param>
+        /// <returns></returns>
+        Task<OauthToken> CreateAccessTokenForDeviceFlow(string clientId, OauthDeviceFlowResponse deviceFlowResponse);
     }
 }

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -2351,6 +2351,15 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Creates the relative <see cref="Uri"/> for initiating the OAuth device Flow
+        /// </summary>
+        /// <returns></returns>
+        public static Uri OauthDeviceCode()
+        {
+            return "login/device/code".FormatUri();
+        }
+
+        /// <summary>
         /// Creates the relative <see cref="Uri"/> to request an OAuth access token.
         /// </summary>
         /// <returns></returns>

--- a/Octokit/Models/Request/OauthDeviceFlowRequest.cs
+++ b/Octokit/Models/Request/OauthDeviceFlowRequest.cs
@@ -32,7 +32,7 @@ namespace Octokit
 
         /// <summary>
         /// A set of scopes to request. If not provided, scope defaults to an empty list of scopes for users that don’t
-        /// have a valid token for the app. For users who do already have a valid token for the app, the user won’t be
+        /// have a valid token for the app. For users who do already have a valid token for the app, the user won't be
         /// shown the OAuth authorization page with the list of scopes. Instead, this step of the flow will
         /// automatically complete with the same scopes that were used last time the user completed the flow.
         /// </summary>

--- a/Octokit/Models/Request/OauthDeviceFlowRequest.cs
+++ b/Octokit/Models/Request/OauthDeviceFlowRequest.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Globalization;
+using Octokit.Internal;
+
+namespace Octokit
+{
+    /// <summary>
+    /// Used to create an Oauth device flow initiation request.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class OauthDeviceFlowRequest
+        : RequestParameters
+    {
+        /// <summary>
+        /// Creates an instance of the OAuth login request with the required parameter.
+        /// </summary>
+        /// <param name="clientId">The client Id you received from GitHub when you registered the application.</param>
+        public OauthDeviceFlowRequest(string clientId)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(clientId, nameof(clientId));
+
+            ClientId = clientId;
+            Scopes = new Collection<string>();
+        }
+
+        /// <summary>
+        /// The client Id you received from GitHub when you registered the application.
+        /// </summary>
+        [Parameter(Key = "client_id")]
+        public string ClientId { get; private set; }
+
+        /// <summary>
+        /// A set of scopes to request. If not provided, scope defaults to an empty list of scopes for users that don’t
+        /// have a valid token for the app. For users who do already have a valid token for the app, the user won’t be
+        /// shown the OAuth authorization page with the list of scopes. Instead, this step of the flow will
+        /// automatically complete with the same scopes that were used last time the user completed the flow.
+        /// </summary>
+        /// <remarks>
+        /// See the <see href="https://developer.github.com/v3/oauth/#scopes">scopes documentation</see> for more
+        /// information about scopes.
+        /// </remarks>
+        [Parameter(Key = "scope")]
+        public Collection<string> Scopes { get; private set; }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format(CultureInfo.InvariantCulture, "ClientId: {0}, Scopes: {1}", ClientId, Scopes);
+            }
+        }
+    }
+}

--- a/Octokit/Models/Request/OauthTokenRequestForDeviceFlow.cs
+++ b/Octokit/Models/Request/OauthTokenRequestForDeviceFlow.cs
@@ -1,0 +1,55 @@
+﻿using System.Diagnostics;
+using System.Globalization;
+using Octokit.Internal;
+
+namespace Octokit
+{
+    /// <summary>
+    /// Used to create an Oauth login request for the device flow.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    internal class OauthTokenRequestForDeviceFlow : RequestParameters
+    {
+        /// <summary>
+        /// Creates an instance of the OAuth login request with the required parameter.
+        /// </summary>
+        /// <param name="clientId">The client Id you received from GitHub when you registered the application.</param>
+        /// <param name="deviceCode">The device code you received from the device flow initiation call.</param>
+        public OauthTokenRequestForDeviceFlow(string clientId, string deviceCode)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(clientId, nameof(clientId));
+            Ensure.ArgumentNotNullOrEmptyString(deviceCode, nameof(deviceCode));
+
+            ClientId = clientId;
+            DeviceCode = deviceCode;
+        }
+
+        /// <summary>
+        /// The client Id you received from GitHub when you registered the application.
+        /// </summary>
+        [Parameter(Key = "client_id")]
+        public string ClientId { get; private set; }
+
+        /// <summary>
+        /// The device code you received from the device flow initiation call.
+        /// </summary>
+        [Parameter(Key = "device_code")]
+        public string DeviceCode { get; private set; }
+
+        /// <summary>
+        /// The authorization grant type.
+        /// </summary>
+        [Parameter(Key = "grant_type")]
+        public string GrantType => "urn:ietf:params:oauth:grant-type:device_code";
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format(CultureInfo.InvariantCulture, "ClientId: {0}, DeviceCode: {1}",
+                    ClientId,
+                    DeviceCode);
+            }
+        }
+    }
+}

--- a/Octokit/Models/Response/OauthDeviceFlowResponse.cs
+++ b/Octokit/Models/Response/OauthDeviceFlowResponse.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace Octokit
+{
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class OauthDeviceFlowResponse
+    {
+        public OauthDeviceFlowResponse() { }
+
+        public OauthDeviceFlowResponse(string deviceCode, string userCode, string verificationUri, int expiresIn, int interval)
+        {
+            DeviceCode = deviceCode;
+            UserCode = userCode;
+            VerificationUri = verificationUri;
+            ExpiresIn = expiresIn;
+            Interval = interval;
+        }
+
+        /// <summary>
+        /// The device verification code is 40 characters and used to verify the device.
+        /// </summary>
+        public string DeviceCode { get; protected set; }
+
+        /// <summary>
+        /// The user verification code is displayed on the device so the user can enter the code in a browser. This code is 8 characters with a hyphen in the middle.
+        /// </summary>
+        public string UserCode { get; protected set; }
+
+        /// <summary>
+        /// The verification URL where users need to enter the UserCode: https://github.com/login/device.
+        /// </summary>
+        public string VerificationUri { get; protected set; }
+
+        /// <summary>
+        /// The number of seconds before the DeviceCode and UserCode expire. The default is 900 seconds or 15 minutes.
+        /// </summary>
+        public int ExpiresIn { get; protected set; }
+
+        /// <summary>
+        /// The minimum number of seconds that must pass before you can make a new access token request (POST https://github.com/login/oauth/access_token) to complete the device authorization.
+        /// For example, if the interval is 5, then you cannot make a new request until 5 seconds pass. If you make more than one request over 5 seconds, then you will hit the rate limit
+        /// and receive a slow_down error.
+        /// </summary>
+        public int Interval { get; protected set; }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format(CultureInfo.InvariantCulture, "DeviceCode: {0}, UserCode: {1}, VerificationUri: {2}, ExpiresIn: {3}, Interval: {4}",
+                    DeviceCode,
+                    UserCode,
+                    VerificationUri,
+                    ExpiresIn,
+                    Interval);
+            }
+        }
+    }
+}

--- a/Octokit/Models/Response/OauthDeviceFlowResponse.cs
+++ b/Octokit/Models/Response/OauthDeviceFlowResponse.cs
@@ -21,29 +21,29 @@ namespace Octokit
         /// <summary>
         /// The device verification code is 40 characters and used to verify the device.
         /// </summary>
-        public string DeviceCode { get; protected set; }
+        public string DeviceCode { get; private set; }
 
         /// <summary>
         /// The user verification code is displayed on the device so the user can enter the code in a browser. This code is 8 characters with a hyphen in the middle.
         /// </summary>
-        public string UserCode { get; protected set; }
+        public string UserCode { get; private set; }
 
         /// <summary>
         /// The verification URL where users need to enter the UserCode: https://github.com/login/device.
         /// </summary>
-        public string VerificationUri { get; protected set; }
+        public string VerificationUri { get; private set; }
 
         /// <summary>
         /// The number of seconds before the DeviceCode and UserCode expire. The default is 900 seconds or 15 minutes.
         /// </summary>
-        public int ExpiresIn { get; protected set; }
+        public int ExpiresIn { get; private set; }
 
         /// <summary>
         /// The minimum number of seconds that must pass before you can make a new access token request (POST https://github.com/login/oauth/access_token) to complete the device authorization.
         /// For example, if the interval is 5, then you cannot make a new request until 5 seconds pass. If you make more than one request over 5 seconds, then you will hit the rate limit
         /// and receive a slow_down error.
         /// </summary>
-        public int Interval { get; protected set; }
+        public int Interval { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/OauthToken.cs
+++ b/Octokit/Models/Response/OauthToken.cs
@@ -10,27 +10,30 @@ namespace Octokit
     {
         public OauthToken() { }
 
-        public OauthToken(string tokenType, string accessToken, IReadOnlyList<string> scope)
+        public OauthToken(string tokenType, string accessToken, IReadOnlyList<string> scope, string error, string errorDescription, string errorUri)
         {
             TokenType = tokenType;
             AccessToken = accessToken;
             Scope = scope;
+            Error = error;
+            ErrorDescription = errorDescription;
+            ErrorUri = errorUri;
         }
 
         /// <summary>
         /// The type of OAuth token
         /// </summary>
-        public string TokenType { get; protected set; }
+        public string TokenType { get; private set; }
 
         /// <summary>
         /// The secret OAuth access token. Use this to authenticate Octokit.net's client.
         /// </summary>
-        public string AccessToken { get; protected set; }
+        public string AccessToken { get; private set; }
 
         /// <summary>
         /// The list of scopes the token includes.
         /// </summary>
-        public IReadOnlyList<string> Scope { get; protected set; }
+        public IReadOnlyList<string> Scope { get; private set; }
 
         /// <summary>
         /// Gets or sets the error code or the response.

--- a/Octokit/Models/Response/OauthToken.cs
+++ b/Octokit/Models/Response/OauthToken.cs
@@ -12,12 +12,12 @@ namespace Octokit
 
         public OauthToken(string tokenType, string accessToken, IReadOnlyList<string> scope, string error, string errorDescription, string errorUri)
         {
-            TokenType = tokenType;
-            AccessToken = accessToken;
-            Scope = scope;
-            Error = error;
-            ErrorDescription = errorDescription;
-            ErrorUri = errorUri;
+            this.TokenType = tokenType;
+            this.AccessToken = accessToken;
+            this.Scope = scope;
+            this.Error = error;
+            this.ErrorDescription = errorDescription;
+            this.ErrorUri = errorUri;
         }
 
         /// <summary>
@@ -39,28 +39,28 @@ namespace Octokit
         /// Gets or sets the error code or the response.
         /// </summary>
         [Parameter(Key = "error")]
-        public string Error { get; set; }
+        public string Error { get; private set; }
 
         /// <summary>
         /// Gets or sets the error description.
         /// </summary>
         [Parameter(Key = "error_description")]
-        public string ErrorDescription { get; set; }
+        public string ErrorDescription { get; private set; }
 
         /// <summary>
         /// Gets or sets the error uri.
         /// </summary>
         [Parameter(Key = "error_uri")]
-        public string ErrorUri { get; set; }
+        public string ErrorUri { get; private set; }
 
         internal string DebuggerDisplay
         {
             get
             {
                 return string.Format(CultureInfo.InvariantCulture, "TokenType: {0}, AccessToken: {1}, Scopes: {2}",
-                    TokenType,
-                    AccessToken,
-                    Scope);
+                    this.TokenType,
+                    this.AccessToken,
+                    this.Scope);
             }
         }
     }

--- a/Octokit/Models/Response/OauthToken.cs
+++ b/Octokit/Models/Response/OauthToken.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using Octokit.Internal;
 
 namespace Octokit
 {
@@ -30,6 +31,24 @@ namespace Octokit
         /// The list of scopes the token includes.
         /// </summary>
         public IReadOnlyList<string> Scope { get; protected set; }
+
+        /// <summary>
+        /// Gets or sets the error code or the response.
+        /// </summary>
+        [Parameter(Key = "error")]
+        public string Error { get; set; }
+
+        /// <summary>
+        /// Gets or sets the error description.
+        /// </summary>
+        [Parameter(Key = "error_description")]
+        public string ErrorDescription { get; set; }
+
+        /// <summary>
+        /// Gets or sets the error uri.
+        /// </summary>
+        [Parameter(Key = "error_uri")]
+        public string ErrorUri { get; set; }
 
         internal string DebuggerDisplay
         {


### PR DESCRIPTION
Adds support for the Device flow authentication pattern: https://docs.github.com/en/developers/apps/authorizing-oauth-apps#device-flow 

Resolves #2308

Usage:

```
var github = new GitHubClient(new ProductHeaderValue("test"));
string clientId = "<clientId>";
var request = new OauthDeviceFlowRequest(clientId);
request.Scopes.Add("repo");

var deviceFlowResponse = await github.Oauth.InitiateDeviceFlow(request);
Console.WriteLine(deviceFlowResponse.UserCode);
OpenWebPage(deviceFlowResponse.VerificationUri);
var token = await github.Oauth.CreateAccessTokenForDeviceFlow(clientId, deviceFlowResponse);
Console.WriteLine(token.AccessToken);
```