### PR TITLE
Various logic and formatting improvements

### DIFF
--- a/Octokit.Reactive/Helpers/AuthorizationExtensions.cs
+++ b/Octokit.Reactive/Helpers/AuthorizationExtensions.cs
@@ -7,7 +7,7 @@ namespace Octokit
     public static class AuthorizationExtensions
     {
         /// <summary>
-        /// This method will create a new authorization for the specified OAuth application, only if an authorization 
+        /// This method will create a new authorization for the specified OAuth application, only if an authorization
         /// for that application doesn’t already exist for the user. It returns the user’s token for the application
         /// if one exists. Otherwise, it creates a new one.
         /// </summary>
@@ -17,7 +17,7 @@ namespace Octokit
         /// the user. Typically the callback is used to show some user interface to the user.
         /// </para>
         /// <para>
-        /// See <a href="http://developer.github.com/v3/oauth/#list-your-authorizations">API documentation</a> 
+        /// See <a href="http://developer.github.com/v3/oauth/#list-your-authorizations">API documentation</a>
         /// for more details.
         /// </para>
         /// </remarks>
@@ -56,8 +56,8 @@ namespace Octokit
         }
 
         /// <summary>
-        /// This method will create a new authorization for the specified OAuth application. If an authorization 
-        /// for that application already exists for the user and fingerprint, it'll delete the existing one and 
+        /// This method will create a new authorization for the specified OAuth application. If an authorization
+        /// for that application already exists for the user and fingerprint, it'll delete the existing one and
         /// recreate it.
         /// </summary>
         /// <remarks>
@@ -67,7 +67,7 @@ namespace Octokit
         /// the user. Typically the callback is used to show some user interface to the user.
         /// </para>
         /// <para>
-        /// See <a href="http://developer.github.com/v3/oauth/#list-your-authorizations">API documentation</a> 
+        /// See <a href="http://developer.github.com/v3/oauth/#list-your-authorizations">API documentation</a>
         /// for more details.
         /// </para>
         /// </remarks>
@@ -111,10 +111,10 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(clientSecret, nameof(clientSecret));
             Ensure.ArgumentNotNull(newAuthorization, nameof(newAuthorization));
 
-            // If retryInvalidTwoFactorCode is false, then we only show the TwoFactorDialog when we catch 
-            // a TwoFactorRequiredException. If it's true, we show it for TwoFactorRequiredException and 
+            // If retryInvalidTwoFactorCode is false, then we only show the TwoFactorDialog when we catch
+            // a TwoFactorRequiredException. If it's true, we show it for TwoFactorRequiredException and
             // TwoFactorChallengeFailedException
-            Func<TwoFactorAuthorizationException, IObservable<TwoFactorChallengeResult>> twoFactorHandler = ex =>
+            IObservable<TwoFactorChallengeResult> HandleTwoFactor(TwoFactorAuthorizationException ex) =>
                 retryInvalidTwoFactorCode || ex is TwoFactorRequiredException
                     ? twoFactorChallengeHandler(ex)
                     : Observable.Throw<TwoFactorChallengeResult>(ex);
@@ -125,21 +125,21 @@ namespace Octokit
                 newAuthorization,
                 twoFactorAuthenticationCode)
                 .Catch<ApplicationAuthorization, TwoFactorAuthorizationException>(
-                    exception => twoFactorHandler(exception)
+                    exception => HandleTwoFactor(exception)
                     .SelectMany(result =>
                         result.ResendCodeRequested
                             ? authorizationsClient.CreateAndDeleteExistingApplicationAuthorization(
                                 clientId,
                                 clientSecret,
                                 newAuthorization,
-                                twoFactorHandler,
+                                HandleTwoFactor,
                                 null, // twoFactorAuthenticationCode
                                 retryInvalidTwoFactorCode)
                             : authorizationsClient.CreateAndDeleteExistingApplicationAuthorization(
                                     clientId,
                                     clientSecret,
                                     newAuthorization,
-                                    twoFactorHandler,
+                                    HandleTwoFactor,
                                     result.AuthenticationCode,
                                     retryInvalidTwoFactorCode)));
         }

