### PR TITLE
Fix null reference access when ContentType is null

### DIFF
--- a/Octokit.Tests/Exceptions/ApiExceptionTests.cs
+++ b/Octokit.Tests/Exceptions/ApiExceptionTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 #if !NO_SERIALIZABLE
@@ -135,6 +136,16 @@ namespace Octokit.Tests.Exceptions
             public void DoesNotThrowIfBodyIsNotDefined()
             {
                 var response = CreateResponse(HttpStatusCode.GatewayTimeout);
+
+                var exception = new ApiException(response);
+                var stringRepresentation = exception.ToString();
+                Assert.NotNull(stringRepresentation);
+            }
+
+            [Fact]
+            public void DoesNotThrowIfContentTypeIsNotDefined()
+            {
+                var response = CreateResponse(HttpStatusCode.GatewayTimeout, null, new Dictionary<string, string>(), null);
 
                 var exception = new ApiException(response);
                 var stringRepresentation = exception.ToString();

--- a/Octokit/Exceptions/ApiException.cs
+++ b/Octokit/Exceptions/ApiException.cs
@@ -200,7 +200,7 @@ namespace Octokit
         {
             get
             {
-                return HttpResponse != null
+                return HttpResponse?.ContentType != null
                        && !HttpResponse.ContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase)
                        && HttpResponse.Body is string
                     ? (string)HttpResponse.Body : string.Empty;


### PR DESCRIPTION
When we receive an ApiException and the ContentType is null, if we try to log the message (or otherwise call the ToString method), we're throwing an NullReferenceException because HttpResponseBodySafe is accessing ContentType without checking if it's null.