### PR TITLE
Standardising api routes to use names, so we can compare with the openapi spec

### DIFF
--- a/Octokit.Tests.Conventions/ApiUrlComparison.cs
+++ b/Octokit.Tests.Conventions/ApiUrlComparison.cs
@@ -1,0 +1,138 @@
+﻿using Octokit.Internal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Octokit.Tests.Conventions
+{
+    public class ApiUrlComparison
+    {
+        private readonly ITestOutputHelper _outputHelper;
+
+        public ApiUrlComparison(ITestOutputHelper outputHelper)
+        {
+            _outputHelper = outputHelper;
+        }
+
+        [Fact]
+        public void WorkOk()
+        {
+            ApiUrls.AllPublicRepositories(1);
+
+            WebClient downloadClient = new WebClient();
+            var jsonFile = downloadClient.DownloadString("https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json");
+
+            var apiSchemaObject = new SimpleJsonSerializer().Deserialize<OpenApiSchema>(jsonFile);
+            var knownPaths = apiSchemaObject.Paths.Keys.ToList();
+
+            List<string> convertedPaths = new List<string>();
+
+            foreach (var knownPath in knownPaths)
+            {
+                var splits = knownPath.Split('{');
+
+                if (splits.Length == 1)
+                {
+                    convertedPaths.Add(knownPath);
+                    continue;
+                }
+
+                var localPath = knownPath;
+
+                foreach (var item in splits.Where(x => x.Contains("}")))
+                {
+                    var cleanItem = item.Replace("{", "").Split('}')[0].Replace("}", "");
+
+                    var matchedType = apiSchemaObject.Components["parameters"].FirstOrDefault(x => x.Value.Name == cleanItem);
+                    if (matchedType.Key != null && matchedType.Value.Schema.Type == "string")
+                    {
+                        localPath = localPath.Replace("{" + cleanItem + "}", "abcdef");
+                    }
+                    else if (matchedType.Key != null && matchedType.Value.Schema.Type == "integer")
+                    {
+                        localPath = localPath.Replace("{" + cleanItem + "}", "12345");
+                    }
+                }
+
+                convertedPaths.Add(localPath);
+            }
+
+            //var apiUrls = ApiUrls._allUrls.Values.Select(x => "/" + x).ToList();
+            //var allMatches = apiUrls.Where(x => knownPaths.Contains(x)).ToList();
+            //var allFailures = apiUrls.Where(x => !knownPaths.Contains(x)).ToList();
+
+            //_outputHelper.WriteLine($"Failures - {allFailures.Count}");
+            
+            //foreach (var item in allFailures)
+            //{
+            //    _outputHelper.WriteLine(item);
+            //}
+
+            //_outputHelper.WriteLine($"Matches - {allMatches.Count}");
+
+            //foreach(var item in allMatches)
+            //{
+            //    _outputHelper.WriteLine(item);
+            //}
+        }
+
+        private class ApiUrlComparisonResult
+        {
+            public ApiUrlComparisonResult(string name, Uri uri)
+            {
+                Name = name;
+                Uri = uri;
+                InvokedSuccessfully = true;
+            }
+
+            public ApiUrlComparisonResult(string name, string failureMessage)
+            {
+                Name = name;
+                InvokedSuccessfully = false;
+                FailureMessage = failureMessage;
+            }
+
+            public string Name { get; set; } = string.Empty;
+
+            public Uri Uri { get; set; }
+
+            public string Url => "/" + Uri.ToString();
+
+            public bool InvokedSuccessfully { get; set; }
+
+            public string FailureMessage { get; set; } = string.Empty;
+        }
+    }
+
+    public class OpenApiSchema
+    {
+        public Dictionary<string, object> Paths { get; set; }
+        public Dictionary<string, Dictionary<string, Parameter>> Components { get; set; }
+    }
+
+    public class Component
+    {
+        public Dictionary<string, Dictionary<string,Parameter>> Parameters { get; set; }
+    }
+
+    public class Parameter
+    {
+        public string Name { get; set; }
+
+        public string Description { get; set; }
+
+        public string In { get; set; }
+
+        public Schema Schema { get; set; }
+    }
+
+    public class Schema
+    {
+        public string Type { get; set; }
+
+        public object Default { get; set; }
+    }
+}