--- a/Octokit.Tests.Conventions/ClientRouteTests.cs
+++ b/Octokit.Tests.Conventions/ClientRouteTests.cs
@@ -51,12 +51,8 @@ namespace Octokit.Tests.Conventions
             }
 
             var obsolete = method.GetCustomAttribute<ObsoleteAttribute>();
-            if (obsolete != null)
-            {
-                return true;
-            }
 
-            return false;
+            return obsolete != null;
         }
 
         static bool IsNotBoilerplateMethod(MethodInfo method)

--- a/Octokit.Tests.Conventions/ClientRouteTests.cs
+++ b/Octokit.Tests.Conventions/ClientRouteTests.cs
@@ -62,12 +62,7 @@ namespace Octokit.Tests.Conventions
                 return false;
             }
 
-            if (method.Name == "GetType" || method.Name == "ToString" || method.Name == "GetHashCode" || method.Name == "Equals")
-            {
-                return false;
-            }
-
-            return true;
+            return method.Name != "GetType" && method.Name != "ToString" && method.Name != "GetHashCode" && method.Name != "Equals";
         }
 
         public static IEnumerable<object[]> GetClientClasses()

--- a/Octokit.Tests.Conventions/PreviewsTests.cs
+++ b/Octokit.Tests.Conventions/PreviewsTests.cs
@@ -75,7 +75,7 @@ namespace Octokit.Tests.Conventions
 
             var validHeaders = defaultHeaders.Concat(previewAcceptHeaders);
 
-            var notAllowedHeaders = values.Values.ToList().Except(validHeaders).OrderBy(k => k);
+            var notAllowedHeaders = values.Values.Except(validHeaders).OrderBy(k => k);
             if (notAllowedHeaders.Any())
             {
                 throw new InvalidAcceptHeadersFound(notAllowedHeaders);

--- a/Octokit.Tests.Integration/Clients/PullRequestReviewCommentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestReviewCommentsClientTests.cs
@@ -837,7 +837,7 @@ public class PullRequestReviewCommentsClientTests : IDisposable
     {
         Assert.Equal(bodies.Count, comments.Count);
 
-        for (var i = 0; i < bodies.Count; i = i + 1)
+        for (var i = 0; i < bodies.Count; i++)
         {
             AssertComment(comments[i], bodies[i], position);
         }

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -1475,7 +1475,7 @@ public class RepositoriesClientTests
             Assert.Empty(result.Names);
 
             var doubleCheck = await _github.Repository.GetAllTopics(_theRepoOwner, _theRepository);
-            Assert.Empty((doubleCheck.Names));
+            Assert.Empty(doubleCheck.Names);
         }
 
         [IntegrationTest]

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -1486,7 +1486,7 @@ public class RepositoriesClientTests
             Assert.Empty(result.Names);
 
             var doubleCheck = await _github.Repository.GetAllTopics(_theRepoOwner, _theRepository);
-            Assert.Empty((doubleCheck.Names));
+            Assert.Empty(doubleCheck.Names);
         }
 
         [IntegrationTest]

--- a/Octokit.Tests.Integration/EnterpriseHelper.cs
+++ b/Octokit.Tests.Integration/EnterpriseHelper.cs
@@ -53,7 +53,7 @@ namespace Octokit.Tests.Integration
         static readonly Lazy<bool> _gitHubEnterpriseEnabled = new Lazy<bool>(() =>
         {
             string enabled = Environment.GetEnvironmentVariable("OCTOKIT_GHE_ENABLED");
-            return !String.IsNullOrWhiteSpace(enabled);
+            return !string.IsNullOrWhiteSpace(enabled);
         });
 
         static readonly Lazy<Uri> _gitHubEnterpriseUrl = new Lazy<Uri>(() =>
@@ -94,7 +94,7 @@ namespace Octokit.Tests.Integration
         {
             get
             {
-                return !String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("OCTOKIT_GHE_OAUTHTOKEN"));
+                return !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("OCTOKIT_GHE_OAUTHTOKEN"));
             }
         }
 

