### PR TITLE
Update permissions based on GitHub documentation

### DIFF
--- a/Octokit/Models/Request/Permission.cs
+++ b/Octokit/Models/Request/Permission.cs
@@ -14,7 +14,19 @@ namespace Octokit
         /// </summary>
         [Parameter(Value = "admin")]
         Admin,
-
+                
+        /// <summary>
+        ///  team members can manage the repository without access to sensitive or destructive actions. Recommended for project managers. Only applies to repositories owned by organizations.
+        /// </summary>
+        [Parameter(Value = "maintain")]
+        Maintain,
+        
+        /// <summary>
+        ///   team members can proactively manage issues and pull requests without write access. Recommended for contributors who triage a repository. Only applies to repositories owned by organizations.
+        /// </summary>
+        [Parameter(Value = "triage")]
+        Triage,
+        
         /// <summary>
         /// team members can pull and push, but not administer these repositories
         /// </summary>


### PR DESCRIPTION
Added the following permissions maintain and triage based on the GitHub documentation

https://docs.github.com/en/rest/reference/teams#add-or-update-team-repository-permissions