--- a/Octokit.Tests.Conventions/TypeExtensions.cs
+++ b/Octokit.Tests.Conventions/TypeExtensions.cs
@@ -110,15 +110,10 @@ namespace Octokit.Tests.Conventions
         {
             var typeInfo = type.GetTypeInfo();
 
-            var isReadOnlyList = typeInfo.HasGenericTypeDefinition(typeof(IReadOnlyList<>));
-            var isReadOnlyDictionary = typeInfo.HasGenericTypeDefinition(typeof(IReadOnlyDictionary<,>));
+            var isReadOnlyList = type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IReadOnlyList<>);
+            var isReadOnlyDictionary = type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IReadOnlyDictionary<,>);
 
             return isReadOnlyList || isReadOnlyDictionary;
-        }
-
-        private static bool HasGenericTypeDefinition(this TypeInfo type, Type genericTypeDefinition)
-        {
-            return type.IsGenericType && type.GetGenericTypeDefinition() == genericTypeDefinition;
         }
     }
 

--- a/Octokit/Clients/UserKeysClient.cs
+++ b/Octokit/Clients/UserKeysClient.cs
@@ -47,7 +47,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(userName, nameof(userName));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return ApiConnection.GetAll<PublicKey>(ApiUrls.Keys(userName), options);
+            return ApiConnection.GetAll<PublicKey>(ApiUrls.SshKeys(userName), options);
         }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return ApiConnection.GetAll<PublicKey>(ApiUrls.Keys(), options);
+            return ApiConnection.GetAll<PublicKey>(ApiUrls.SshKeys(), options);
         }
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace Octokit
         [ManualRoute("GET", "/user/keys/{key_id}")]
         public Task<PublicKey> Get(int id)
         {
-            return ApiConnection.Get<PublicKey>(ApiUrls.Keys(id));
+            return ApiConnection.Get<PublicKey>(ApiUrls.SshKey(id));
         }
 
         /// <summary>
@@ -106,7 +106,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNull(newKey, nameof(newKey));
 
-            return ApiConnection.Post<PublicKey>(ApiUrls.Keys(), newKey);
+            return ApiConnection.Post<PublicKey>(ApiUrls.SshKeys(), newKey);
         }
 
         /// <summary>
@@ -120,7 +120,7 @@ namespace Octokit
         [ManualRoute("DELETE", "/user/keys/{key_id}")]
         public Task Delete(int id)
         {
-            return ApiConnection.Delete(ApiUrls.Keys(id));
+            return ApiConnection.Delete(ApiUrls.SshKey(id));
         }
     }
 }

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -25,95 +25,59 @@ namespace Octokit
         /// Returns the <see cref="Uri"/> that returns all public repositories in
         /// response to a GET request.
         /// </summary>
-        public static Uri AllPublicRepositories()
-        {
-            return "repositories".FormatUri();
-        }
+        public static Uri AllPublicRepositories() => ApiRoutes.AllPublicRepositories.FormatUri();
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns all public repositories in
         /// response to a GET request.
         /// </summary>
         /// <param name="since">The integer Id of the last Repository that you’ve seen.</param>
-        public static Uri AllPublicRepositories(long since)
-        {
-            string[] chars = new string[] { "since" };
-
-            var url = "repositories?since={since}";
-
-            var result = url.ReplaceAll(new Dictionary<string, string> { { nameof(since), since.ToString() } });
-
-            return result.FormatUri();
-        }
-
-        public static string ReplaceAll(this string seed, Dictionary<string, string> chars)
-        {
-            return chars.Aggregate(seed, (str, cItem) => str.Replace("{" + cItem.Key + "}", cItem.Value));
-        }
+        public static Uri AllPublicRepositories(long since) => ApiRoutes.AllPublicRepositoriesSince.FormatUri((nameof(since), since.ToString()));
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns all of the repositories for the currently logged in user in
         /// response to a GET request. A POST to this URL creates a new repository.
         /// </summary>
