### PR TITLE
Configure the project for GitHub Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/dotnet/sdk:3.1
+WORKDIR /home/
+COPY . .
+RUN bash ./setup.sh

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+  "name": "Octokit.NET",
+  "extensions": [
+		"formulahendry.dotnet-test-explorer",
+    "eamodio.gitlens",
+    "fernandoescolar.vscode-solution-explorer",
+    "ms-dotnettools.csharp",
+    "redhat.vscode-yaml",
+  ],
+  "dockerFile": "Dockerfile",
+  "containerEnv": {
+    // Enable detection of running in a container
+    "DOTNET_RUNNING_IN_CONTAINER": "true",
+    // Enable correct mode for dotnet watch (only mode supported in a container)
+    "DOTNET_USE_POLLING_FILE_WATCHER": "true",
+    // Skip extraction of XML docs - generally not useful within an image/container - helps perfomance
+    "NUGET_XMLDOC_MODE": "true"
+  }
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,3 @@
+apt-get update
+apt-get install -y python3 python3-pip
+pip3 install mkdocs

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,7 +2,7 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "build",
+      "label": "Build",
       "command": "dotnet",
       "type": "shell",
       "args": [
@@ -28,6 +28,89 @@
         "reveal": "silent"
       },
       "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "Run docs server",
+      "command": "mkdocs",
+      "type": "shell",
+      "args": ["serve"],
+      "presentation": {
+        "reveal": "silent",
+        "revealProblems": "onProblem"
+      }
+    }
+  ]
+}
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build",
+      "command": "dotnet",
+      "type": "shell",
+      "args": [
+        "build",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "reveal": "silent"
+      },
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "Unit Tests",
+      "command": "./build.sh",
+      "type": "shell",
+      "args": [
+        "--target=UnitTests"
+      ],
+      "group": {
+        "kind": "test"
+      },
+      "presentation": {
+        "reveal": "always"
+      },
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "Convention Tests",
+      "command": "./build.sh",
+      "type": "shell",
+      "args": [
+        "--target=ConventionTests"
+      ],
+      "group": {
+        "kind": "test"
+      },
+      "presentation": {
+        "reveal": "always"
+      },
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "Format",
+      "command": "dotnet",
+      "type": "shell",
+      "args": ["format"],
+      "presentation": {
+        "reveal": "silent"
+      },
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "Docs",
+      "command": "mkdocs",
+      "type": "shell",
+      "args": ["serve"],
+      "presentation": {
+        "reveal": "silent",
+        "revealProblems": "onProblem"
+      }
     }
   ]
 }


### PR DESCRIPTION
This adds a simple Codespaces configuration, `.devcontainer/devcontainer.json`, to the project.

It uses v3.1 of the .NET Core SDK from Docker Hub, installs Python 3 and `mkdocs` to support building the docs and includes useful VS Code extensions for working on the project.

I also improve the Visual Studio Code tasks definitions (`.vscode/ tasks.json`), adding pre-defined tasks for running unit and convention tests and building the docs.

Codespaces magic means that, when you build the docs, the port will automatically be opened so you can view the docs in real time at `localhost:4000`.