--- a/Octokit.Tests.Integration/Helper.cs
+++ b/Octokit.Tests.Integration/Helper.cs
@@ -107,7 +107,7 @@ namespace Octokit.Tests.Integration
         static Helper()
         {
             // Force reading of environment variables.
-            // This wasn't happening if UserName/Organization were 
+            // This wasn't happening if UserName/Organization were
             // retrieved before Credentials.
             Debug.WriteIf(Credentials == null, "No credentials specified.");
         }
@@ -246,12 +246,9 @@ namespace Octokit.Tests.Integration
         {
             var key = "Octokit.Tests.Integration.fixtures." + fileName;
             var stream = typeof(Helper).GetTypeInfo().Assembly.GetManifestResourceStream(key);
-            if (stream == null)
-            {
-                throw new InvalidOperationException(
+
+            return stream ?? throw new InvalidOperationException(
                     "The file '" + fileName + "' was not found as an embedded resource in the assembly. Failing the test...");
-            }
-            return stream;
         }
 
         public static IGitHubClient GetAuthenticatedClient(bool useSecondUser = false)

--- a/Octokit.Tests.Integration/Helper.cs
+++ b/Octokit.Tests.Integration/Helper.cs
@@ -69,7 +69,7 @@ namespace Octokit.Tests.Integration
         static readonly Lazy<bool> _gitHubAppsEnabled = new Lazy<bool>(() =>
         {
             string enabled = Environment.GetEnvironmentVariable("OCTOKIT_GITHUBAPP_ENABLED");
-            return !String.IsNullOrWhiteSpace(enabled);
+            return !string.IsNullOrWhiteSpace(enabled);
         });
 
         static readonly Lazy<Credentials> _githubAppCredentials = new Lazy<Credentials>(() =>

--- a/Octokit.Tests.Integration/Helpers/GitHubEnterpriseManagementConsoleTestAttribute.cs
+++ b/Octokit.Tests.Integration/Helpers/GitHubEnterpriseManagementConsoleTestAttribute.cs
@@ -24,7 +24,7 @@ namespace Octokit.Tests.Integration
             if (!EnterpriseHelper.IsGitHubEnterpriseEnabled)
                 return Enumerable.Empty<IXunitTestCase>();
 
-            if (String.IsNullOrEmpty(EnterpriseHelper.ManagementConsolePassword))
+            if (string.IsNullOrEmpty(EnterpriseHelper.ManagementConsolePassword))
                 return Enumerable.Empty<IXunitTestCase>();
 
             return new[] { new XunitTestCase(diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), TestMethodDisplayOptions.None, testMethod) };

--- a/Octokit.Tests.Integration/Reactive/ObservableTeamsClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableTeamsClientTests.cs
@@ -261,7 +261,7 @@ public class ObservableTeamsClientTests
                 var observable = client.GetAllRepositories(_team.Id, ApiOptions.None);
                 var repos = await observable.ToList();
 
-                Assert.True(repos.Count() > 0);
+                Assert.True(repos.Any());
                 Assert.NotNull(repos[0].Permissions);
             }
         }

--- a/Octokit.Tests/Clients/AuthorizationsClientTests.cs
+++ b/Octokit.Tests/Clients/AuthorizationsClientTests.cs
@@ -276,7 +276,7 @@ namespace Octokit.Tests.Clients
                 Assert.NotNull(calledBody);
                 var fingerprintProperty = ((IEnumerable<PropertyInfo>)calledBody.GetType().DeclaredProperties).FirstOrDefault(x => x.Name == "fingerprint");
                 Assert.NotNull(fingerprintProperty);
-                Assert.Equal(fingerprintProperty.GetValue(calledBody), "ha-ha-fingerprint");
+                Assert.Equal("ha-ha-fingerprint", fingerprintProperty.GetValue(calledBody));
             }
         }
 

