### PR TITLE
Adds mono-complete to the dev container 

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,3 +11,5 @@ COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet/shared /usr/share
 # # Add mkdocs for doc generation
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive && apt-get -y install --no-install-recommends python3-pip
 RUN pip3 install mkdocs
+
+RUN apt-get install -y mono-complete


### PR DESCRIPTION
This dependency is needed to run the tests successfully from code spaces.

Note: prebuilds are enabled on main, so that if you create a branch from main you'll not have to worry about the spin-up time from docker generating the environment.

I tried other versions of mono from the Linux [packages](https://www.mono-project.com/download/stable/#download-lin) listed on mono-project and this seemed to be the only one that would not result in tests throwing errors. I'll need to take a sidebar to determine why mono complete is needed here.