### PR TITLE
Support for IsTemplate and Create Template from Repository

### DIFF
--- a/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
@@ -28,7 +28,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="templateOwner">The owner of the template</param>
         /// <param name="templateRepo">The name of the template</param>
-        /// <param name="newRepository"></param>
+        /// <param name="newRepository">A <see cref="NewRepositoryFromTemplate"/> instance describing the new repository to create from a template</param>
         /// <returns>An <see cref="IObservable{Repository}"/> instance for the created repository</returns>
         IObservable<Repository> Generate(string templateOwner, string templateRepo, NewRepositoryFromTemplate newRepository);
 

--- a/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
@@ -26,11 +26,11 @@ namespace Octokit.Reactive
         /// <summary>
         /// Creates a new repository using a repository template.
         /// </summary>
-        /// <param name="owner">The owner of the template</param>
-        /// <param name="repo">The name of the template</param>
+        /// <param name="templateOwner">The owner of the template</param>
+        /// <param name="templateRepo">The name of the template</param>
         /// <param name="newRepository"></param>
         /// <returns>An <see cref="IObservable{Repository}"/> instance for the created repository</returns>
-        IObservable<Repository> Generate(string owner, string repo, NewRepositoryFromTemplate newRepository);
+        IObservable<Repository> Generate(string templateOwner, string templateRepo, NewRepositoryFromTemplate newRepository);
 
         /// <summary>
         /// Deletes a repository for the specified owner and name.

--- a/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
@@ -24,6 +24,15 @@ namespace Octokit.Reactive
         IObservable<Repository> Create(string organizationLogin, NewRepository newRepository);
 
         /// <summary>
+        /// Creates a new repository using a repository template.
+        /// </summary>
+        /// <param name="owner">The owner of the template</param>
+        /// <param name="repo">The name of the template</param>
+        /// <param name="newRepository"></param>
+        /// <returns>An <see cref="IObservable{Repository}"/> instance for the created repository</returns>
+        IObservable<Repository> Generate(string owner, string repo, NewRepositoryFromTemplate newRepository);
+
+        /// <summary>
         /// Deletes a repository for the specified owner and name.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>

--- a/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
@@ -77,7 +77,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="templateOwner">The organization or person who will owns the template</param>
         /// <param name="templateRepo">The name of template repository to work from</param>