--- a/Octokit.Tests/Clients/AuthorizationsClientTests.cs
+++ b/Octokit.Tests/Clients/AuthorizationsClientTests.cs
@@ -129,7 +129,7 @@ namespace Octokit.Tests.Clients
 
                 client.Received().Put<ApplicationAuthorization>(
                     Arg.Is<Uri>(u => u.ToString() == "authorizations/clients/clientId"),
-                    Arg.Is<Object>(o => o.GetType().GetProperty("client_secret").GetValue(o).ToString() == "secret"));
+                    Arg.Is<object>(o => o.GetType().GetProperty("client_secret").GetValue(o).ToString() == "secret"));
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/AuthorizationsClientTests.cs
+++ b/Octokit.Tests/Clients/AuthorizationsClientTests.cs
@@ -143,7 +143,7 @@ namespace Octokit.Tests.Clients
 
                 client.Received().Put<ApplicationAuthorization>(
                     Arg.Is<Uri>(u => u.ToString() == "authorizations/clients/clientId"),
-                    Arg.Is<Object>(o => o.GetType().GetProperty("client_secret").GetValue(o).ToString() == "secret"),
+                    Arg.Is<object>(o => o.GetType().GetProperty("client_secret").GetValue(o).ToString() == "secret"),
                     "two-factor");
             }
 
@@ -292,7 +292,7 @@ namespace Octokit.Tests.Clients
 
                 client.Received().Post<ApplicationAuthorization>(
                     Arg.Is<Uri>(u => u.ToString() == "applications/clientId/token"),
-                    Arg.Is<Object>(o => o.GetType().GetProperty("access_token").GetValue(o).ToString() == "accessToken"),
+                    Arg.Is<object>(o => o.GetType().GetProperty("access_token").GetValue(o).ToString() == "accessToken"),
                     "application/vnd.github.doctor-strange-preview+json");
             }
 
@@ -321,7 +321,7 @@ namespace Octokit.Tests.Clients
 
                 client.Received().Patch<ApplicationAuthorization>(
                     Arg.Is<Uri>(u => u.ToString() == "applications/clientId/token"),
-                    Arg.Is<Object>(o => o.GetType().GetProperty("access_token").GetValue(o).ToString() == "accessToken"),
+                    Arg.Is<object>(o => o.GetType().GetProperty("access_token").GetValue(o).ToString() == "accessToken"),
                     "application/vnd.github.doctor-strange-preview+json");
             }
 
@@ -350,7 +350,7 @@ namespace Octokit.Tests.Clients
 
                 client.Received().Delete(
                     Arg.Is<Uri>(u => u.ToString() == "applications/clientId/token"),
-                    Arg.Is<Object>(o => o.GetType().GetProperty("access_token").GetValue(o).ToString() == "accessToken"),
+                    Arg.Is<object>(o => o.GetType().GetProperty("access_token").GetValue(o).ToString() == "accessToken"),
                     "application/vnd.github.doctor-strange-preview+json");
             }
 

--- a/Octokit.Tests/Clients/UserAdministrationClientTests.cs
+++ b/Octokit.Tests/Clients/UserAdministrationClientTests.cs
@@ -150,8 +150,8 @@ namespace Octokit.Tests.Clients
                     Arg.Any<Uri>(),
                     Arg.Is<NewImpersonationToken>(a =>
                         a.Scopes.Count() == scopes.Length &&
-                        a.Scopes.ToList().All(s => scopes.Contains(s)) &&
-                        scopes.ToList().All(s => a.Scopes.Contains(s))));
+                        a.Scopes.All(s => scopes.Contains(s)) &&
+                        scopes.All(s => a.Scopes.Contains(s))));
             }
         }
 

--- a/Octokit/Clients/CheckSuitesClient.cs
+++ b/Octokit/Clients/CheckSuitesClient.cs
@@ -274,12 +274,9 @@ namespace Octokit
 
             var httpStatusCode = await Connection.Post(ApiUrls.CheckSuiteRerequest(owner, name, checkSuiteId), null, AcceptHeaders.ChecksApiPreview).ConfigureAwait(false);
 
