### PR TITLE
Explicitly configure identation settings for VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,14 @@
 {
-    "files.exclude": {
-        "**/bin": true,
-        "**/obj": true,
-        "**/packaging": true,
-        "**/coverage-results": true
-    },
-    "files.trimTrailingWhitespace": true,
-    "files.trimFinalNewlines": true,
-    "files.insertFinalNewline": true
+  "files.exclude": {
+    "**/bin": true,
+    "**/obj": true,
+    "**/packaging": true,
+    "**/coverage-results": true
+  },
+  "files.trimTrailingWhitespace": true,
+  "files.trimFinalNewlines": true,
+  "files.insertFinalNewline": true,
+  "editor.detectIndentation": false,
+  "editor.tabSize": 2,
+  "editor.insertSpaces": true
 }


### PR DESCRIPTION
This adds explicit configuration to `.vscode/settings.json` so we use two spaces for indentation, rather than relying on the user's own settings or automatic detection. It also fixes the indentation of the settings file itself 😂 😓 