### PR TITLE
Fixing the use of the binary formatter in net461 so all unit tests now pass.

### DIFF
--- a/Octokit.Tests/Clients/UsersClientTests.cs
+++ b/Octokit.Tests/Clients/UsersClientTests.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-#if NET_45
-using System.Collections.ObjectModel;
-#endif
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Internal;

--- a/Octokit.Tests/Exceptions/ApiExceptionTests.cs
+++ b/Octokit.Tests/Exceptions/ApiExceptionTests.cs
@@ -2,11 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-#if !NO_SERIALIZABLE
-using System.Runtime.Serialization.Formatters.Binary;
-using System.IO;
-#endif
 using NSubstitute;
+using Octokit.Tests.Helpers;
 using Xunit;
 
 using static Octokit.Internal.TestSetup;
@@ -92,7 +89,6 @@ namespace Octokit.Tests.Exceptions
                 Assert.Equal("message2", thirdException.ApiError.Message);
             }
 
-#if !NO_SERIALIZABLE
             [Fact]
             public void CanPopulateObjectFromSerializedData()
             {
@@ -102,19 +98,11 @@ namespace Octokit.Tests.Exceptions
                     @"already in use"",""resource"":""PublicKey""}],""message"":""Validation Failed""}");
 
                 var exception = new ApiException(response);
+                var deserialized = BinaryFormatterExtensions.SerializeAndDeserializeObject(exception);
 
-                using (var stream = new MemoryStream())
-                {
-                    var formatter = new BinaryFormatter();
-                    formatter.Serialize(stream, exception);
-                    stream.Position = 0;
-                    var deserializedObject = formatter.Deserialize(stream);
-                    var deserialized = (ApiException)deserializedObject;
-                    Assert.Equal("Validation Failed", deserialized.ApiError.Message);
-                    Assert.Equal("key is already in use", exception.ApiError.Errors.First().Message);
-                }
+                Assert.Equal("Validation Failed", deserialized.ApiError.Message);
+                Assert.Equal("key is already in use", exception.ApiError.Errors.First().Message);
             }
-#endif
         }
 
         public class TheToStringMethod

--- a/Octokit.Tests/Exceptions/ApiValidationExceptionTests.cs
+++ b/Octokit.Tests/Exceptions/ApiValidationExceptionTests.cs
@@ -1,12 +1,9 @@
 ﻿using System.Linq;
 using System.Net;
-#if !NO_SERIALIZABLE
-using System.Runtime.Serialization.Formatters.Binary;
-using System.IO;
-#endif
 using Xunit;
 
 using static Octokit.Internal.TestSetup;
+using Octokit.Tests.Helpers;
 
 namespace Octokit.Tests.Exceptions
 {
@@ -38,7 +35,6 @@ namespace Octokit.Tests.Exceptions
                 Assert.Equal("Validation Failed", exception.Message);
             }
 
-#if !NO_SERIALIZABLE
             [Fact]
             public void CanPopulateObjectFromSerializedData()
             {
@@ -48,18 +44,11 @@ namespace Octokit.Tests.Exceptions
                     @"already in use"",""resource"":""PublicKey""}],""message"":""Validation Failed""}");
 
                 var exception = new ApiValidationException(response);
+                var deserialized = BinaryFormatterExtensions.SerializeAndDeserializeObject(exception);
 
-                using (var stream = new MemoryStream())
-                {
-                    var formatter = new BinaryFormatter();
-                    formatter.Serialize(stream, exception);
-                    stream.Position = 0;
-                    var deserialized = (ApiValidationException)formatter.Deserialize(stream);
-                    Assert.Equal("Validation Failed", deserialized.ApiError.Message);
-                    Assert.Equal("key is already in use", exception.ApiError.Errors.First().Message);
-                }
+                Assert.Equal("Validation Failed", deserialized.ApiError.Message);
+                Assert.Equal("key is already in use", exception.ApiError.Errors.First().Message);
             }
-#endif
         }
     }
 }

--- a/Octokit.Tests/Helpers/BindaryFormatterHelpers.cs
+++ b/Octokit.Tests/Helpers/BindaryFormatterHelpers.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+
+namespace Octokit.Tests.Helpers
+{
+    public class BinaryFormatterExtensions
+    {
+        public static T SerializeAndDeserializeObject<T>(T input)
+        {
+            using (var stream = new MemoryStream())
+            {
+                var formatter = new BinaryFormatter();
+                formatter.Serialize(stream, input);
+                stream.Position = 0;
+                formatter.Binder = new SerializationBinderHelper();
+                var deserializedObject = formatter.Deserialize(stream);
+                var deserialized = (T)deserializedObject;
+                return deserialized;
+            }
+        }
+
+        internal class SerializationBinderHelper : SerializationBinder
+        {
+            public string Name { get; set; }
+
+            public override Type BindToType(string i_AssemblyName, string i_TypeName)
+            {
+                Type typeToDeserialize = Type.GetType(String.Format(" {0}, {1}", i_TypeName, i_AssemblyName)); return typeToDeserialize;
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Http/RateLimitTests.cs
+++ b/Octokit.Tests/Http/RateLimitTests.cs
@@ -1,10 +1,7 @@
-﻿using System;
+﻿using Octokit.Tests.Helpers;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
-#if !NO_SERIALIZABLE
-using System.IO;
-using System.Runtime.Serialization.Formatters.Binary;
-#endif
 using Xunit;
 
 namespace Octokit.Tests.Http
@@ -71,7 +68,6 @@ namespace Octokit.Tests.Http
                 Assert.Equal(expectedReset, rateLimit.Reset);
             }
 
-#if !NO_SERIALIZABLE
             [Fact]
             public void CanPopulateObjectFromSerializedData()
             {
@@ -83,24 +79,17 @@ namespace Octokit.Tests.Http
                 };
 
                 var rateLimit = new RateLimit(headers);
+                var deserialized = BinaryFormatterExtensions.SerializeAndDeserializeObject(rateLimit);
 
-                using (var stream = new MemoryStream())
-                {
-                    var formatter = new BinaryFormatter();
-                    formatter.Serialize(stream, rateLimit);
-                    stream.Position = 0;
-                    var deserialized = (RateLimit)formatter.Deserialize(stream);
-
-                    Assert.Equal(100, deserialized.Limit);
-                    Assert.Equal(42, deserialized.Remaining);
-                    var expectedReset = DateTimeOffset.ParseExact(
-                        "Mon 01 Jul 2013 5:47:53 PM -00:00",
-                        "ddd dd MMM yyyy h:mm:ss tt zzz",
-                        CultureInfo.InvariantCulture);
-                    Assert.Equal(expectedReset, deserialized.Reset);
-                }
+                Assert.Equal(100, deserialized.Limit);
+                Assert.Equal(42, deserialized.Remaining);
+                var expectedReset = DateTimeOffset.ParseExact(
+                    "Mon 01 Jul 2013 5:47:53 PM -00:00",
+                    "ddd dd MMM yyyy h:mm:ss tt zzz",
+                    CultureInfo.InvariantCulture);
+                Assert.Equal(expectedReset, deserialized.Reset);
             }
-#endif
+
             [Fact]
             public void EnsuresHeadersNotNull()
             {


### PR DESCRIPTION
Also removed the need to have binary formatter tests run only in framework as it also works on netcoreapp3.1.
#2496 