-        /// <param name="newRepository"></param>
+        /// <param name="newRepository">A <see cref="NewRepositoryFromTemplate"/> instance describing the new repository to create from a template</param>
         /// <returns></returns>
         public IObservable<Repository> Generate(string templateOwner, string templateRepo, NewRepositoryFromTemplate newRepository)
         {

--- a/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
@@ -73,21 +73,21 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
-        /// Create a new repository from a template
+        /// Creates a new repository from a template
         /// </summary>
-        /// <param name="owner"></param>
-        /// <param name="repo"></param>
+        /// <param name="templateOwner">The organization or person who will owns the template</param>
+        /// <param name="templateRepo">The name of template repository to work from</param>
         /// <param name="newRepository"></param>
         /// <returns></returns>
-        public IObservable<Repository> Generate(string owner, string repo, NewRepositoryFromTemplate newRepository)
+        public IObservable<Repository> Generate(string templateOwner, string templateRepo, NewRepositoryFromTemplate newRepository)
         {
-            Ensure.ArgumentNotNull(owner, nameof(owner));
-            Ensure.ArgumentNotNull(repo, nameof(repo));
+            Ensure.ArgumentNotNull(templateOwner, nameof(templateOwner));
+            Ensure.ArgumentNotNull(templateRepo, nameof(templateRepo));
             Ensure.ArgumentNotNull(newRepository, nameof(newRepository));
             if (string.IsNullOrEmpty(newRepository.Name))
                 throw new ArgumentException("The new repository's name must not be null.");
 
-            return _client.Generate(owner, repo, newRepository).ToObservable();
+            return _client.Generate(templateOwner, templateRepo, newRepository).ToObservable();
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
@@ -73,6 +73,24 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Create a new repository from a template
+        /// </summary>
+        /// <param name="owner"></param>
+        /// <param name="repo"></param>
+        /// <param name="newRepository"></param>
+        /// <returns></returns>
+        public IObservable<Repository> Generate(string owner, string repo, NewRepositoryFromTemplate newRepository)
+        {
+            Ensure.ArgumentNotNull(owner, nameof(owner));
+            Ensure.ArgumentNotNull(repo, nameof(repo));
+            Ensure.ArgumentNotNull(newRepository, nameof(newRepository));
+            if (string.IsNullOrEmpty(newRepository.Name))
+                throw new ArgumentException("The new repository's name must not be null.");
+
+            return _client.Generate(owner, repo, newRepository).ToObservable();
+        }
+
+        /// <summary>
         /// Deletes a repository for the specified owner and name.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -220,6 +220,51 @@ public class RepositoriesClientTests
         }
 
         [IntegrationTest]
+        public async Task CreatesARepositoryAsTemplate()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var repoName = Helper.MakeNameWithTimestamp("repo-as-template");
+
+            var newRepository = new NewRepository(repoName)
+            {
+                IsTemplate = true
+            };
+
+            using (var context = await github.CreateRepositoryContext(newRepository))
+            {
+                var createdRepository = context.Repository;
+
+                var repository = await github.Repository.Get(Helper.UserName, repoName);
+
+                Assert.True(repository.IsTemplate);
+            }
+        }
+
+        [IntegrationTest]
+        public async Task CreatesARepositoryFromTemplate()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var repoTemplateName = Helper.MakeNameWithTimestamp("repo-template");
+            var repoFromTemplateName = Helper.MakeNameWithTimestamp("repo-from-template");
+            var owner = github.User.Current().Result.Login;
+
+            var newTemplate = new NewRepository(repoTemplateName)
+            {
+                IsTemplate = true
+            };
+
+            var newRepo = new NewRepositoryFromTemplate(repoFromTemplateName);
+
+            using (var templateContext = await github.CreateRepositoryContext(newTemplate))
+            using (var context = await github.Generate(owner, repoFromTemplateName, newRepo))
+            {
+                var repository = await github.Repository.Get(Helper.UserName, repoFromTemplateName);
+
+                Assert.Equal(repoFromTemplateName, repository.Name);
+            }
+        }
+
+        [IntegrationTest]
         public async Task CreatesARepositoryWithDeleteBranchOnMergeEnabled()
         {
             var github = Helper.GetAuthenticatedClient();

--- a/Octokit.Tests.Integration/Helpers/GithubClientExtensions.cs
+++ b/Octokit.Tests.Integration/Helpers/GithubClientExtensions.cs
@@ -26,6 +26,13 @@ namespace Octokit.Tests.Integration.Helpers
             return new RepositoryContext(client.Connection, repo);
         }
 
+        internal static async Task<RepositoryContext> Generate(this IGitHubClient client, string owner, string repoName, NewRepositoryFromTemplate newRepository)
+        {
+            var repo = await client.Repository.Generate(owner, repoName, newRepository);
+
+            return new RepositoryContext(client.Connection, repo);
+        }
+
         internal static async Task<TeamContext> CreateTeamContext(this IGitHubClient client, string organization, NewTeam newTeam)
         {
             newTeam.Privacy = TeamPrivacy.Closed;

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -214,6 +214,44 @@ namespace Octokit.Tests.Clients
             }
         }
 
+        public class TheGenerateMethod
+        {
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new RepositoriesClient(Substitute.For<IApiConnection>());
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Generate(null, null, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Generate("asd", null, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Generate("asd", "asd", null));
+            }
+
+            [Fact]
+            public void UsesTheUserReposUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+
+                client.Generate("asd", "asd", new NewRepositoryFromTemplate("aName"));
+
+                connection.Received().Post<Repository>(Arg.Is<Uri>(u => u.ToString() == "repos/asd/asd/generate"),
+                    Arg.Any<NewRepositoryFromTemplate>(),
+                    "application/vnd.github.baptiste-preview+json");
+            }
+
+            [Fact]
+            public void TheNewRepositoryDescription()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+                var newRepository = new NewRepositoryFromTemplate("aName");
+
+                client.Generate("anOwner", "aRepo", newRepository);
+
+                connection.Received().Post<Repository>(Args.Uri, newRepository, "application/vnd.github.baptiste-preview+json");
+            }
+        }
+
         public class TheTransferMethod
         {
             [Fact]
@@ -1332,7 +1370,7 @@ namespace Octokit.Tests.Clients
                 await _client.ReplaceAllTopics("owner", "name", _emptyTopics);
 
                 _connection.Received()
-                    .Put<RepositoryTopics>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/topics"), _emptyTopics, null,"application/vnd.github.mercy-preview+json");
+                    .Put<RepositoryTopics>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/topics"), _emptyTopics, null, "application/vnd.github.mercy-preview+json");
             }
 
             [Fact]