-            if (httpStatusCode != HttpStatusCode.Created)
-            {
-                throw new ApiException("Invalid Status Code returned. Expected a 201", httpStatusCode);
-            }
-
-            return httpStatusCode == HttpStatusCode.Created;
+            return httpStatusCode != HttpStatusCode.Created
+                ? throw new ApiException("Invalid Status Code returned. Expected a 201", httpStatusCode)
+                : httpStatusCode == HttpStatusCode.Created;
         }
 
         /// <summary>
@@ -296,12 +293,9 @@ namespace Octokit
         {
             var httpStatusCode = await Connection.Post(ApiUrls.CheckSuiteRerequest(repositoryId, checkSuiteId), null, AcceptHeaders.ChecksApiPreview).ConfigureAwait(false);
 
-            if (httpStatusCode != HttpStatusCode.Created)
-            {
-                throw new ApiException("Invalid Status Code returned. Expected a 201", httpStatusCode);
-            }
-
-            return httpStatusCode == HttpStatusCode.Created;
+            return httpStatusCode != HttpStatusCode.Created
+                ? throw new ApiException("Invalid Status Code returned. Expected a 201", httpStatusCode)
+                : httpStatusCode == HttpStatusCode.Created;
         }
     }
 }

--- a/Octokit/Clients/Enterprise/EnterpriseLdapClient.cs
+++ b/Octokit/Clients/Enterprise/EnterpriseLdapClient.cs
@@ -93,10 +93,12 @@ namespace Octokit
             var endpoint = ApiUrls.EnterpriseLdapTeamSync(teamId);
 
             var response = await Connection.Post<LdapSyncResponse>(endpoint).ConfigureAwait(false);
+            if (response.HttpResponse.StatusCode != HttpStatusCode.Created)
+            {
+                throw new ApiException("Invalid Status Code returned. Expected a 201", response.HttpResponse.StatusCode);
+            }
 
-            return response.HttpResponse.StatusCode != HttpStatusCode.Created
-                ? throw new ApiException("Invalid Status Code returned. Expected a 201", response.HttpResponse.StatusCode)
-                : response.Body;
+            return response.Body;
         }
     }
 }

--- a/Octokit/Clients/Enterprise/EnterpriseLdapClient.cs
+++ b/Octokit/Clients/Enterprise/EnterpriseLdapClient.cs
@@ -93,12 +93,10 @@ namespace Octokit
             var endpoint = ApiUrls.EnterpriseLdapTeamSync(teamId);
 
             var response = await Connection.Post<LdapSyncResponse>(endpoint).ConfigureAwait(false);
-            if (response.HttpResponse.StatusCode != HttpStatusCode.Created)
-            {
-                throw new ApiException("Invalid Status Code returned. Expected a 201", response.HttpResponse.StatusCode);
-            }
 
-            return response.Body;
+            return response.HttpResponse.StatusCode != HttpStatusCode.Created
+                ? throw new ApiException("Invalid Status Code returned. Expected a 201", response.HttpResponse.StatusCode)
+                : response.Body;
         }
     }
 }

--- a/Octokit/Clients/Enterprise/EnterpriseLdapClient.cs
+++ b/Octokit/Clients/Enterprise/EnterpriseLdapClient.cs
@@ -51,12 +51,10 @@ namespace Octokit
             var endpoint = ApiUrls.EnterpriseLdapUserSync(userName);
 
             var response = await Connection.Post<LdapSyncResponse>(endpoint).ConfigureAwait(false);
-            if (response.HttpResponse.StatusCode != HttpStatusCode.Created)
-            {
-                throw new ApiException("Invalid Status Code returned. Expected a 201", response.HttpResponse.StatusCode);
-            }
 
-            return response.Body;
+            return response.HttpResponse.StatusCode != HttpStatusCode.Created
+                ? throw new ApiException("Invalid Status Code returned. Expected a 201", response.HttpResponse.StatusCode)
+                : response.Body;
         }
 
         /// <summary>

