### PR TITLE
Fixing a number of warnings for a cleaner build

### DIFF
--- a/Octokit.Reactive/Clients/IObservableReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableReactionsClient.cs
@@ -36,13 +36,5 @@ namespace Octokit.Reactive
         /// Refer to the API documentation for more information: https://developer.github.com/v3/reactions/
         /// </remarks>
         IObservablePullRequestReviewCommentReactionsClient PullRequestReviewComment { get; }
-
-        /// <summary>
-        /// Delete a reaction.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/reactions/#delete-a-reaction</remarks>        
-        /// <param name="number">The reaction id</param>        
-        /// <returns></returns>
-        IObservable<Unit> Delete(int number);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableReactionsClient.cs
@@ -51,16 +51,5 @@ namespace Octokit.Reactive
         /// Refer to the API documentation for more information: https://developer.github.com/v3/reactions/
         /// </remarks>
         public IObservablePullRequestReviewCommentReactionsClient PullRequestReviewComment { get; private set; }
-
-        /// <summary>
-        /// Delete a reaction.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/reactions/#delete-a-reaction</remarks>        
-        /// <param name="number">The reaction id</param>        
-        /// <returns></returns>
-        public IObservable<Unit> Delete(int number)
-        {
-            return _client.Delete(number).ToObservable();
-        }
     }
 }

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -879,7 +879,6 @@ public class RepositoriesClientTests
             Assert.False(repository.Private);
             Assert.False(repository.Fork);
             Assert.Equal(AccountType.User, repository.Owner.Type);
-            Assert.True(repository.WatchersCount > 0);
         }
 
         [IntegrationTest]
@@ -894,7 +893,6 @@ public class RepositoriesClientTests
             Assert.False(repository.Private);
             Assert.False(repository.Fork);
             Assert.Equal(AccountType.User, repository.Owner.Type);
-            Assert.True(repository.WatchersCount > 0);
         }
 
         [IntegrationTest]

--- a/Octokit.Tests/Clients/ReactionsClientTests.cs
+++ b/Octokit.Tests/Clients/ReactionsClientTests.cs
@@ -15,19 +15,5 @@ namespace Octokit.Tests.Clients
                 Assert.Throws<ArgumentNullException>(() => new ReactionsClient(null));
             }
         }
-
-        public class TheDeleteMethod
-        {
-            [Fact]
-            public async Task DeletesCorrectUrl()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new ReactionsClient(connection);
-
-                await client.Delete(42);
-
-                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "reactions/42"), Arg.Any<object>());
-            }
-        }
     }
 }

--- a/Octokit.Tests/Exceptions/ApiExceptionTests.cs
+++ b/Octokit.Tests/Exceptions/ApiExceptionTests.cs
@@ -108,7 +108,8 @@ namespace Octokit.Tests.Exceptions
                     var formatter = new BinaryFormatter();
                     formatter.Serialize(stream, exception);
                     stream.Position = 0;
-                    var deserialized = (ApiException)formatter.Deserialize(stream);
+                    var deserializedObject = formatter.Deserialize(stream);
+                    var deserialized = (ApiException)deserializedObject;
                     Assert.Equal("Validation Failed", deserialized.ApiError.Message);
                     Assert.Equal("key is already in use", exception.ApiError.Errors.First().Message);
                 }

--- a/Octokit.Tests/Reactive/ObservableReactionsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableReactionsClientTests.cs
@@ -17,19 +17,5 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => new ObservableReactionsClient(null));
             }
         }
-
-        public class TheDeleteMethod
-        {
-            [Fact]
-            public void PostsToCorrectUrl()
-            {
-                var gitHubClient = Substitute.For<IGitHubClient>();
-                var client = new ObservableReactionsClient(gitHubClient);
-
-                client.Delete(13);
-
-                gitHubClient.Reaction.Received().Delete(13);
-            }
-        }
     }
 }

--- a/Octokit/Clients/IReactionsClient.cs
+++ b/Octokit/Clients/IReactionsClient.cs
@@ -41,13 +41,5 @@ namespace Octokit
         /// Refer to the API documentation for more information: https://developer.github.com/v3/reactions/
         /// </remarks>
         IPullRequestReviewCommentReactionsClient PullRequestReviewComment { get; }
-
-        /// <summary>
-        /// Delete a reaction.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/reactions/#delete-a-reaction</remarks>        
-        /// <param name="number">The reaction id</param>        
-        /// <returns></returns>
-        Task Delete(int number);
     }
 }