-        /// <returns></returns>
-        public static Uri Repositories()
-        {
-            return _currentUserRepositoriesUrl;
-        }
+        public static Uri Repositories() => ApiRoutes.ActiveUserRepositories.FormatUri();
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns all of the repositories for the specified login.
         /// </summary>
         /// <param name="login">The login for the user</param>
-        /// <returns></returns>
-        public static Uri Repositories(string login)
-        {
-            return "users/{0}/repos".FormatUri(login);
-        }
+        public static Uri Repositories(string login) => ApiRoutes.LoggedInUserRepositories.FormatUri((nameof(login), login));
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that create a repository using a template.
         /// </summary>
-        /// <returns></returns>
-        public static Uri Repositories(string owner, string repo)
-        {
-            return "repos/{0}/{1}/generate".FormatUri(owner, repo);
-        }
+        public static Uri Repositories(string owner, string repo) => ApiRoutes.GenerateRepository.FormatUri((nameof(owner), owner), (nameof(repo), repo));
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns all of the repositories for the specified organization in
         /// response to a GET request. A POST to this URL creates a new repository for the organization.
         /// </summary>
         /// <param name="organization">The name of the organization</param>
-        /// <returns></returns>
-        public static Uri OrganizationRepositories(string organization)
-        {
-            return "orgs/{0}/repos".FormatUri(organization);
-        }
+        public static Uri OrganizationRepositories(string organization) => ApiRoutes.OrganizationRepositories.FormatUri((nameof(organization), organization));
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns all of the organizations for the currently logged in user.
         /// </summary>
-        /// <returns></returns>
         public static Uri UserOrganizations()
         {
-            return "user/orgs".FormatUri();
+            return ApiRoutes.UserOrganizations.FormatUri();
         }
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns all of the organizations for the specified login.
         /// </summary>
         /// <param name="login">The login for the user</param>
-        /// <returns></returns>
         public static Uri UserOrganizations(string login)
         {
-            return "users/{0}/orgs".FormatUri(login);
+            return ApiRoutes.LoggedInUserOrganizations.FormatUri((nameof(login), login));
         }
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns all of the organizations.
         /// </summary>
