### PR TITLE
move deprecation warning from subscribers_count to watchers_count.

### DIFF
--- a/Octokit/Models/Response/Repository.cs
+++ b/Octokit/Models/Response/Repository.cs
@@ -108,6 +108,7 @@ namespace Octokit
 
         public int StargazersCount { get; protected set; }
 
+        [Obsolete("WatchersCount returns the same data as StargazersCount. You are likely looking to use SubscribersCount. Update your code to use SubscribersCount, as this field will stop containing data in the future")]
         public int WatchersCount { get; protected set; }
 
         public string DefaultBranch { get; protected set; }
@@ -142,7 +143,6 @@ namespace Octokit
 
         public bool HasPages { get; protected set; }
 
-        [Obsolete("Update your code to use WatchersCount as this field will stop containing data in the future")]
         public int SubscribersCount { get; protected set; }
 
         public long Size { get; protected set; }


### PR DESCRIPTION
Subscribers_count shows the actual watchers_count. Many people think they are retrieving the watchers_count, but are actually retrieving the stargazers_count...
This is because the GitHub UI is still calling subscribers, "Watchers".
To prevent many others from falling into this trap, a warning should be added to the watchers_count property.

On top of this, subscribers_count is no longer deprecated as far as the GitHub documentation goes.

Fixes #2509

Signed-off-by: Brend Smits <brend.smits@philips.com>