### PR TITLE
Drop support for .NET 4.6

### DIFF
--- a/Octokit.Reactive/Octokit.Reactive.csproj
+++ b/Octokit.Reactive/Octokit.Reactive.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reactive" Version="4.4.1" />
+    <PackageReference Include="System.Reactive" Version="5.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
   </ItemGroup>
 </Project>

--- a/Octokit.Reactive/Octokit.Reactive.csproj
+++ b/Octokit.Reactive/Octokit.Reactive.csproj
@@ -6,7 +6,7 @@
     <Authors>GitHub</Authors>
     <Version>0.0.0-dev</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Octokit.Reactive</AssemblyName>
     <PackageId>Octokit.Reactive</PackageId>
     <DebugType>embedded</DebugType>

--- a/Octokit.Reactive/Octokit.Reactive.csproj
+++ b/Octokit.Reactive/Octokit.Reactive.csproj
@@ -6,7 +6,7 @@
     <Authors>GitHub</Authors>
     <Version>0.0.0-dev</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Octokit.Reactive</AssemblyName>
     <PackageId>Octokit.Reactive</PackageId>
     <DebugType>embedded</DebugType>
@@ -19,11 +19,8 @@
     <Copyright>Copyright GitHub 2017</Copyright>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
-  </PropertyGroup>
-
   <PropertyGroup>
+    <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
     <NoWarn>1591;1701;1702;1705</NoWarn>
   </PropertyGroup>
 
@@ -44,11 +41,4 @@
     <PackageReference Include="System.Reactive" Version="4.4.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
   </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
-  </ItemGroup>
-
 </Project>

--- a/Octokit.Reactive/Octokit.Reactive.csproj
+++ b/Octokit.Reactive/Octokit.Reactive.csproj
@@ -20,7 +20,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
     <NoWarn>1591;1701;1702;1705</NoWarn>
   </PropertyGroup>
 

--- a/Octokit.Reactive/Octokit.Reactive.csproj
+++ b/Octokit.Reactive/Octokit.Reactive.csproj
@@ -7,6 +7,7 @@
     <Version>0.0.0-dev</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <AssemblyName>Octokit.Reactive</AssemblyName>
     <PackageId>Octokit.Reactive</PackageId>
     <DebugType>embedded</DebugType>

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -531,35 +531,6 @@ public class RepositoriesClientTests
         }
 
         [IntegrationTest]
-        public async Task UpdatesNameObsolete()
-        {
-            using (var repoContext = await _github.CreateUserRepositoryContext())
-            {
-                var updatedName = Helper.MakeNameWithTimestamp("updated-repo");
-                var update = new RepositoryUpdate() { Name = updatedName };
-
-                var updatedRepository = await _github.Repository.Edit(repoContext.RepositoryOwner, repoContext.RepositoryName, update);
-
-                Assert.Equal(update.Name, updatedRepository.Name);
-            }
-        }
-
-        [IntegrationTest]
-        public async Task UpdatesNameWithRepositoryIdObsolete()
-        {
-            using (var repoContext = await _github.CreateUserRepositoryContext())
-            {
-                var updatedName = Helper.MakeNameWithTimestamp("updated-repo");
-                var update = new RepositoryUpdate() { Name = updatedName };
-
-
-                var updatedRepository = await _github.Repository.Edit(repoContext.RepositoryId, update);
-
-                Assert.Equal(update.Name, updatedRepository.Name);
-            }
-        }
-
-        [IntegrationTest]
         public async Task UpdatesDescription()
         {
             using (var repoContext = await _github.CreateUserRepositoryContext())

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -536,7 +536,7 @@ public class RepositoriesClientTests
             using (var repoContext = await _github.CreateUserRepositoryContext())
             {
                 var updatedName = Helper.MakeNameWithTimestamp("updated-repo");
-                var update = new RepositoryUpdate(updatedName);
+                var update = new RepositoryUpdate() { Name = updatedName };
 
                 var updatedRepository = await _github.Repository.Edit(repoContext.RepositoryOwner, repoContext.RepositoryName, update);
 
@@ -550,7 +550,8 @@ public class RepositoriesClientTests
             using (var repoContext = await _github.CreateUserRepositoryContext())
             {
                 var updatedName = Helper.MakeNameWithTimestamp("updated-repo");
-                var update = new RepositoryUpdate(updatedName);
+                var update = new RepositoryUpdate() { Name = updatedName };
+
 
                 var updatedRepository = await _github.Repository.Edit(repoContext.RepositoryId, update);
 
@@ -811,7 +812,7 @@ public class RepositoriesClientTests
                 Assert.True(editedRepository.AllowAutoMerge);
             }
         }
-        
+
         [IntegrationTest]
         public async Task UpdatesDeleteBranchOnMergeMethod()
         {
@@ -826,7 +827,7 @@ public class RepositoriesClientTests
                 Assert.True(repository.DeleteBranchOnMerge);
             }
         }