-        /// <returns></returns>
         public static Uri AllOrganizations()
         {
             return "organizations".FormatUri();
@@ -123,7 +87,6 @@ namespace Octokit
         /// Returns the <see cref="Uri"/> that returns all of the organizations.
         /// </summary>
         /// /// <param name="since">The integer Id of the last Organization that you’ve seen.</param>
-        /// <returns></returns>
         public static Uri AllOrganizations(long since)
         {
             return "organizations?since={0}".FormatUri(since);
@@ -133,7 +96,6 @@ namespace Octokit
         /// Returns the <see cref="Uri"/> that returns the organization for the specified organization name
         /// </summary>
         /// <param name="organizationName">The name of the organization</param>
-        /// <returns>The <see cref="Uri"/> that returns the organization for the specified organization name</returns>
         public static Uri Organization(string organizationName)
         {
             return "orgs/{0}".FormatUri(organizationName);
@@ -142,7 +104,6 @@ namespace Octokit
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns all of the SSH keys for the currently logged in user.
         /// </summary>
-        /// <returns></returns>
         public static Uri SshKeys()
         {
             return _currentUserSshKeys;
@@ -152,7 +113,6 @@ namespace Octokit
         /// Returns the <see cref="Uri"/> that returns all of the SSH keys for the specified user.
         /// </summary>
         /// <param name="login">The login for the user</param>
-        /// <returns></returns>
         public static Uri SshKeys(string login)
         {
             return "users/{0}/keys".FormatUri(login);
@@ -187,7 +147,6 @@ namespace Octokit
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns all of the email addresses for the currently logged in user.
         /// </summary>
-        /// <returns></returns>
         public static Uri Emails()
         {
             return _currentUserEmailsEndpoint;
@@ -198,7 +157,6 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         public static Uri Releases(string owner, string name)
         {
             return "repos/{0}/{1}/releases".FormatUri(owner, name);
@@ -210,7 +168,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="id">The id of the release</param>
-        /// <returns></returns>
         public static Uri Releases(string owner, string name, int id)
         {
             return "repos/{0}/{1}/releases/{2}".FormatUri(owner, name, id);
@@ -222,7 +179,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="tag">The tag of the release</param>
-        /// <returns></returns>
         public static Uri Releases(string owner, string name, string tag)
         {
             return "repos/{0}/{1}/releases/tags/{2}".FormatUri(owner, name, tag);
@@ -233,7 +189,6 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         public static Uri LatestRelease(string owner, string name)
         {
             return "repos/{0}/{1}/releases/latest".FormatUri(owner, name);
@@ -245,7 +200,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="id">The id of the release</param>
-        /// <returns></returns>
         public static Uri ReleaseAssets(string owner, string name, int id)
         {
             return "repos/{0}/{1}/releases/{2}/assets".FormatUri(owner, name, id);
@@ -257,7 +211,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="id">The id of the release asset</param>
-        /// <returns></returns>
         public static Uri Asset(string owner, string name, int id)
         {
             return "repos/{0}/{1}/releases/assets/{2}".FormatUri(owner, name, id);
@@ -266,7 +219,6 @@ namespace Octokit
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns all of the notifications for the currently logged in user.
         /// </summary>
-        /// <returns></returns>
         public static Uri Notifications()
         {
             return _currentUserNotificationsEndpoint;
@@ -278,7 +230,6 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         public static Uri Notifications(string owner, string name)
         {
             return "repos/{0}/{1}/notifications".FormatUri(owner, name);
@@ -288,7 +239,6 @@ namespace Octokit
         /// Returns the <see cref="Uri"/> for the specified notification.
         /// </summary>
         /// <param name="id">The Id of the notification.</param>
-        /// <returns></returns>
         public static Uri Notification(int id)
         {
             return "notifications/threads/{0}".FormatUri(id);
@@ -348,7 +298,6 @@ namespace Octokit
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns the repository's installation information.
         /// </summary>
-        /// <returns></returns>
         public static Uri RepoInstallation(string owner, string repo)
         {
             return "repos/{0}/{1}/installation".FormatUri(owner, repo);
@@ -357,7 +306,6 @@ namespace Octokit
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns the repository's installation information.
         /// </summary>
-        /// <returns></returns>
         public static Uri RepoInstallation(long repositoryId)
         {
             return "repositories/{0}/installation".FormatUri(repositoryId);
@@ -398,7 +346,6 @@ namespace Octokit
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns all the repositories
         /// </summary>
-        /// <returns></returns>
         public static Uri InstallationRepositories()
         {
             return "installation/repositories".FormatUri();
@@ -428,7 +375,6 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         public static Uri Issues(string owner, string name)
         {
             return "repos/{0}/{1}/issues".FormatUri(owner, name);
@@ -439,7 +385,6 @@ namespace Octokit
         /// currently logged in user.
         /// </summary>
         /// <param name="organization">The name of the organization</param>
-        /// <returns></returns>
         public static Uri Issues(string organization)
         {
             return "orgs/{0}/issues".FormatUri(organization);
@@ -451,7 +396,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         public static Uri Issue(string owner, string name, int number)
         {
             return "repos/{0}/{1}/issues/{2}".FormatUri(owner, name, number);
@@ -4454,5 +4398,17 @@ namespace Octokit
         {
             return "meta".FormatUri();
         }
+    }
+
+    public static class ApiRoutes
+    {
+        public static string AllPublicRepositories => "repositories";
+        public static string AllPublicRepositoriesSince => "repositories?since={since}";
+        public static string ActiveUserRepositories => "user/repos";
+        public static string LoggedInUserRepositories => "users/{login}/repos";
+        public static string GenerateRepository => "repos/{owner}/{repo}/generate";
+        public static string OrganizationRepositories => "orgs/{organization}/repos";
+        public static string UserOrganizations => "user/orgs";
+        public static string LoggedInUserOrganizations = "users/{login}/orgs";
     }
 }

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -61,52 +61,37 @@ namespace Octokit
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns all of the organizations for the currently logged in user.
         /// </summary>
-        public static Uri UserOrganizations()
-        {
-            return ApiRoutes.UserOrganizations.FormatUri();
-        }
+        public static Uri UserOrganizations() => ApiRoutes.UserOrganizations.FormatUri();
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns all of the organizations for the specified login.
         /// </summary>
         /// <param name="login">The login for the user</param>
-        public static Uri UserOrganizations(string login)
-        {
-            return ApiRoutes.LoggedInUserOrganizations.FormatUri((nameof(login), login));
-        }
+        public static Uri UserOrganizations(string login) => ApiRoutes.LoggedInUserOrganizations.FormatUri((nameof(login), login));
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns all of the organizations.
         /// </summary>
-        public static Uri AllOrganizations()
-        {
-            return "organizations".FormatUri();
-        }
+        public static Uri AllOrganizations() => ApiRoutes.AllOrganizations.FormatUri();
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns all of the organizations.
         /// </summary>
         /// /// <param name="since">The integer Id of the last Organization that you’ve seen.</param>
-        public static Uri AllOrganizations(long since)
-        {
-            return "organizations?since={0}".FormatUri(since);
-        }
+        public static Uri AllOrganizations(long since) => ApiRoutes.AllOrganizationsSince.FormatUri((nameof(since), since));
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns the organization for the specified organization name
         /// </summary>
         /// <param name="organizationName">The name of the organization</param>
-        public static Uri Organization(string organizationName)
-        {
-            return "orgs/{0}".FormatUri(organizationName);
-        }
+        public static Uri Organization(string organizationName) => ApiRoutes.Organization.FormatUri((nameof(organizationName), organizationName));
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns all of the SSH keys for the currently logged in user.
         /// </summary>
         public static Uri SshKeys()
         {
-            return _currentUserSshKeys;
+            return ApiRoutes.CurrentUserSshKeys.FormatUri();
         }
 
         /// <summary>
@@ -115,7 +100,7 @@ namespace Octokit
         /// <param name="login">The login for the user</param>
         public static Uri SshKeys(string login)
         {
-            return "users/{0}/keys".FormatUri(login);
+            return ApiRoutes.LoggedInUserSshKeys.FormatUri((nameof(login), login));
         }
 
         /// <summary>
@@ -4410,5 +4395,10 @@ namespace Octokit
         public static string OrganizationRepositories => "orgs/{organization}/repos";
         public static string UserOrganizations => "user/orgs";
         public static string LoggedInUserOrganizations = "users/{login}/orgs";
+        public static string AllOrganizations = "organizations";
+        public static string AllOrganizationsSince = "organizations?since={since}";
+        public static string Organization = "orgs/{organizationName}";
+        public static string CurrentUserSshKeys = "user/keys";
+        public static string LoggedInUserSshKeys = "users/{0}/keys";
     }
 }

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -10,13 +10,9 @@ namespace Octokit
     /// </summary>
     public static partial class ApiUrls
     {
-        static readonly Uri _currentUserRepositoriesUrl = new Uri("user/repos", UriKind.Relative);
-        static readonly Uri _currentUserOrganizationsUrl = new Uri("user/orgs", UriKind.Relative);
-        static readonly Uri _currentUserSshKeys = new Uri("user/keys", UriKind.Relative);
         static readonly Uri _currentUserGpgKeys = new Uri("user/gpg_keys", UriKind.Relative);
         static readonly Uri _currentUserStars = new Uri("user/starred", UriKind.Relative);
         static readonly Uri _currentUserWatched = new Uri("user/subscriptions", UriKind.Relative);
-        static readonly Uri _currentUserEmailsEndpoint = new Uri("user/emails", UriKind.Relative);
         static readonly Uri _currentUserNotificationsEndpoint = new Uri("notifications", UriKind.Relative);
         static readonly Uri _currentUserAllIssues = new Uri("issues", UriKind.Relative);
         static readonly Uri _currentUserOwnedAndMemberIssues = new Uri("user/issues", UriKind.Relative);
@@ -72,13 +68,13 @@ namespace Octokit
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns all of the organizations.
         /// </summary>
-        public static Uri AllOrganizations() => ApiRoutes.AllOrganizations.FormatUri();
+        public static Uri AllOrganizations() => ApiRoutes.Organizations.FormatUri();
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns all of the organizations.
         /// </summary>
         /// /// <param name="since">The integer Id of the last Organization that you’ve seen.</param>
-        public static Uri AllOrganizations(long since) => ApiRoutes.AllOrganizationsSince.FormatUri((nameof(since), since));
+        public static Uri AllOrganizations(long since) => ApiRoutes.OrganizationsSince.FormatUri((nameof(since), since));
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns the organization for the specified organization name
@@ -87,65 +83,33 @@ namespace Octokit
         public static Uri Organization(string organizationName) => ApiRoutes.Organization.FormatUri((nameof(organizationName), organizationName));
 
         /// <summary>
-        /// Returns the <see cref="Uri"/> that returns all of the SSH keys for the currently logged in user.
-        /// </summary>
-        public static Uri SshKeys()
-        {
-            return ApiRoutes.CurrentUserSshKeys.FormatUri();
-        }
-
-        /// <summary>
-        /// Returns the <see cref="Uri"/> that returns all of the SSH keys for the specified user.
-        /// </summary>
-        /// <param name="login">The login for the user</param>
-        public static Uri SshKeys(string login)
-        {
-            return ApiRoutes.LoggedInUserSshKeys.FormatUri((nameof(login), login));
-        }
-
-        /// <summary>
         /// Returns the <see cref="Uri"/> to retrieve keys for the current user.
         /// </summary>
-        public static Uri Keys()
-        {
-            return "user/keys".FormatUri();
-        }
+        public static Uri SshKeys() => ApiRoutes.AuthenticatedUserSshKeys.FormatUri();
 
         /// <summary>
         /// Returns the <see cref="Uri"/> to retrieve keys for a given user.
         /// </summary>
         /// <param name="userName">The user to search on</param>
-        public static Uri Keys(string userName)
-        {
-            return "users/{0}/keys".FormatUri(userName);
-        }
+        public static Uri SshKeys(string userName) => ApiRoutes.SpecificUserSshKeys.FormatUri((nameof(userName), userName));
 
         /// <summary>
         /// Returns the <see cref="Uri"/> to retrieve a given key.
         /// </summary>
         /// <param name="id">The Key Id to retrieve</param>
-        public static Uri Keys(int id)
-        {
-            return "user/keys/{0}".FormatUri(id);
-        }
+        public static Uri SshKey(int id) => ApiRoutes.AuthenticatedUserSshKey.FormatUri((nameof(id), id));
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns all of the email addresses for the currently logged in user.
         /// </summary>
-        public static Uri Emails()
-        {
-            return _currentUserEmailsEndpoint;
-        }
+        public static Uri Emails() => ApiRoutes.AuthenticatedUserEmails.FormatUri();
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns all of the releases for the specified repository.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        public static Uri Releases(string owner, string name)
-        {
-            return "repos/{0}/{1}/releases".FormatUri(owner, name);
-        }
+        public static Uri Releases(string owner, string name) => ApiRoutes.ReleasesByOwnerName.FormatUri((nameof(owner), owner), (nameof(name), name));
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns a single release for the specified repository
@@ -155,7 +119,7 @@ namespace Octokit
         /// <param name="id">The id of the release</param>
         public static Uri Releases(string owner, string name, int id)
         {
-            return "repos/{0}/{1}/releases/{2}".FormatUri(owner, name, id);
+            return "repos/{owner}/{name}/releases/{id}".FormatUri((nameof(owner), owner), (nameof(name), name), (nameof(id), id));
         }
 
         /// <summary>
@@ -4395,10 +4359,13 @@ namespace Octokit
         public static string OrganizationRepositories => "orgs/{organization}/repos";
         public static string UserOrganizations => "user/orgs";
         public static string LoggedInUserOrganizations = "users/{login}/orgs";
-        public static string AllOrganizations = "organizations";
-        public static string AllOrganizationsSince = "organizations?since={since}";
+        public static string Organizations = "organizations";
+        public static string OrganizationsSince = "organizations?since={since}";
         public static string Organization = "orgs/{organizationName}";
-        public static string CurrentUserSshKeys = "user/keys";
-        public static string LoggedInUserSshKeys = "users/{0}/keys";
+        public static string AuthenticatedUserSshKeys = "user/keys";
+        public static string AuthenticatedUserSshKey = "user/keys/{id}";
+        public static string SpecificUserSshKeys = "users/{username}/keys";
+        public static string AuthenticatedUserEmails = "user/emails";
+        public static string ReleasesByOwnerName = "repos/{owner}/{name}/releases";
     }
 }

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -4358,14 +4358,14 @@ namespace Octokit
         public static string GenerateRepository => "repos/{owner}/{repo}/generate";
         public static string OrganizationRepositories => "orgs/{organization}/repos";
         public static string UserOrganizations => "user/orgs";
-        public static string LoggedInUserOrganizations = "users/{login}/orgs";
-        public static string Organizations = "organizations";
-        public static string OrganizationsSince = "organizations?since={since}";
-        public static string Organization = "orgs/{organizationName}";
-        public static string AuthenticatedUserSshKeys = "user/keys";
-        public static string AuthenticatedUserSshKey = "user/keys/{id}";
-        public static string SpecificUserSshKeys = "users/{username}/keys";
-        public static string AuthenticatedUserEmails = "user/emails";
-        public static string ReleasesByOwnerName = "repos/{owner}/{name}/releases";
+        public static string LoggedInUserOrganizations => "users/{login}/orgs";
+        public static string Organizations => "organizations";
+        public static string OrganizationsSince => "organizations?since={since}";
+        public static string Organization => "orgs/{organizationName}";
+        public static string AuthenticatedUserSshKeys => "user/keys";
+        public static string AuthenticatedUserSshKey => "user/keys/{id}";
+        public static string SpecificUserSshKeys => "users/{username}/keys";
+        public static string AuthenticatedUserEmails => "user/emails";
+        public static string ReleasesByOwnerName => "repos/{owner}/{name}/releases";
     }
 }

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 namespace Octokit
 {
@@ -35,7 +37,18 @@ namespace Octokit
         /// <param name="since">The integer Id of the last Repository that you’ve seen.</param>
         public static Uri AllPublicRepositories(long since)
         {
-            return "repositories?since={0}".FormatUri(since);
+            string[] chars = new string[] { "since" };
+
+            var url = "repositories?since={since}";
+
+            var result = url.ReplaceAll(new Dictionary<string, string> { { nameof(since), since.ToString() } });
+
+            return result.FormatUri();
+        }
+
+        public static string ReplaceAll(this string seed, Dictionary<string, string> chars)
+        {
+            return chars.Aggregate(seed, (str, cItem) => str.Replace("{" + cItem.Key + "}", cItem.Value));
         }
 
         /// <summary>

--- a/Octokit/Helpers/Ensure.cs
+++ b/Octokit/Helpers/Ensure.cs
@@ -15,7 +15,7 @@ namespace Octokit
         /// </summary>
         /// <param name = "value">The argument value to check</param>
         /// <param name = "name">The name of the argument</param>
-        public static void ArgumentNotNull([ValidatedNotNull]object value, string name)
+        public static void ArgumentNotNull([ValidatedNotNull] object value, string name)
         {
             if (value != null) return;
 
@@ -27,7 +27,7 @@ namespace Octokit
         /// </summary>
         /// <param name = "value">The argument value to check</param>
         /// <param name = "name">The name of the argument</param>
-        public static void ArgumentNotNullOrEmptyString([ValidatedNotNull]string value, string name)
+        public static void ArgumentNotNullOrEmptyString([ValidatedNotNull] string value, string name)
         {
             ArgumentNotNull(value, name);
             if (!string.IsNullOrWhiteSpace(value)) return;
@@ -41,7 +41,7 @@ namespace Octokit
         /// <param name = "value">The argument value to check</param>
         /// <param name = "name">The name of the argument</param>
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        public static void GreaterThanZero([ValidatedNotNull]TimeSpan value, string name)
+        public static void GreaterThanZero([ValidatedNotNull] TimeSpan value, string name)
         {
             ArgumentNotNull(value, name);
 
@@ -55,12 +55,21 @@ namespace Octokit
         /// </summary>
         /// <param name = "value">The argument value to check</param>
         /// <param name = "name">The name of the argument</param>
-        public static void ArgumentNotNullOrEmptyEnumerable<T>([ValidatedNotNull]IEnumerable<T> value, string name)
+        public static void ArgumentNotNullOrEmptyEnumerable<T>([ValidatedNotNull] IEnumerable<T> value, string name)
         {
             ArgumentNotNull(value, name);
             if (Enumerable.Any(value)) return;
 
             throw new ArgumentException("List cannot be empty", name);
+        }
+
+        public static void ArgumentNotContainsBraces(string value, string name)
+        {
+            ArgumentNotNull(value, name);
+
+            if (!value.Contains("{") && !value.Contains("}")) return;
+
+            throw new ArgumentException("Pattern contains braces", name);
         }
     }
 

--- a/Octokit/Helpers/StringExtensions.cs
+++ b/Octokit/Helpers/StringExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Linq;
 using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -20,11 +21,24 @@ namespace Octokit
             return !string.IsNullOrWhiteSpace(value);
         }
 
+        public static Uri FormatUri(this string pattern) => new Uri(pattern, UriKind.Relative);
+
         public static Uri FormatUri(this string pattern, params object[] args)
         {
             Ensure.ArgumentNotNullOrEmptyString(pattern, nameof(pattern));
 
             return new Uri(string.Format(CultureInfo.InvariantCulture, pattern, args), UriKind.Relative);
+        }
+
+        public static Uri FormatUri(this string pattern, params (string Key, string Value)[] args)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(pattern, nameof(pattern));
+
+            var formattedString = pattern.ReplaceAll(args);
+
+            Ensure.ArgumentNotContainsBraces(pattern, nameof(pattern));
+
+            return new Uri(formattedString, UriKind.Relative);
         }
 
         public static string UriEncode(this string input)
@@ -134,6 +148,11 @@ namespace Octokit
         internal static bool IsNameWithOwnerFormat(this string input)
         {
             return nameWithOwner.IsMatch(input);
+        }
+
+        private static string ReplaceAll(this string seed, params (string Key, string Value)[] chars)
+        {
+            return chars.Aggregate(seed, (str, cItem) => str.Replace("{" + cItem.Key + "}", cItem.Value));
         }
     }
 }


### PR DESCRIPTION
fixes #2508 

Please could I get some feedback on where I'm going with this PR? It's going to be a lot of work to go through this file and separate the api urls into a separate file and change to use replacement by name instead of by position.

So far, these are the results.
![image](https://user-images.githubusercontent.com/15954362/183150627-766c8ded-88fa-4fbb-a837-92589f4aa4db.png)

Please could you let me know if I'm going down the wrong road before I get too involved?

Thanks!
@nickfloyd 