### PR TITLE
[WIP] Fixed emojis return type

### DIFF
--- a/Octokit.Reactive/Clients/IObservableMiscellaneousClient.cs
+++ b/Octokit.Reactive/Clients/IObservableMiscellaneousClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Octokit.Reactive
@@ -12,7 +13,7 @@ namespace Octokit.Reactive
         /// <returns>An <see cref="IObservable{Emoji}"/> of emoji and their URI.</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate",
             Justification = "Makes a network request")]
-        IObservable<Emoji> GetAllEmojis();
+        IObservable<KeyValuePair<string, Uri>> GetAllEmojis();
 
         /// <summary>
         /// Gets the rendered Markdown for an arbitrary markdown document.

--- a/Octokit.Reactive/Clients/ObservableMiscellaneousClient.cs
+++ b/Octokit.Reactive/Clients/ObservableMiscellaneousClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
@@ -21,7 +22,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>An <see cref="IObservable{Emoji}"/> of emoji and their URI.</returns>
-        public IObservable<Emoji> GetAllEmojis()
+        public IObservable<KeyValuePair<string, Uri>> GetAllEmojis()
         {
             return _client.GetAllEmojis().ToObservable().SelectMany(e => e);
         }

--- a/Octokit/Clients/IMiscellaneousClient.cs
+++ b/Octokit/Clients/IMiscellaneousClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
@@ -19,7 +20,7 @@ namespace Octokit
         /// <returns>An <see cref="IReadOnlyDictionary{TKey,TValue}"/> of emoji and their URI.</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
-        Task<IReadOnlyList<Emoji>> GetAllEmojis();
+        Task<IReadOnlyDictionary<string, Uri>> GetAllEmojis();
 
         /// <summary>
         /// Gets the rendered Markdown for the specified plain-text Markdown document.

--- a/Octokit/Clients/MiscellaneousClient.cs
+++ b/Octokit/Clients/MiscellaneousClient.cs
@@ -28,9 +28,9 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>An <see cref="IReadOnlyDictionary{TKey,TValue}"/> of emoji and their URI.</returns>
         [ManualRoute("GET", "/emojis")]
-        public Task<IReadOnlyList<Emoji>> GetAllEmojis()
+        public Task<IReadOnlyDictionary<string, Uri>> GetAllEmojis()
         {
-            return ApiConnection.GetAll<Emoji>(ApiUrls.Emojis());
+            return ApiConnection.Get<IReadOnlyDictionary<string, Uri>>(ApiUrls.Emojis());
         }
 
         /// <summary>


### PR DESCRIPTION
There is a problem with the current return type of github emojis endpoint. 
At the moment `MiscellaneousClient.GetAllEmojis()` try to return this data format:

```
[
	  {
		"name": "+1",
		"url": "https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png?v8"
	  },
	...
]
```

But the current github api format is:

```
{
	"+1": "https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png?v8"
	"-1": "https://github.githubassets.com/images/icons/emoji/unicode/1f44e.png?v8",
	...
}
```
The consequence is that  `MiscellaneousClient.GetAllEmojis()` currently returns an empty set.
So I've updated octokit in order to use the new Github API response format and fix  `MiscellaneousClient.GetAllEmojis()`