-        
+
         [IntegrationTest]
         public async Task UpdatesDeleteBranchOnMergeMethodWithRepositoryId()
         {
@@ -1047,7 +1048,7 @@ public class RepositoriesClientTests
             Assert.Equal("mit", repository.License.Key);
             Assert.Equal("MIT License", repository.License.Name);
         }
-        
+
         [IntegrationTest]
         public async Task ReturnsRepositoryDeleteBranchOnMergeOptions()
         {
@@ -2099,10 +2100,10 @@ public class RepositoriesClientTests
             using (var repoContext = await _github.CreateUserRepositoryContext())
             {
                 await _github.Repository.Content.CreateFile(repoContext.RepositoryOwner, repoContext.RepositoryName, ".github/codeowners", new CreateFileRequest("Create codeowners", @"* snyrting6@hotmail.com"));
-                
+
                 // Sometimes it takes a second to create the file
                 Thread.Sleep(TimeSpan.FromSeconds(2));
-                
+
                 var license = await _github.Repository.GetAllCodeOwnersErrors(repoContext.RepositoryOwner, repoContext.RepositoryName);
                 Assert.NotEmpty(license.Errors);
             }

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -1129,7 +1129,7 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
-                var update = new RepositoryUpdate("repo");
+                var update = new RepositoryUpdate() { Name= "repo" };
 
                 client.Edit("owner", "repo", update);
 
@@ -1143,7 +1143,7 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
-                var update = new RepositoryUpdate("repo");
+                var update = new RepositoryUpdate() { Name= "repo" };
 
                 client.Edit(1, update);
 
@@ -1155,7 +1155,7 @@ namespace Octokit.Tests.Clients
             public async Task EnsuresNonNullArguments()
             {
                 var client = new RepositoriesClient(Substitute.For<IApiConnection>());
-                var update = new RepositoryUpdate("anyreponame");
+                var update = new RepositoryUpdate() { Name= "anyreponame" };
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Edit(null, "repo", update));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Edit("owner", null, update));

