### PR TITLE
Deployment task is arbitrary string value

### DIFF
--- a/Octokit.Tests/Models/DeploymentTests.cs
+++ b/Octokit.Tests/Models/DeploymentTests.cs
@@ -17,7 +17,7 @@ namespace Octokit.Tests.Models
             };
             var deserialized = new SimpleJsonSerializer().Serialize(deployment);
             
-            Assert.Equal(@"{""ref"":""ref"",""task"":""deploy"",""payload"":{""environment"":""production""}}", deserialized);
+            Assert.Equal(@"{""ref"":""ref"",""payload"":{""environment"":""production""}}", deserialized);
         }
 
         [Fact]
@@ -50,7 +50,8 @@ namespace Octokit.Tests.Models
                     ""created_at"": ""2012-07-20T01:19:13Z"",
                     ""updated_at"": ""2012-07-20T01:19:13Z"",
                     ""description"": ""Deploy request from hubot"",
-                    ""statuses_url"": ""https://api.github.com/repos/octocat/example/deployments/1/statuses""
+                    ""statuses_url"": ""https://api.github.com/repos/octocat/example/deployments/1/statuses"",
+                    ""task"": ""deploy""
                 }";
 
             var actual = new SimpleJsonSerializer().Deserialize<Deployment>(json);
@@ -63,6 +64,7 @@ namespace Octokit.Tests.Models
             Assert.Equal(DateTimeOffset.Parse("2012-07-20T01:19:13Z"), actual.UpdatedAt);
             Assert.Equal("Deploy request from hubot", actual.Description);
             Assert.Equal("https://api.github.com/repos/octocat/example/deployments/1/statuses", actual.StatusesUrl);
+            Assert.Equal("deploy", actual.Task);
         }
     }
 }

--- a/Octokit/Models/Request/NewDeployment.cs
+++ b/Octokit/Models/Request/NewDeployment.cs
@@ -33,12 +33,9 @@ namespace Octokit
 
         /// <summary>
         /// Gets or sets the optional task used to specify a task to execute, e.g. deploy or deploy:migrations. 
-        /// Default: deploy
+        /// Default if not specified: deploy
         /// </summary>
-        /// <value>
-        /// The task.
-        /// </value>
-        public DeployTask Task { get; set; }
+        public string Task { get; set; }
 
         /// <summary>
         /// Merges the default branch into the requested deployment branch if true;
@@ -94,23 +91,5 @@ namespace Octokit
                 return string.Format(CultureInfo.InvariantCulture, "Description: {0}", Description);
             }
         }
-    }
-
-    /// <summary>
-    /// The types of deployments tasks that are available.
-    /// </summary>
-    public enum DeployTask
-    {
-        /// <summary>
-        /// Deploy everything (default)
-        /// </summary>
-        [Parameter(Value = "deploy")]
-        Deploy,
-
-        /// <summary>
-        /// Deploy migrations only.
-        /// </summary>
-        [Parameter(Value = "deploy:migrations")]
-        DeployMigrations
     }
 }

--- a/Octokit/Models/Response/Deployment.cs
+++ b/Octokit/Models/Response/Deployment.cs
@@ -13,7 +13,7 @@ namespace Octokit
     {
         public Deployment() { }
 
-        public Deployment(int id, string nodeId, string sha, string url, User creator, IReadOnlyDictionary<string, string> payload, DateTimeOffset createdAt, DateTimeOffset updatedAt, string description, string statusesUrl, bool transientEnvironment, bool productionEnvironment)
+        public Deployment(int id, string nodeId, string sha, string url, User creator, IReadOnlyDictionary<string, string> payload, DateTimeOffset createdAt, DateTimeOffset updatedAt, string description, string statusesUrl, bool transientEnvironment, bool productionEnvironment, string task)
         {
             Id = id;
             NodeId = nodeId;
@@ -27,6 +27,7 @@ namespace Octokit
             StatusesUrl = statusesUrl;
             TransientEnvironment = transientEnvironment;
             ProductionEnvironment = productionEnvironment;
+            Task = task;
         }
 
         /// <summary>
@@ -88,6 +89,11 @@ namespace Octokit
         /// Indicates if the environment is one with which end users directly interact.
         /// </summary>
         public bool ProductionEnvironment { get; protected set; }
+
+        /// <summary>
+        /// Specifies a task to execute (e.g., deploy or deploy:migrations)
+        /// </summary>
+        public string Task { get; protected set; }
 
         internal string DebuggerDisplay
         {


### PR DESCRIPTION
- Changed `NewDeployment` Task property to `string`
- Added `string Task` property to `Deployment` response
- Updated tests

Changes here align the project to the intended usage based on the documentation linked below.

> The task parameter is used by the deployment system to allow different execution paths. In the web world this might be `deploy:migrations` to run schema changes on the system. In the compiled world this could be a flag to compile an application with debugging enabled.

https://docs.github.com/en/rest/reference/deployments#create-a-deployment

Fixes #2412