@@ -1341,7 +1379,7 @@ namespace Octokit.Tests.Clients
                 await _client.ReplaceAllTopics("owner", "name", _listOfTopics);
 
                 _connection.Received()
-                    .Put<RepositoryTopics>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/topics"), _listOfTopics,null, "application/vnd.github.mercy-preview+json");
+                    .Put<RepositoryTopics>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/topics"), _listOfTopics, null, "application/vnd.github.mercy-preview+json");
             }
 
             [Fact]
@@ -1356,10 +1394,10 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task RequestsTheCorrectUrlForRepoIdWithListOfTopics()
             {
-                await _client.ReplaceAllTopics(1234,_listOfTopics);
+                await _client.ReplaceAllTopics(1234, _listOfTopics);
 
                 _connection.Received()
-                    .Put<RepositoryTopics>(Arg.Is<Uri>(u => u.ToString() == "repositories/1234/topics"), _listOfTopics,null, "application/vnd.github.mercy-preview+json");
+                    .Put<RepositoryTopics>(Arg.Is<Uri>(u => u.ToString() == "repositories/1234/topics"), _listOfTopics, null, "application/vnd.github.mercy-preview+json");
             }
         }
     }

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -42,7 +42,7 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().Post<Repository>(Arg.Is<Uri>(u => u.ToString() == "user/repos"),
                     Arg.Any<NewRepository>(),
-                    "application/vnd.github.nebula-preview+json");
+                    "application/vnd.github.nebula-preview+json,application/vnd.github.baptiste-preview+json");
             }
 
             [Fact]
@@ -54,7 +54,7 @@ namespace Octokit.Tests.Clients
 
                 client.Create(newRepository);
 
-                connection.Received().Post<Repository>(Args.Uri, newRepository, "application/vnd.github.nebula-preview+json");
+                connection.Received().Post<Repository>(Args.Uri, newRepository, "application/vnd.github.nebula-preview+json,application/vnd.github.baptiste-preview+json");
             }
 
             [Fact]
@@ -70,7 +70,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 connection.Connection.BaseAddress.Returns(GitHubClient.GitHubApiUrl);
                 connection.Connection.Credentials.Returns(credentials);
-                connection.Post<Repository>(Args.Uri, newRepository, "application/vnd.github.nebula-preview+json")
+                connection.Post<Repository>(Args.Uri, newRepository, "application/vnd.github.nebula-preview+json,application/vnd.github.baptiste-preview+json")
                     .Returns<Task<Repository>>(_ => { throw new ApiValidationException(response); });
                 var client = new RepositoriesClient(connection);
 
@@ -97,7 +97,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 connection.Connection.BaseAddress.Returns(GitHubClient.GitHubApiUrl);
                 connection.Connection.Credentials.Returns(credentials);
-                connection.Post<Repository>(Args.Uri, newRepository, "application/vnd.github.nebula-preview+json")
+                connection.Post<Repository>(Args.Uri, newRepository, "application/vnd.github.nebula-preview+json,application/vnd.github.baptiste-preview+json")
                     .Returns<Task<Repository>>(_ => { throw new ApiValidationException(response); });
                 var client = new RepositoriesClient(connection);
 
@@ -130,7 +130,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().Post<Repository>(
                     Arg.Is<Uri>(u => u.ToString() == "orgs/theLogin/repos"),
                     Args.NewRepository,
-                    "application/vnd.github.nebula-preview+json");
+                    "application/vnd.github.nebula-preview+json,application/vnd.github.baptiste-preview+json");
             }
 
             [Fact]