--- a/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
@@ -846,7 +846,7 @@ namespace Octokit.Tests.Reactive
             {
                 var github = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoriesClient(github);
-                var update = new RepositoryUpdate("anyreponame");
+                var update = new RepositoryUpdate(){ Name= "anyreponame" };
 
                 client.Edit("owner", "repo", update);
 
@@ -858,7 +858,7 @@ namespace Octokit.Tests.Reactive
             {
                 var github = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoriesClient(github);
-                var update = new RepositoryUpdate("anyreponame");
+                var update = new RepositoryUpdate(){ Name= "anyreponame" };
 
                 client.Edit(1, update);
 
@@ -869,7 +869,7 @@ namespace Octokit.Tests.Reactive
             public async Task EnsuresNonNullArguments()
             {
                 var client = new ObservableRepositoriesClient(Substitute.For<IGitHubClient>());
-                var update = new RepositoryUpdate("anyreponame");
+                var update = new RepositoryUpdate() { Name= "anyreponame" };
 
                 Assert.Throws<ArgumentNullException>(() => client.Edit(null, "repo", update));
                 Assert.Throws<ArgumentNullException>(() => client.Edit("owner", null, update));

--- a/Octokit/Models/Request/RepositoryUpdate.cs
+++ b/Octokit/Models/Request/RepositoryUpdate.cs
@@ -17,17 +17,6 @@ namespace Octokit
         public RepositoryUpdate() { }
 
         /// <summary>
-        /// Creates an object that describes an update to a repository on GitHub.
-        /// </summary>
-        /// <param name="name">The name of the repository. This is the only required parameter.</param>
-        [Obsolete("Use the constructor with no parameters as name is no longer a required field")]
-        public RepositoryUpdate(string name)
-        {
-            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
-            Name = name;
-        }
-
-        /// <summary>
         /// Required. Gets or sets the repository name.
         /// </summary>
         public string Name { get; set; }

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -6,7 +6,7 @@
     <Authors>GitHub</Authors>
     <Version>0.0.0-dev</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Octokit</AssemblyName>
     <PackageId>Octokit</PackageId>
     <DebugType>embedded</DebugType>
@@ -19,25 +19,11 @@
     <Copyright>Copyright GitHub 2017</Copyright>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  <PropertyGroup>
     <DefineConstants>$(DefineConstants);HAS_TYPEINFO;SIMPLE_JSON_INTERNAL;SIMPLE_JSON_OBJARRAYINTERNAL;SIMPLE_JSON_READONLY_COLLECTIONS;SIMPLE_JSON_TYPEINFO</DefineConstants>
     <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <DefineConstants>$(DefineConstants);HAS_ENVIRONMENT;HAS_REGEX_COMPILED_OPTIONS;SIMPLE_JSON_INTERNAL;SIMPLE_JSON_OBJARRAYINTERNAL;SIMPLE_JSON_READONLY_COLLECTIONS;HAS_SERVICEPOINTMANAGER</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <NoWarn>1591;1701;1702;1705</NoWarn>
   </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
-  </ItemGroup>
 
   <ItemGroup>
     <None Include="images\octokit.png" Pack="true" PackagePath="\" />

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -6,7 +6,7 @@
     <Authors>GitHub</Authors>
     <Version>0.0.0-dev</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Octokit</AssemblyName>
     <PackageId>Octokit</PackageId>
     <DebugType>embedded</DebugType>

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -21,7 +21,6 @@
 
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);HAS_TYPEINFO;SIMPLE_JSON_INTERNAL;SIMPLE_JSON_OBJARRAYINTERNAL;SIMPLE_JSON_READONLY_COLLECTIONS;SIMPLE_JSON_TYPEINFO</DefineConstants>
-    <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
     <NoWarn>1591;1701;1702;1705</NoWarn>
   </PropertyGroup>
 

--- a/build/Context.cs
+++ b/build/Context.cs
@@ -1,6 +1,6 @@
 using Cake.Common;
 using Cake.Common.Diagnostics;
-using Cake.Common.Tools.DotNetCore.Test;
+using Cake.Common.Tools.DotNet.Test;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Frosting;
@@ -28,9 +28,9 @@ public class Context : FrostingContext
 
     public FilePath GitVersionToolPath { get; set; }
 
-    public DotNetCoreTestSettings GetTestSettings()
+    public DotNetTestSettings GetTestSettings()
     {
-        var settings = new DotNetCoreTestSettings
+        var settings = new DotNetTestSettings
         {
             Configuration = Configuration,
             NoBuild = true

--- a/build/Lifetime.cs
+++ b/build/Lifetime.cs
@@ -51,8 +51,8 @@ public class Lifetime : FrostingLifetime<Context>
             new Project { Name = "Octokit.Tests.Integration", Path = "./Octokit.Tests.Integration/Octokit.Tests.Integration.csproj", IntegrationTests = true }
         };
 
-        context.GitVersionToolPath = ToolInstaller.DotNetCoreToolInstall(context, "GitVersion.Tool", "5.6.5", "dotnet-gitversion");
-        ToolInstaller.DotNetCoreToolInstall(context, "coverlet.console", "1.7.2", "coverlet");
+        context.GitVersionToolPath = ToolInstaller.DotNetToolInstall(context, "GitVersion.Tool", "5.6.5", "dotnet-gitversion");
+        ToolInstaller.DotNetToolInstall(context, "coverlet.console", "1.7.2", "coverlet");
 
         // Calculate semantic version.
         context.Version = BuildVersion.Calculate(context);

--- a/build/Tasks/Build.cs
+++ b/build/Tasks/Build.cs
@@ -9,7 +9,7 @@ public class Build : FrostingTask<Context>
 {
     public override void Run(Context context)
     {
-        context.DotNetCoreBuild("./Octokit.sln", new DotNetCoreBuildSettings
+        context.DotNetBuild("./Octokit.sln", new DotNetCoreBuildSettings
         {
             Configuration = context.Configuration,
             ArgumentCustomization = args => args

--- a/build/Tasks/Build.cs
+++ b/build/Tasks/Build.cs
@@ -1,5 +1,5 @@
-using Cake.Common.Tools.DotNetCore;
-using Cake.Common.Tools.DotNetCore.Build;
+using Cake.Common.Tools.DotNet;
+using Cake.Common.Tools.DotNet.Build;
 using Cake.Core;
 using Cake.Frosting;
 
@@ -9,7 +9,7 @@ public class Build : FrostingTask<Context>
 {
     public override void Run(Context context)
     {
-        context.DotNetBuild("./Octokit.sln", new DotNetCoreBuildSettings
+        context.DotNetBuild("./Octokit.sln", new DotNetBuildSettings
         {
             Configuration = context.Configuration,
             ArgumentCustomization = args => args

--- a/build/Tasks/ConventionTests.cs
+++ b/build/Tasks/ConventionTests.cs
@@ -1,6 +1,6 @@
 using System.Linq;
 using Cake.Common.Diagnostics;
-using Cake.Common.Tools.DotNetCore;
+using Cake.Common.Tools.DotNet;
 using Cake.Frosting;
 
 [IsDependentOn(typeof(Build))]

--- a/build/Tasks/ConventionTests.cs
+++ b/build/Tasks/ConventionTests.cs
@@ -11,7 +11,7 @@ public sealed class ConventionTests : FrostingTask<Context>
         foreach (var project in context.Projects.Where(x => x.ConventionTests))
         {
             context.Information("Executing Convention Tests Project {0}...", project.Name);
-            context.DotNetCoreTest(project.Path.FullPath, context.GetTestSettings());
+            context.DotNetTest(project.Path.FullPath, context.GetTestSettings());
         }
     }
 }

--- a/build/Tasks/IntegrationTests.cs
+++ b/build/Tasks/IntegrationTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.Linq;
 using Cake.Common.Diagnostics;
-using Cake.Common.Tools.DotNetCore;
-using Cake.Common.Tools.DotNetCore.Test;
+using Cake.Common.Tools.DotNet;
+using Cake.Common.Tools.DotNet.Test;
 using Cake.Frosting;
 
 [IsDependentOn(typeof(Build))]

--- a/build/Tasks/IntegrationTests.cs
+++ b/build/Tasks/IntegrationTests.cs
@@ -12,7 +12,7 @@ public sealed class IntegrationTests : FrostingTask<Context>
         foreach (var project in context.Projects.Where(x => x.IntegrationTests))
         {
             context.Information("Executing Integration Tests Project {0}...", project.Name);
-            context.DotNetCoreTest(project.Path.FullPath, context.GetTestSettings());
+            context.DotNetTest(project.Path.FullPath, context.GetTestSettings());
         }
     }
 

--- a/build/Tasks/Package.cs
+++ b/build/Tasks/Package.cs
@@ -16,7 +16,7 @@ public sealed class Package : FrostingTask<Context>
             if (project.Publish)
             {
                 context.Information("Packing {0}...", project.Name);
-                context.DotNetCorePack(project.Path.FullPath, new DotNetCorePackSettings()
+                context.DotNetPack(project.Path.FullPath, new DotNetCorePackSettings()
                 {
                     Configuration = context.Configuration,
                     NoBuild = true,

--- a/build/Tasks/Package.cs
+++ b/build/Tasks/Package.cs
@@ -1,6 +1,6 @@
 using Cake.Common.Diagnostics;
-using Cake.Common.Tools.DotNetCore;
-using Cake.Common.Tools.DotNetCore.Pack;
+using Cake.Common.Tools.DotNet;
+using Cake.Common.Tools.DotNet.Pack;
 using Cake.Core;
 using Cake.Frosting;
 
@@ -16,7 +16,7 @@ public sealed class Package : FrostingTask<Context>
             if (project.Publish)
             {
                 context.Information("Packing {0}...", project.Name);
-                context.DotNetPack(project.Path.FullPath, new DotNetCorePackSettings()
+                context.DotNetPack(project.Path.FullPath, new DotNetPackSettings()
                 {
                     Configuration = context.Configuration,
                     NoBuild = true,

--- a/build/Tasks/Restore.cs
+++ b/build/Tasks/Restore.cs
@@ -1,5 +1,5 @@
-using Cake.Common.Tools.DotNetCore;
-using Cake.Common.Tools.DotNetCore.Restore;
+using Cake.Common.Tools.DotNet;
+using Cake.Common.Tools.DotNet.Restore;
 using Cake.Core;
 using Cake.Frosting;
 
@@ -8,7 +8,7 @@ public sealed class Restore : FrostingTask<Context>
 {
     public override void Run(Context context)
     {
-        context.DotNetRestore(".", new DotNetCoreRestoreSettings
+        context.DotNetRestore(".", new DotNetRestoreSettings
         {
             ArgumentCustomization = args => args
                 .Append("/p:Version={0}", context.Version.GetSemanticVersion())

--- a/build/Tasks/Restore.cs
+++ b/build/Tasks/Restore.cs
@@ -8,7 +8,7 @@ public sealed class Restore : FrostingTask<Context>
 {
     public override void Run(Context context)
     {
-        context.DotNetCoreRestore(".", new DotNetCoreRestoreSettings
+        context.DotNetRestore(".", new DotNetCoreRestoreSettings
         {
             ArgumentCustomization = args => args
                 .Append("/p:Version={0}", context.Version.GetSemanticVersion())

--- a/build/Tasks/UnitTests.cs
+++ b/build/Tasks/UnitTests.cs
@@ -11,7 +11,7 @@ public sealed class UnitTests : FrostingTask<Context>
         foreach (var project in context.Projects.Where(x => x.UnitTests))
         {
             context.Information("Executing Unit Tests Project {0}...", project.Name);
-            context.DotNetCoreTest(project.Path.FullPath, context.GetTestSettings());
+            context.DotNetTest(project.Path.FullPath, context.GetTestSettings());
         }
     }
 }

--- a/build/Tasks/UnitTests.cs
+++ b/build/Tasks/UnitTests.cs
@@ -1,6 +1,6 @@
 using System.Linq;
 using Cake.Common.Diagnostics;
-using Cake.Common.Tool;
+using Cake.Common.Tools;
 using Cake.Frosting;
 
 [IsDependentOn(typeof(Build))]

--- a/build/Tasks/UnitTests.cs
+++ b/build/Tasks/UnitTests.cs
@@ -1,6 +1,6 @@
 using System.Linq;
 using Cake.Common.Diagnostics;
-using Cake.Common.Tools.DotNetCore;
+using Cake.Common.Tool;
 using Cake.Frosting;
 
 [IsDependentOn(typeof(Build))]

--- a/build/Tasks/UnitTests.cs
+++ b/build/Tasks/UnitTests.cs
@@ -1,7 +1,8 @@
 using System.Linq;
+using Cake.Frosting;
 using Cake.Common.Diagnostics;
 using Cake.Common.Tools;
-using Cake.Frosting;
+using Cake.Common.Tools.DotNet;
 
 [IsDependentOn(typeof(Build))]
 public sealed class UnitTests : FrostingTask<Context>

--- a/build/Tasks/ValidateLINQPadSamples.cs
+++ b/build/Tasks/ValidateLINQPadSamples.cs
@@ -17,7 +17,7 @@ public sealed class ValidateLINQPadSamples : FrostingTask<Context>
             .Combine("Octokit.Reactive")
             .Combine("bin")
             .Combine(context.Configuration)
-            .Combine("net46")
+            .Combine("netstandard2.0")
             .MakeAbsolute(context.Environment)
             .FullPath;
 

--- a/build/Utilities/ToolInstaller.cs
+++ b/build/Utilities/ToolInstaller.cs
@@ -8,7 +8,7 @@ using Cake.Core.IO;
 
 public static class ToolInstaller
 {
-    private static DirectoryPath ToolsPath { get; } = "./tools"; 
+    private static DirectoryPath ToolsPath { get; } = "./tools";
     public static void Install(ICakeContext context, string package, string version)
     {
         context.NuGetInstall(package, new NuGetInstallSettings
@@ -42,10 +42,10 @@ public static class ToolInstaller
                                 : ".exe"
                             )
                         );
-                    
+
         if (!context.DirectoryExists(toolInstallPath) && context.FileExists(toolPath))
         {
-            context.DotNetCoreTool("tool", new DotNetCoreToolSettings
+            context.DotNetTool("tool", new DotNetCoreToolSettings
                 {
                     ArgumentCustomization = args => args
                         .Append("uninstall")
@@ -56,7 +56,7 @@ public static class ToolInstaller
 
         if (!context.FileExists(toolPath))
         {
-            context.DotNetCoreTool("tool", new DotNetCoreToolSettings
+            context.DotNetTool("tool", new DotNetCoreToolSettings
                 {
                     ArgumentCustomization = args => args
                         .Append("install")

--- a/build/Utilities/ToolInstaller.cs
+++ b/build/Utilities/ToolInstaller.cs
@@ -1,6 +1,6 @@
 ﻿using Cake.Common.IO;
-using Cake.Common.Tools.DotNetCore;
-using Cake.Common.Tools.DotNetCore.Tool;
+using Cake.Common.Tools.DotNet;
+using Cake.Common.Tools.DotNet.Tool;
 using Cake.Common.Tools.NuGet;
 using Cake.Common.Tools.NuGet.Install;
 using Cake.Core;
@@ -19,7 +19,7 @@ public static class ToolInstaller
         });
     }
 
-    public static FilePath DotNetCoreToolInstall(
+    public static FilePath DotNetToolInstall(
         this ICakeContext context,
         string package,
         string version,
@@ -45,7 +45,7 @@ public static class ToolInstaller
 
         if (!context.DirectoryExists(toolInstallPath) && context.FileExists(toolPath))
         {
-            context.DotNetTool("tool", new DotNetCoreToolSettings
+            context.DotNetTool("tool", new DotNetToolSettings
                 {
                     ArgumentCustomization = args => args
                         .Append("uninstall")
@@ -56,7 +56,7 @@ public static class ToolInstaller
 
         if (!context.FileExists(toolPath))
         {
-            context.DotNetTool("tool", new DotNetCoreToolSettings
+            context.DotNetTool("tool", new DotNetToolSettings
                 {
                     ArgumentCustomization = args => args
                         .Append("install")


### PR DESCRIPTION
Fixes: https://github.com/octokit/octokit.net/issues/2500

Already covered by the explanation via @JamieMagee - this needs to be done so we can move forward with the framework and innovate using the new APIs and assemblies.

Highlights from the [issue](https://github.com/octokit/octokit.net/issues/2500) description:
> .NET Framework 4.6 (and 4.6.1) went out of support on April 26, 2022. Continuing to publish Octokit for this target adds a support burden.

> .NET standard 2.0 covers .NET Framework 4.6.2 already.

> Supporting a single target framework, .NET standard 2.0, would simplify maintenance of this project while supporting all target frameworks currently supported upstream.

For reference, these are the supported versions going forward

.NET implementation | Version support
-- | --
.NET and .NET Core | 2.0, 2.1, 2.2, 3.0, 3.1, 5.0, 6.0
.NET Framework  | 4.6.1 2, 4.6.2, 4.7, 4.7.1, 4.7.2, 4.8

