### PR TITLE
Tweak `User-Agent` to refer to `Octokit.net`, not just `Octokit`

### DIFF
--- a/Octokit.Tests/Http/ConnectionTests.cs
+++ b/Octokit.Tests/Http/ConnectionTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -749,6 +749,7 @@ namespace Octokit.Tests.Http
 
                 Assert.Equal(new Uri("https://github.com/"), connection.BaseAddress);
                 Assert.StartsWith("OctokitTests (", connection.UserAgent);
+                Assert.Contains("Octokit.net", connection.UserAgent);
             }
         }
 

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -763,7 +763,7 @@ namespace Octokit
 
         static string FormatUserAgent(ProductHeaderValue productInformation)
         {
-            return string.Format(CultureInfo.InvariantCulture, "{0} ({1}; {2}; Octokit {3})",
+            return string.Format(CultureInfo.InvariantCulture, "{0} ({1}; {2}; Octokit.net {3})",
                 productInformation,
                 GetPlatformInformation(),
                 GetCultureInformation(),


### PR DESCRIPTION
This improves the `User-Agent` header sent by Octokit.net to explicitly refer to `Octokit.net`, rather than just `Octokit`. This will make it easier to identify requests from this SDK in GitHub logs and other reporting.