--- a/Octokit/Clients/OrganizationMembersClient.cs
+++ b/Octokit/Clients/OrganizationMembersClient.cs
@@ -351,13 +351,12 @@ namespace Octokit
             {
                 var response = await Connection.Get<object>(ApiUrls.CheckMember(org, user), null, null).ConfigureAwait(false);
                 var statusCode = response.HttpResponse.StatusCode;
-                if (statusCode != HttpStatusCode.NotFound
-                    && statusCode != HttpStatusCode.NoContent
-                    && statusCode != HttpStatusCode.Found)
-                {
-                    throw new ApiException("Invalid Status Code returned. Expected a 204, a 302 or a 404", statusCode);
-                }
-                return statusCode == HttpStatusCode.NoContent;
+
+                return statusCode == HttpStatusCode.NotFound
+                    || statusCode == HttpStatusCode.NoContent
+                    || statusCode == HttpStatusCode.Found
+                    ? statusCode == HttpStatusCode.NoContent
+                    : throw new ApiException("Invalid Status Code returned. Expected a 204, a 302 or a 404", statusCode);
             }
             catch (NotFoundException)
             {

--- a/Octokit/Exceptions/AbuseException.cs
+++ b/Octokit/Exceptions/AbuseException.cs
@@ -49,8 +49,7 @@ namespace Octokit
             var header = response.Headers.FirstOrDefault(h => string.Equals(h.Key, "Retry-After", StringComparison.OrdinalIgnoreCase));
             if (header.Equals(default(KeyValuePair<string, string>))) { return null; }
 
-            int retrySeconds;
-            if (!int.TryParse(header.Value, out retrySeconds)) { return null; }
+            if (!int.TryParse(header.Value, out int retrySeconds)) { return null; }
             if (retrySeconds < 0) { return null; }
 
             return retrySeconds;

--- a/Octokit/Exceptions/ApiException.cs
+++ b/Octokit/Exceptions/ApiException.cs
@@ -199,8 +199,8 @@ namespace Octokit
             {
                 return HttpResponse != null
                        && !HttpResponse.ContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase)
-                       && HttpResponse.Body is string
-                    ? (string)HttpResponse.Body : string.Empty;
+                       && HttpResponse.Body is string bodyString
+                    ? bodyString : string.Empty;
             }
         }
 

--- a/Octokit/Exceptions/ApiException.cs
+++ b/Octokit/Exceptions/ApiException.cs
@@ -202,7 +202,7 @@ namespace Octokit
                 return HttpResponse != null
                        && !HttpResponse.ContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase)
                        && HttpResponse.Body is string bodyString
-                    ? bodyst : string.Empty;
+                    ? bodyString : string.Empty;
             }
         }
 

--- a/Octokit/Exceptions/ApiException.cs
+++ b/Octokit/Exceptions/ApiException.cs
@@ -180,12 +180,9 @@ namespace Octokit
         {
             get
             {
-                if (ApiError != null && !string.IsNullOrWhiteSpace(ApiError.Message))
-                {
-                    return ApiError.Message;
-                }
-
-                return null;
+                return ApiError != null && !string.IsNullOrWhiteSpace(ApiError.Message)
+                    ? ApiError.Message
+                    : null;
             }
         }
 

--- a/Octokit/Exceptions/ApiException.cs
+++ b/Octokit/Exceptions/ApiException.cs
@@ -134,8 +134,10 @@ namespace Octokit
                     return _jsonSerializer.Deserialize<ApiError>(responseContent) ?? new ApiError(responseContent);
                 }
             }
-            catch (Exception)
+            catch (Exception e)
             {
+                // Complete handling or remove catch block
+                throw;
             }
 
             return new ApiError(responseContent);
@@ -200,7 +202,7 @@ namespace Octokit
                 return HttpResponse != null
                        && !HttpResponse.ContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase)
                        && HttpResponse.Body is string bodyString
-                    ? bodyString : string.Empty;
+                    ? bodyst : string.Empty;
             }
         }
 

