### PR TITLE
fix: links into github documentation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,11 +6,11 @@ The easiest way to get started with Octokit is to use a plain `GitHubClient`:
 var client = new GitHubClient(new ProductHeaderValue("my-cool-app"));
 ```
 
-This will let you access unauthenticated GitHub APIs, but you will be subject to rate limiting (you can read more about this [here](https://developer.github.com/v3/#rate-limiting)).
+This will let you access unauthenticated GitHub APIs, but you will be subject to rate limiting (you can read more about this [here](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting)).
 
 But why do you need this `ProductHeaderValue` value?
 
-The API will reject you if you don't provide a `User-Agent` header (more details [here](https://developer.github.com/v3/#user-agent-required)). This is also to identify applications that are accessing the API and enable GitHub to contact the application author if there are problems. So pick a name that stands out!
+The API will reject you if you don't provide a `User-Agent` header (more details [here](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#user-agent-required)). This is also to identify applications that are accessing the API and enable GitHub to contact the application author if there are problems. So pick a name that stands out!
 
 ### Authenticated Access
 


### PR DESCRIPTION
I was just curious to know about that `ProductHeaderValue` type and found references in this file. However the links were not 404's but also not what was originally intended. I didn't check the whole file, just these two URLs.