### PR TITLE
Creates the config file for stalebot to help us clean up old/inactive issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,40 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale (approx. 9 months)
+daysUntilStale: 270
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually but will remain marked as stale.
+daysUntilClose: 7
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: []
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - pinned
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  Hey Friends, this issue has been automatically marked as `stale` because it has not had
+  recent activity. It will be closed if no further activity occurs. Please add the 
+  `pinned` label if you feel that this issue needs to remain open/active. 
+  Thank you for your contributions and help in keeping things tidy!
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+only: issues


### PR DESCRIPTION
We are in need of some house cleaning to get us back to a good "supported" state.  This will activate the stalebot to help us parse through any issues that are either no longer relevant, need to be rethought, or are not able to be addressed.  

Note:  It's not that these issues are not important or useful.  We simply need a clear starting point to begin actively introducing improvements and changes into this SDK.  If anyone feels like the issues that are marked as stale from the bot still need to be opened they can label them with the `pinned` and `followup-needed` labels with some details on the current state of things so that it will not auto close. That way we can have a closer look at the issue and see what we need to do to get it resolved.