--- a/Octokit/Helpers/ApiErrorExtensions.cs
+++ b/Octokit/Helpers/ApiErrorExtensions.cs
@@ -9,7 +9,7 @@ namespace Octokit
             if (apiError == null) return null;
             if (apiError.Errors == null) return apiError.Message;
             var firstError = apiError.Errors.FirstOrDefault();
-            return firstError == null ? null : firstError.Message;
+            return firstError?.Message;
         }
     }
 }

--- a/Octokit/Helpers/CollectionExtensions.cs
+++ b/Octokit/Helpers/CollectionExtensions.cs
@@ -15,18 +15,12 @@ namespace Octokit
 
         public static IList<string> Clone(this IReadOnlyList<string> input)
         {
-            if (input == null)
-                return null;
-
-            return input.Select(item => new string(item.ToCharArray())).ToList();
+            return input?.Select(item => new string(item.ToCharArray())).ToList();
         }
 
         public static IDictionary<string, Uri> Clone(this IReadOnlyDictionary<string, Uri> input)
         {
-            if (input == null)
-                return null;
-
-            return input.ToDictionary(item => new string(item.Key.ToCharArray()), item => new Uri(item.Value.ToString()));
+            return input?.ToDictionary(item => new string(item.Key.ToCharArray()), item => new Uri(item.Value.ToString()));
         }
     }
 }

--- a/Octokit/Helpers/CollectionExtensions.cs
+++ b/Octokit/Helpers/CollectionExtensions.cs
@@ -10,8 +10,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNull(dictionary, nameof(dictionary));
 
-            TValue value;
-            return dictionary.TryGetValue(key, out value) ? value : default(TValue);
+            return dictionary.TryGetValue(key, out TValue value) ? value : default;
         }
 
         public static IList<string> Clone(this IReadOnlyList<string> input)

--- a/Octokit/Http/ApiInfo.cs
+++ b/Octokit/Http/ApiInfo.cs
@@ -74,7 +74,7 @@ namespace Octokit
                                OauthScopes.Clone(),
                                AcceptedOauthScopes.Clone(),
                                Etag != null ? new string(Etag.ToCharArray()) : null,
-                               RateLimit != null ? RateLimit.Clone() : null,
+                               RateLimit?.Clone(),
                                ServerTimeDifference);
         }
     }

--- a/Octokit/Http/ApiResponse.cs
+++ b/Octokit/Http/ApiResponse.cs
@@ -39,9 +39,9 @@
 
         static T GetBodyAsObject(IResponse response)
         {
-            var body = response.Body;
-            if (body is T) return (T)body;
-            return default(T);
+            return response.Body is T tBody
+                ? tBody
+                : default;
         }
     }
 }

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -168,7 +168,7 @@ namespace Octokit
             // on thread writing to the object while another was reading.  Now we are cloning the ApiInfo on request - thus removing the need (or overhead)
             // of putting locks in place.
             // See https://github.com/octokit/octokit.net/pull/855#discussion_r36774884
-            return _lastApiInfo == null ? null : _lastApiInfo.Clone();
+            return _lastApiInfo?.Clone();
         }
         private ApiInfo _lastApiInfo;
 

--- a/Octokit/Http/HttpClientAdapter.cs
+++ b/Octokit/Http/HttpClientAdapter.cs
@@ -205,9 +205,9 @@ namespace Octokit.Internal
 
         protected virtual void Dispose(bool disposing)
         {
-            if (disposing)
+            if (disposing && _http != null)
             {
-                if (_http != null) _http.Dispose();
+                _http.Dispose();
             }
         }
 
@@ -222,7 +222,7 @@ namespace Octokit.Internal
             var receivedTime = DateTimeOffset.Now;
             // Since Properties are stored as objects, serialize to HTTP round-tripping string (Format: r)
             // Resolution is limited to one-second, matching the resolution of the HTTP Date header
-            request.Properties[ApiInfoParser.ReceivedTimeHeaderName] = 
+            request.Properties[ApiInfoParser.ReceivedTimeHeaderName] =
                 receivedTime.ToString("r", CultureInfo.InvariantCulture);
 
             // Can't redirect without somewhere to redirect to.