@@ -142,7 +142,7 @@ namespace Octokit.Tests.Clients
 
                 await client.Create("aLogin", newRepository);
 
-                connection.Received().Post<Repository>(Args.Uri, newRepository, "application/vnd.github.nebula-preview+json");
+                connection.Received().Post<Repository>(Args.Uri, newRepository, "application/vnd.github.nebula-preview+json,application/vnd.github.baptiste-preview+json");
             }
 
             [Fact]
@@ -156,7 +156,7 @@ namespace Octokit.Tests.Clients
                     + @"""code"":""custom"",""field"":""name"",""message"":""name already exists on this account""}]}");
                 var connection = Substitute.For<IApiConnection>();
                 connection.Connection.BaseAddress.Returns(GitHubClient.GitHubApiUrl);
-                connection.Post<Repository>(Args.Uri, newRepository, "application/vnd.github.nebula-preview+json")
+                connection.Post<Repository>(Args.Uri, newRepository, "application/vnd.github.nebula-preview+json,application/vnd.github.baptiste-preview+json")
                     .Returns<Task<Repository>>(_ => { throw new ApiValidationException(response); });
                 var client = new RepositoriesClient(connection);
 
@@ -181,7 +181,7 @@ namespace Octokit.Tests.Clients
                     + @"""http://developer.github.com/v3/repos/#create"",""errors"":[]}");
                 var connection = Substitute.For<IApiConnection>();
                 connection.Connection.BaseAddress.Returns(GitHubClient.GitHubApiUrl);
-                connection.Post<Repository>(Args.Uri, newRepository, "application/vnd.github.nebula-preview+json")
+                connection.Post<Repository>(Args.Uri, newRepository, "application/vnd.github.nebula-preview+json,application/vnd.github.baptiste-preview+json")
                     .Returns<Task<Repository>>(_ => { throw new ApiValidationException(response); });
                 var client = new RepositoriesClient(connection);
 
