### PR TITLE
Fix the Visual Studio Code tasks configuration file

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -20,49 +20,6 @@
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "Format",
-      "command": "dotnet",
-      "type": "shell",
-      "args": ["format"],
-      "presentation": {
-        "reveal": "silent"
-      },
-      "problemMatcher": "$msCompile"
-    },
-    {
-      "label": "Run docs server",
-      "command": "mkdocs",
-      "type": "shell",
-      "args": ["serve"],
-      "presentation": {
-        "reveal": "silent",
-        "revealProblems": "onProblem"
-      }
-    }
-  ]
-}
-{
-  "version": "2.0.0",
-  "tasks": [
-    {
-      "label": "Build",
-      "command": "dotnet",
-      "type": "shell",
-      "args": [
-        "build",
-        "/property:GenerateFullPaths=true",
-        "/consoleloggerparameters:NoSummary"
-      ],
-      "group": {
-        "kind": "build",
-        "isDefault": true
-      },
-      "presentation": {
-        "reveal": "silent"
-      },
-      "problemMatcher": "$msCompile"
-    },
-    {
       "label": "Unit Tests",
       "command": "./build.sh",
       "type": "shell",


### PR DESCRIPTION
This fixes the Visual Studio Code tasks configuration file (`.vscode/tasks.json`), which somehow got corrupted, meaning that it was no longer valid and didn't work.