--- a/Octokit/Http/ProductHeaderValue.cs
+++ b/Octokit/Http/ProductHeaderValue.cs
@@ -96,8 +96,7 @@
         public static bool TryParse(string input,
             out ProductHeaderValue parsedValue)
         {
-            System.Net.Http.Headers.ProductHeaderValue value;
-            var result = System.Net.Http.Headers.ProductHeaderValue.TryParse(input, out value);
+            var result = System.Net.Http.Headers.ProductHeaderValue.TryParse(input, out System.Net.Http.Headers.ProductHeaderValue value);
             parsedValue = result ? Parse(input) : null;
             return result;
         }

--- a/Octokit/Models/Request/RequestParameters.cs
+++ b/Octokit/Models/Request/RequestParameters.cs
@@ -84,12 +84,10 @@ namespace Octokit
             {
                 // GitHub does not recognize title-case boolean values as arguments.
                 // We need to convert them to lowercase.
-                return (prop, value) => value != null ? value.ToString().ToLowerInvariant() : null;
+                return (prop, value) => value?.ToString().ToLowerInvariant();
             }
 
-            return (prop, value) => value != null
-                ? value.ToString()
-                : null;
+            return (prop, value) => value?.ToString();
         }
 
         static string GetParameterAttributeValueForEnumName(Type enumType, string name)
@@ -100,7 +98,7 @@ namespace Octokit
             var attribute = member.GetCustomAttributes(typeof(ParameterAttribute), false)
                 .Cast<ParameterAttribute>()
                 .FirstOrDefault();
-            return attribute != null ? attribute.Value : null;
+            return attribute?.Value;
         }
 
         class PropertyParameter

--- a/Octokit/Models/Response/Issue.cs
+++ b/Octokit/Models/Response/Issue.cs
@@ -170,13 +170,9 @@ namespace Octokit
                 ? new int?()
                 : Milestone.Number;
 
-            var assignees = Assignees == null
-                ? null
-                : Assignees.Select(x => x.Login);
+            var assignees = Assignees?.Select(x => x.Login);
 
-            var labels = Labels == null
-                ? null
-                : Labels.Select(x => x.Name);
+            var labels = Labels?.Select(x => x.Name);
 
             ItemState state;
             var issueUpdate = new IssueUpdate

--- a/Octokit/Models/Response/Issue.cs
+++ b/Octokit/Models/Response/Issue.cs
@@ -174,12 +174,11 @@ namespace Octokit
 
             var labels = Labels?.Select(x => x.Name);
 
-            ItemState state;
             var issueUpdate = new IssueUpdate
             {
                 Body = Body,
                 Milestone = milestoneId,
-                State = (State.TryParse(out state) ? (ItemState?)state : null),
+                State = (State.TryParse(out ItemState state) ? (ItemState?)state : null),
                 Title = Title
             };
 

--- a/Octokit/Models/Response/RepositoryContent.cs
+++ b/Octokit/Models/Response/RepositoryContent.cs
@@ -39,9 +39,7 @@ namespace Octokit
         {
             get
             {
-                return EncodedContent != null
-                    ? EncodedContent.FromBase64String()
-                    : null;
+                return EncodedContent?.FromBase64String();
             }
         }
 

--- a/Octokit/Models/Response/StringEnum.cs
+++ b/Octokit/Models/Response/StringEnum.cs
@@ -100,7 +100,7 @@ namespace Octokit
 
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj))
+            if (obj is null)
             {
                 return false;
             }


### PR DESCRIPTION
Main changes:

- Replaced throws and returns in if statements with conditionals
- Replaced defining of null based on null checks with null propagation
- Simplified condition logic to speed up execution
- Inline declaration of variables
- Simplified Object and String to they're keyword counterparts
- Merged if statements
- Replaced cast with pattern matching
- Used the ++ operator instead of i = i + 1
- Replaced Count() > 0 with Any() as to stop the LINQ yielding after the first item
- Removed unnecessary creations of lists from enumerables in LINQ expresisons
- Made an empty catch block throw the caught exception with a notice to complete the handling