@@ -202,7 +202,7 @@ namespace Octokit.Tests.Clients
                     + @"""code"":""custom"",""field"":""name"",""message"":""name already exists on this account""}]}");
                 var connection = Substitute.For<IApiConnection>();
                 connection.Connection.BaseAddress.Returns(new Uri("https://example.com"));
-                connection.Post<Repository>(Args.Uri, newRepository, "application/vnd.github.nebula-preview+json")
+                connection.Post<Repository>(Args.Uri, newRepository, "application/vnd.github.nebula-preview+json,application/vnd.github.baptiste-preview+json")
                     .Returns<Task<Repository>>(_ => { throw new ApiValidationException(response); });
                 var client = new RepositoriesClient(connection);
 
@@ -490,7 +490,7 @@ namespace Octokit.Tests.Clients
                 connection.Received()
                     .GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "user/repos"),
                     null,
-                    "application/vnd.github.nebula-preview+json",
+                    "application/vnd.github.nebula-preview+json,application/vnd.github.baptiste-preview+json",
                     Args.ApiOptions);
             }
 
@@ -644,7 +644,7 @@ namespace Octokit.Tests.Clients
                 await client.GetAllForOrg("orgname");
 
                 connection.Received()
-                    .GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "orgs/orgname/repos"), null, "application/vnd.github.nebula-preview+json", Args.ApiOptions);
+                    .GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "orgs/orgname/repos"), null, "application/vnd.github.nebula-preview+json,application/vnd.github.baptiste-preview+json", Args.ApiOptions);
             }
 
             [Fact]
@@ -1078,7 +1078,7 @@ namespace Octokit.Tests.Clients
                 connection.Received()
                     .Patch<Repository>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo"),
                     Arg.Any<RepositoryUpdate>(),
-                    "application/vnd.github.nebula-preview+json");
+                    "application/vnd.github.nebula-preview+json,application/vnd.github.baptiste-preview+json");
             }
 
             [Fact]

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -78,6 +78,16 @@ namespace Octokit
         Task<Repository> Create(string organizationLogin, NewRepository newRepository);
 
         /// <summary>
+        /// Creates a new repository using a repository template.
+        /// </summary>
+        /// <param name="owner">The owner of the template</param>
+        /// <param name="repo">The name of the template</param>
+        /// <param name="newRepository"></param>
+        /// <returns></returns>
+        Task<Repository> Generate(string owner, string repo, NewRepositoryFromTemplate newRepository);
+
+
+        /// <summary>
         /// Deletes the specified repository.
         /// </summary>
         /// <remarks>

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -78,13 +78,13 @@ namespace Octokit
         Task<Repository> Create(string organizationLogin, NewRepository newRepository);
 
         /// <summary>
-        /// Creates a new repository using a repository template.
+        /// Creates a new repository from a template
         /// </summary>
-        /// <param name="owner">The owner of the template</param>
-        /// <param name="repo">The name of the template</param>
+        /// <param name="templateOwner">The organization or person who will owns the template</param>
+        /// <param name="templateRepo">The name of template repository to work from</param>
         /// <param name="newRepository"></param>
         /// <returns></returns>
-        Task<Repository> Generate(string owner, string repo, NewRepositoryFromTemplate newRepository);
+        Task<Repository> Generate(string templateOwner, string templateRepo, NewRepositoryFromTemplate newRepository);
 
 
         /// <summary>

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -82,6 +82,13 @@ namespace Octokit
             return Create(ApiUrls.OrganizationRepositories(organizationLogin), organizationLogin, newRepository);
         }
 
+        /// <summary>
+        /// Creates a new repository from a template
+        /// </summary>
+        /// <param name="owner">The organization or person who will own the new repository. To create a new repository in an organization, the authenticated user must be a member of the specified organization.</param>
+        /// <param name="repo">The name of the new repository.</param>
+        /// <param name="newRepository"></param>
+        /// <returns></returns>
         [Preview("baptiste")]
         [ManualRoute("POST", "/repos/{owner}/{repo}/generate")]
         public Task<Repository> Generate(string owner, string repo, NewRepositoryFromTemplate newRepository)

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -70,6 +70,7 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="Repository"/> instance for the created repository</returns>
         [Preview("nebula")]
+        [Preview("baptiste")]
         [ManualRoute("POST", "/orgs/{org}/repos")]
         public Task<Repository> Create(string organizationLogin, NewRepository newRepository)
         {
@@ -81,11 +82,24 @@ namespace Octokit
             return Create(ApiUrls.OrganizationRepositories(organizationLogin), organizationLogin, newRepository);
         }
 
+        [Preview("baptiste")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/generate")]
+        public Task<Repository> Generate(string owner, string repo, NewRepositoryFromTemplate newRepository)
+        {
+            Ensure.ArgumentNotNull(owner, nameof(owner));
+            Ensure.ArgumentNotNull(repo, nameof(repo));
+            Ensure.ArgumentNotNull(newRepository, nameof(newRepository));
+            if (string.IsNullOrEmpty(newRepository.Name))
+                throw new ArgumentException("The new repository's name must not be null.");
+
+            return ApiConnection.Post<Repository>(ApiUrls.Repositories(owner, repo), newRepository, AcceptHeaders.TemplatePreview);
+        }
+
         async Task<Repository> Create(Uri url, string organizationLogin, NewRepository newRepository)
         {
             try
             {
-                return await ApiConnection.Post<Repository>(url, newRepository, AcceptHeaders.VisibilityPreview).ConfigureAwait(false);
+                return await ApiConnection.Post<Repository>(url, newRepository, AcceptHeaders.Concat(AcceptHeaders.VisibilityPreview, AcceptHeaders.TemplatePreview)).ConfigureAwait(false);
             }
             catch (ApiValidationException e)
             {
@@ -216,6 +230,7 @@ namespace Octokit
         /// <param name="update">New values to update the repository with</param>
         /// <returns>The updated <see cref="T:Octokit.Repository"/></returns>
         [Preview("nebula")]
+        [Preview("baptiste")]
         [ManualRoute("PATCH", "/repos/{owner}/{repo}")]
         public Task<Repository> Edit(string owner, string name, RepositoryUpdate update)
         {
@@ -224,7 +239,7 @@ namespace Octokit
             Ensure.ArgumentNotNull(update, nameof(update));
             Ensure.ArgumentNotNull(update.Name, nameof(update.Name));
 
-            return ApiConnection.Patch<Repository>(ApiUrls.Repository(owner, name), update, AcceptHeaders.VisibilityPreview);
+            return ApiConnection.Patch<Repository>(ApiUrls.Repository(owner, name), update, AcceptHeaders.Concat(AcceptHeaders.VisibilityPreview, AcceptHeaders.TemplatePreview));
         }
 
         /// <summary>
@@ -326,6 +341,7 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>.</returns>
         [Preview("nebula")]
+        [Preview("baptiste")]
         [ManualRoute("GET", "/user/repos")]
         public Task<IReadOnlyList<Repository>> GetAllForCurrent()
         {
@@ -343,12 +359,13 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>.</returns>
         [Preview("nebula")]
+        [Preview("baptiste")]
         [ManualRoute("GET", "/user/repos")]
         public Task<IReadOnlyList<Repository>> GetAllForCurrent(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return ApiConnection.GetAll<Repository>(ApiUrls.Repositories(), null, AcceptHeaders.VisibilityPreview, options);
+            return ApiConnection.GetAll<Repository>(ApiUrls.Repositories(), null, AcceptHeaders.Concat(AcceptHeaders.VisibilityPreview, AcceptHeaders.TemplatePreview), options);
         }
 
         /// <summary>
@@ -440,6 +457,7 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>.</returns>
         [Preview("nebula")]
+        [Preview("baptiste")]
         [ManualRoute("GET", "/orgs/{org}/repos")]
         public Task<IReadOnlyList<Repository>> GetAllForOrg(string organization)
         {
@@ -459,13 +477,14 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>.</returns>
         [Preview("nebula")]
+        [Preview("baptiste")]
         [ManualRoute("GET", "/orgs/{org}/repos")]
         public Task<IReadOnlyList<Repository>> GetAllForOrg(string organization, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, nameof(organization));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return ApiConnection.GetAll<Repository>(ApiUrls.OrganizationRepositories(organization), null, AcceptHeaders.VisibilityPreview, options);
+            return ApiConnection.GetAll<Repository>(ApiUrls.OrganizationRepositories(organization), null, AcceptHeaders.Concat(AcceptHeaders.VisibilityPreview, AcceptHeaders.TemplatePreview), options);
         }
 
         /// <summary>
@@ -745,7 +764,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNull(options, nameof(options));
             var endpoint = ApiUrls.RepositoryTopics(repositoryId);
-            var data = await ApiConnection.Get<RepositoryTopics>(endpoint,null,AcceptHeaders.RepositoryTopicsPreview).ConfigureAwait(false);
+            var data = await ApiConnection.Get<RepositoryTopics>(endpoint, null, AcceptHeaders.RepositoryTopicsPreview).ConfigureAwait(false);
 
             return data ?? new RepositoryTopics();
         }
@@ -824,7 +843,7 @@ namespace Octokit
             Ensure.ArgumentNotNull(topics, nameof(topics));
 
             var endpoint = ApiUrls.RepositoryTopics(owner, name);
-            var data = await ApiConnection.Put<RepositoryTopics>(endpoint, topics,null, AcceptHeaders.RepositoryTopicsPreview).ConfigureAwait(false);
+            var data = await ApiConnection.Put<RepositoryTopics>(endpoint, topics, null, AcceptHeaders.RepositoryTopicsPreview).ConfigureAwait(false);
 
             return data ?? new RepositoryTopics();
         }

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -85,21 +85,21 @@ namespace Octokit
         /// <summary>
         /// Creates a new repository from a template
         /// </summary>
-        /// <param name="owner">The organization or person who will own the new repository. To create a new repository in an organization, the authenticated user must be a member of the specified organization.</param>
-        /// <param name="repo">The name of the new repository.</param>
+        /// <param name="templateOwner">The organization or person who will owns the template</param>
+        /// <param name="templateRepo">The name of template repository to work from</param>
         /// <param name="newRepository"></param>
         /// <returns></returns>
         [Preview("baptiste")]
         [ManualRoute("POST", "/repos/{owner}/{repo}/generate")]
-        public Task<Repository> Generate(string owner, string repo, NewRepositoryFromTemplate newRepository)
+        public Task<Repository> Generate(string templateOwner, string templateRepo, NewRepositoryFromTemplate newRepository)
         {
-            Ensure.ArgumentNotNull(owner, nameof(owner));
-            Ensure.ArgumentNotNull(repo, nameof(repo));
+            Ensure.ArgumentNotNull(templateOwner, nameof(templateOwner));
+            Ensure.ArgumentNotNull(templateRepo, nameof(templateRepo));
             Ensure.ArgumentNotNull(newRepository, nameof(newRepository));
             if (string.IsNullOrEmpty(newRepository.Name))
                 throw new ArgumentException("The new repository's name must not be null.");
 
-            return ApiConnection.Post<Repository>(ApiUrls.Repositories(owner, repo), newRepository, AcceptHeaders.TemplatePreview);
+            return ApiConnection.Post<Repository>(ApiUrls.Repositories(templateOwner, templateRepo), newRepository, AcceptHeaders.TemplatePreview);
         }
 
         async Task<Repository> Create(Uri url, string organizationLogin, NewRepository newRepository)

--- a/Octokit/Helpers/AcceptHeaders.cs
+++ b/Octokit/Helpers/AcceptHeaders.cs
@@ -54,6 +54,8 @@ namespace Octokit
 
         public const string VisibilityPreview = "application/vnd.github.nebula-preview+json";
 
+        public const string TemplatePreview = "application/vnd.github.baptiste-preview+json";
+
         /// <summary>
         /// Combines multiple preview headers. GitHub API supports Accept header with multiple
         /// values separated by comma.

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -59,6 +59,15 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Returns the <see cref="Uri"/> that create a repository using a template.
+        /// </summary>
+        /// <returns></returns>
+        public static Uri Repositories(string owner, string repo)
+        {
+            return "repos/{0}/{1}/generate".FormatUri(owner, repo);
+        }
+
+        /// <summary>
         /// Returns the <see cref="Uri"/> that returns all of the repositories for the specified organization in
         /// response to a GET request. A POST to this URL creates a new repository for the organization.
         /// </summary>

--- a/Octokit/Models/Request/NewRepository.cs
+++ b/Octokit/Models/Request/NewRepository.cs
@@ -48,6 +48,11 @@ namespace Octokit
         public bool? HasWiki { get; set; }
 
         /// <summary>
+        /// Either true to make this repo available as a template repository or false to prevent it. Default: false.
+        /// </summary>
+        public bool? IsTemplate { get; set; }
+
+        /// <summary>
         /// Optional. Gets or sets the new repository's optional website.
         /// </summary>
         public string Homepage { get; set; }

--- a/Octokit/Models/Request/NewRepositoryFromTemplate.cs
+++ b/Octokit/Models/Request/NewRepositoryFromTemplate.cs
@@ -1,0 +1,46 @@
+﻿using System.Diagnostics;
+using System.Globalization;
+
+namespace Octokit
+{
+    /// <summary>
+    /// Describes a new repository to create via the <see cref="IRepositoriesClient.Generate"/> method.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class NewRepositoryFromTemplate
+    {
+        /// <summary>
+        /// Creates an object that describes the repository to create on GitHub.
+        /// </summary>
+        /// <param name="name">The name of the repository. This is the only required parameter.</param>
+        public NewRepositoryFromTemplate(string name)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+
+            Name = name;
+        }
+
+        /// <summary>
+        /// Optional. The organization or person who will own the new repository.
+        /// To create a new repository in an organization, the authenticated user must be a member of the specified organization.
+        /// </summary>
+        public string Owner { get; set; }
+
+        /// <summary>
+        /// Required. The name of the new repository.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Optional. A short description of the new repository.
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Optional. Either true to create a new private repository or false to create a new public one. Default: false
+        /// </summary>
+        public bool Private { get; set; }
+
+        internal string DebuggerDisplay => string.Format(CultureInfo.InvariantCulture, "Name: {0} Description: {1}", Name, Description);
+    }
+}


### PR DESCRIPTION
Fixes [#2148](https://github.com/octokit/octokit.net/issues/2148)
Adding the ability to create repositories from a template. Most code borrowed from FrediKats PR 2187 but with fixed tests. Baptiste preview tag added to all repository endpoints mentioned in the GitHub Api documentation.

Further testing and IObservable code added to satisfy tests.