--- a/Octokit/Clients/ReactionsClient.cs
+++ b/Octokit/Clients/ReactionsClient.cs
@@ -49,18 +49,5 @@ namespace Octokit
         /// Refer to the API documentation for more information: https://developer.github.com/v3/reactions/
         /// </remarks>
         public IPullRequestReviewCommentReactionsClient PullRequestReviewComment { get; private set; }
-
-        /// <summary>
-        /// Delete a reaction.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/reactions/#delete-a-reaction</remarks>
-        /// <param name="number">The reaction id</param>
-        /// <returns></returns>
-        [ManualRoute("DELETE", "/reactions/{reaction_id}")]
-        [Obsolete("This route no longer works and is replaced with individual routes in each client")]
-        public Task Delete(int number)
-        {
-            return ApiConnection.Delete(ApiUrls.Reactions(number), new object());
-        }
     }
 }

--- a/Octokit/Exceptions/ApiException.cs
+++ b/Octokit/Exceptions/ApiException.cs
@@ -25,7 +25,9 @@ namespace Octokit
         /// <summary>
         /// Constructs an instance of ApiException
         /// </summary>
+#pragma warning disable CS0618 // Response() is obsolete but we need this as a default as Response passed down cannot be null
         public ApiException() : this(new Response())
+#pragma warning restore CS0618 // Response() is obsolete but we need this as a default as Response passed down cannot be null
         {
         }
 
@@ -202,8 +204,8 @@ namespace Octokit
             {
                 return HttpResponse?.ContentType != null
                        && !HttpResponse.ContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase)
-                       && HttpResponse.Body is string
-                    ? (string)HttpResponse.Body : string.Empty;
+                       && HttpResponse.Body is string @string
+                       ? @string : string.Empty;
             }
         }
 

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -109,7 +109,7 @@ namespace Octokit
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns all of the organizations.
         /// </summary>
-        /// /// <param name="since">The integer Id of the last Organization that you’ve seen.</param>
+        /// <param name="since">The integer Id of the last Organization that you’ve seen.</param>
         /// <returns></returns>
         public static Uri AllOrganizations(long since)
         {
@@ -497,7 +497,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        /// /// <param name="reaction">The reactionid for the issue</param>
+        /// <param name="reaction">The reactionid for the issue</param>
         /// <returns></returns>
         public static Uri IssueReaction(long repositoryId, int number, int reaction)
         {
@@ -591,7 +591,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment number</param>
-        /// /// <param name="reaction">The reactionid for the comment</param>
+        /// <param name="reaction">The reactionid for the comment</param>
         /// <returns></returns>
         public static Uri IssueCommentReaction(string owner, string name, int number, int reaction)
         {

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -485,6 +485,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
+        /// <param name="reaction">The reactionid for the issue</param>
         /// <returns></returns>
         public static Uri IssueReaction(string owner, string name, int number, int reaction)
         {
@@ -496,6 +497,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
+        /// /// <param name="reaction">The reactionid for the issue</param>
         /// <returns></returns>
         public static Uri IssueReaction(long repositoryId, int number, int reaction)
         {
@@ -589,6 +591,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment number</param>
+        /// /// <param name="reaction">The reactionid for the comment</param>
         /// <returns></returns>
         public static Uri IssueCommentReaction(string owner, string name, int number, int reaction)
         {
@@ -600,6 +603,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="number">The comment number</param>
+        /// <param name="reaction">The reactionid for the comment</param>
         /// <returns></returns>
         public static Uri IssueCommentReaction(long repositoryId, int number, int reaction)
         {
@@ -1705,6 +1709,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment number</param>
+        /// <param name="reaction">The reactionid for the comment</param>
         /// <returns></returns>
         public static Uri PullRequestReviewCommentReaction(string owner, string name, int number, int reaction)
         {
@@ -1716,6 +1721,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment number</param>
+        /// <param name="reaction">The reactionid for the comment</param>
         /// <returns></returns>
         public static Uri PullRequestReviewCommentReaction(long repositoryId, int number, int reaction)
         {

--- a/Octokit/Models/Response/Repository.cs
+++ b/Octokit/Models/Response/Repository.cs
@@ -58,7 +58,9 @@ namespace Octokit
             AllowSquashMerge = allowSquashMerge;
             AllowMergeCommit = allowMergeCommit;
             Archived = archived;
+#pragma warning disable CS0618 // Type or member is obsolete
             WatchersCount = watchersCount;
+#pragma warning restore CS0618 // Type or member is obsolete
             Topics = topics.ToList();
             DeleteBranchOnMerge = deleteBranchOnMerge;
             Visibility = visibility;


### PR DESCRIPTION
I tried to also work out why the net462 tests fail on binary deserialization, but I couldn't. One for another time.