### PR TITLE
Add generators project for source generation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,6 +7,7 @@ FROM mcr.microsoft.com/vscode/devcontainers/dotnet
 # "install" the dotnet 3.1 & 5.0 runtime for tests
 COPY --from=mcr.microsoft.com/dotnet/sdk:3.1 /usr/share/dotnet/shared /usr/share/dotnet/shared
 COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet/shared /usr/share/dotnet/shared
+COPY --from=mcr.microsoft.com/dotnet/sdk:6.0 /usr/share/dotnet/shared /usr/share/dotnet/shared
 
 # # Add mkdocs for doc generation
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive && apt-get -y install --no-install-recommends python3-pip

--- a/.github/workflows/netcore.yml
+++ b/.github/workflows/netcore.yml
@@ -19,6 +19,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+    - name: Setup .NET 5
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.*
     - name: Setup .NET 6
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/netcore.yml
+++ b/.github/workflows/netcore.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup .NET 5
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.*
+        dotnet-version: 6.0.*
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/netcore.yml
+++ b/.github/workflows/netcore.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Setup .NET 5
+    - name: Setup .NET 6
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 6.0.*

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,11 +13,14 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
+    - name: Setup .NET 5
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.*
     - name: Setup .NET 6
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 6.0.*
-
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: Setup .NET 5
+    - name: Setup .NET 6
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.*
+        dotnet-version: 6.0.*
 
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,16 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Run Generator",
+      "type": "coreclr",
+      "request": "launch",
+      "program": "${workspaceFolder}/Octokit.Generators/bin/Debug/net6.0/Octokit.Generators",
+      "args": [],
+      "cwd": "${workspaceFolder}/Octokit.Generators",
+      "console": "internalConsole",
+      "stopAtEntry": false
+    },
+    {
       "name": "Run unit tests",
       "type": "coreclr",
       "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
       "name": "Run Generator",
       "type": "coreclr",
       "request": "launch",
-      "program": "${workspaceFolder}/Octokit.Generators/bin/Debug/net6.0/Octokit.Generators",
+      "program": "${workspaceFolder}/Octokit.Generators/bin/Debug/net5.0/Octokit.Generators",
       "args": [],
       "cwd": "${workspaceFolder}/Octokit.Generators",
       "console": "internalConsole",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
       "name": "Run Generator",
       "type": "coreclr",
       "request": "launch",
-      "program": "${workspaceFolder}/Octokit.Generators/bin/Debug/net5.0/Octokit.Generators",
+      "program": "${workspaceFolder}/Octokit.Generators/bin/Debug/net6.0/Octokit.Generators",
       "args": [],
       "cwd": "${workspaceFolder}/Octokit.Generators",
       "console": "internalConsole",

--- a/Octokit.AsyncPaginationExtension/Extensions.cs
+++ b/Octokit.AsyncPaginationExtension/Extensions.cs
@@ -1,870 +1,822 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace Octokit.AsyncPaginationExtension
 {
-    /// <summary>
-    /// Provides all extensions for pagination.
-    /// </summary>
-    /// <remarks>
-    /// The <code>pageSize</code> parameter at the end of all methods allows for specifying the amount of elements to be fetched per page.
-    /// Only useful to optimize the amount of API calls made.
-    /// </remarks>
-    public static class Extensions
-    {
-        private const int DEFAULT_PAGE_SIZE = 30;
-
-        /// <inheritdoc cref="IAssigneesClient.GetAllForRepository(string, string, ApiOptions)"/>
-        public static IPaginatedList<User> GetAllForRepositoryAsync(this IAssigneesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IAssigneesClient.GetAllForRepository(long, ApiOptions)"/>
-        public static IPaginatedList<User> GetAllForRepositoryAsync(this IAssigneesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IAuthorizationsClient.GetAll(ApiOptions)"/>
-        public static IPaginatedList<Authorization> GetAllAsync(this IAuthorizationsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Authorization>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="ICheckRunsClient.GetAllAnnotations(string, string, long, ApiOptions)"/>
-        public static IPaginatedList<CheckRunAnnotation> GetAllAnnotationsAsync(this ICheckRunsClient t, string owner, string name, long checkRunId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<CheckRunAnnotation>(options => t.GetAllAnnotations(owner, name, checkRunId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="ICheckRunsClient.GetAllAnnotations(long, long, ApiOptions)"/>
-        public static IPaginatedList<CheckRunAnnotation> GetAllAnnotationsAsync(this ICheckRunsClient t, long repositoryId, long checkRunId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<CheckRunAnnotation>(options => t.GetAllAnnotations(repositoryId, checkRunId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="ICommitCommentReactionsClient.GetAll(string, string, int, ApiOptions)"/>
-        public static IPaginatedList<Reaction> GetAllAsync(this ICommitCommentReactionsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="ICommitCommentReactionsClient.GetAll(long, int, ApiOptions)"/>
-        public static IPaginatedList<Reaction> GetAllAsync(this ICommitCommentReactionsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="ICommitStatusClient.GetAll(string, string, string, ApiOptions)"/>
-        public static IPaginatedList<CommitStatus> GetAllAsync(this ICommitStatusClient t, string owner, string name, string reference, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<CommitStatus>(options => t.GetAll(owner, name, reference, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="ICommitStatusClient.GetAll(long, string, ApiOptions)"/>
-        public static IPaginatedList<CommitStatus> GetAllAsync(this ICommitStatusClient t, long repositoryId, string reference, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<CommitStatus>(options => t.GetAll(repositoryId, reference, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IDeploymentsClient.GetAll(string, string, ApiOptions)"/>
-        public static IPaginatedList<Deployment> GetAllAsync(this IDeploymentsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Deployment>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IDeploymentsClient.GetAll(long, ApiOptions)"/>
-        public static IPaginatedList<Deployment> GetAllAsync(this IDeploymentsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Deployment>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IDeploymentStatusClient.GetAll(string, string, int, ApiOptions)"/>
-        public static IPaginatedList<DeploymentStatus> GetAllAsync(this IDeploymentStatusClient t, string owner, string name, int deploymentId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<DeploymentStatus>(options => t.GetAll(owner, name, deploymentId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IDeploymentStatusClient.GetAll(long, int, ApiOptions)"/>
-        public static IPaginatedList<DeploymentStatus> GetAllAsync(this IDeploymentStatusClient t, long repositoryId, int deploymentId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<DeploymentStatus>(options => t.GetAll(repositoryId, deploymentId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IEventsClient.GetAll(ApiOptions)"/>
-        public static IPaginatedList<Activity> GetAllAsync(this IEventsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Activity>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IEventsClient.GetAllForRepository(string, string, ApiOptions)"/>
-        public static IPaginatedList<Activity> GetAllForRepositoryAsync(this IEventsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IEventsClient.GetAllForRepository(long, ApiOptions)"/>
-        public static IPaginatedList<Activity> GetAllForRepositoryAsync(this IEventsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IEventsClient.GetAllIssuesForRepository(string, string, ApiOptions)"/>
-        public static IPaginatedList<IssueEvent> GetAllIssuesForRepositoryAsync(this IEventsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllIssuesForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IEventsClient.GetAllIssuesForRepository(long, ApiOptions)"/>
-        public static IPaginatedList<IssueEvent> GetAllIssuesForRepositoryAsync(this IEventsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllIssuesForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IEventsClient.GetAllForRepositoryNetwork(string, string, ApiOptions)"/>
-        public static IPaginatedList<Activity> GetAllForRepositoryNetworkAsync(this IEventsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllForRepositoryNetwork(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IEventsClient.GetAllForOrganization(string, ApiOptions)"/>
-        public static IPaginatedList<Activity> GetAllForOrganizationAsync(this IEventsClient t, string organization, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllForOrganization(organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IEventsClient.GetAllUserReceived(string, ApiOptions)"/>
-        public static IPaginatedList<Activity> GetAllUserReceivedAsync(this IEventsClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllUserReceived(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IEventsClient.GetAllUserReceivedPublic(string, ApiOptions)"/>
-        public static IPaginatedList<Activity> GetAllUserReceivedPublicAsync(this IEventsClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllUserReceivedPublic(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IEventsClient.GetAllUserPerformed(string, ApiOptions)"/>
-        public static IPaginatedList<Activity> GetAllUserPerformedAsync(this IEventsClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllUserPerformed(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IEventsClient.GetAllUserPerformedPublic(string, ApiOptions)"/>
-        public static IPaginatedList<Activity> GetAllUserPerformedPublicAsync(this IEventsClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllUserPerformedPublic(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IEventsClient.GetAllForAnOrganization(string, string, ApiOptions)"/>
-        public static IPaginatedList<Activity> GetAllForAnOrganizationAsync(this IEventsClient t, string user, string organization, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllForAnOrganization(user, organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IFollowersClient.GetAllForCurrent(ApiOptions)"/>
-        public static IPaginatedList<User> GetAllForCurrentAsync(this IFollowersClient t, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<User>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IFollowersClient.GetAll(string, ApiOptions)"/>
-        public static IPaginatedList<User> GetAllAsync(this IFollowersClient t, string login, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(login, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IFollowersClient.GetAllFollowingForCurrent(ApiOptions)"/>
-        public static IPaginatedList<User> GetAllFollowingForCurrentAsync(this IFollowersClient t, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<User>(t.GetAllFollowingForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IFollowersClient.GetAllFollowing(string, ApiOptions)"/>
-        public static IPaginatedList<User> GetAllFollowingAsync(this IFollowersClient t, string login, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllFollowing(login, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IGistCommentsClient.GetAllForGist(string, ApiOptions)"/>
-        public static IPaginatedList<GistComment> GetAllForGistAsync(this IGistCommentsClient t, string gistId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<GistComment>(options => t.GetAllForGist(gistId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IGistsClient.GetAll(ApiOptions)"/>
-        public static IPaginatedList<Gist> GetAllAsync(this IGistsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Gist>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IGistsClient.GetAll(DateTimeOffset, ApiOptions)"/>
-        public static IPaginatedList<Gist> GetAllAsync(this IGistsClient t, DateTimeOffset since, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Gist>(options => t.GetAll(since, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IGistsClient.GetAllPublic(ApiOptions)"/>
-        public static IPaginatedList<Gist> GetAllPublicAsync(this IGistsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Gist>(t.GetAllPublic, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IGistsClient.GetAllPublic(DateTimeOffset, ApiOptions)"/>
-        public static IPaginatedList<Gist> GetAllPublicAsync(this IGistsClient t, DateTimeOffset since, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Gist>(options => t.GetAllPublic(since, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IGistsClient.GetAllStarred(ApiOptions)"/>
-        public static IPaginatedList<Gist> GetAllStarredAsync(this IGistsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Gist>(t.GetAllStarred, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IGistsClient.GetAllStarred(DateTimeOffset, ApiOptions)"/>
-        public static IPaginatedList<Gist> GetAllStarredAsync(this IGistsClient t, DateTimeOffset since, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Gist>(options => t.GetAllStarred(since, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IGistsClient.GetAllForUser(string, ApiOptions)"/>
-        public static IPaginatedList<Gist> GetAllForUserAsync(this IGistsClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Gist>(options => t.GetAllForUser(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IGistsClient.GetAllForUser(string, DateTimeOffset, ApiOptions)"/>
-        public static IPaginatedList<Gist> GetAllForUserAsync(this IGistsClient t, string user, DateTimeOffset since, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Gist>(options => t.GetAllForUser(user, since, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IGistsClient.GetAllCommits(string, ApiOptions)"/>
-        public static IPaginatedList<GistHistory> GetAllCommitsAsync(this IGistsClient t, string id, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<GistHistory>(options => t.GetAllCommits(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IGistsClient.GetAllForks(string, ApiOptions)"/>
-        public static IPaginatedList<GistFork> GetAllForksAsync(this IGistsClient t, string id, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<GistFork>(options => t.GetAllForks(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IGitHubAppsClient.GetAllInstallationsForCurrent(ApiOptions)"/>
-        public static IPaginatedList<Installation> GetAllInstallationsForCurrentAsync(this IGitHubAppsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Installation>(t.GetAllInstallationsForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IIssueCommentReactionsClient.GetAll(string, string, int, ApiOptions)"/>
-        public static IPaginatedList<Reaction> GetAllAsync(this IIssueCommentReactionsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IIssueCommentReactionsClient.GetAll(long, int, ApiOptions)"/>
-        public static IPaginatedList<Reaction> GetAllAsync(this IIssueCommentReactionsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IIssueCommentsClient.GetAllForRepository(string, string, ApiOptions)"/>
-        public static IPaginatedList<IssueComment> GetAllForRepositoryAsync(this IIssueCommentsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IIssueCommentsClient.GetAllForRepository(long, ApiOptions)"/>
-        public static IPaginatedList<IssueComment> GetAllForRepositoryAsync(this IIssueCommentsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IIssueCommentsClient.GetAllForRepository(string, string, IssueCommentRequest, ApiOptions)"/>
-        public static IPaginatedList<IssueComment> GetAllForRepositoryAsync(this IIssueCommentsClient t, string owner, string name, IssueCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IIssueCommentsClient.GetAllForRepository(long, IssueCommentRequest, ApiOptions)"/>
-        public static IPaginatedList<IssueComment> GetAllForRepositoryAsync(this IIssueCommentsClient t, long repositoryId, IssueCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IIssueCommentsClient.GetAllForIssue(string, string, int, ApiOptions)"/>
-        public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForIssue(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IIssueCommentsClient.GetAllForIssue(long, int, ApiOptions)"/>
-        public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForIssue(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IIssueCommentsClient.GetAllForIssue(string, string, int, IssueCommentRequest, ApiOptions)"/>
-        public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, string owner, string name, int number, IssueCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForIssue(owner, name, number, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IIssueCommentsClient.GetAllForIssue(long, int, IssueCommentRequest, ApiOptions)"/>
-        public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, long repositoryId, int number, IssueCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForIssue(repositoryId, number, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IIssueReactionsClient.GetAll(string, string, int, ApiOptions)"/>
-        public static IPaginatedList<Reaction> GetAllAsync(this IIssueReactionsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IIssueReactionsClient.GetAll(long, int, ApiOptions)"/>
-        public static IPaginatedList<Reaction> GetAllAsync(this IIssueReactionsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IIssuesClient.GetAllForCurrent(ApiOptions)"/>
-        public static IPaginatedList<Issue> GetAllForCurrentAsync(this IIssuesClient t, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Issue>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IIssuesClient.GetAllForCurrent(IssueRequest, ApiOptions)"/>
-        public static IPaginatedList<Issue> GetAllForCurrentAsync(this IIssuesClient t, IssueRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForCurrent(request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IIssuesClient.GetAllForOwnedAndMemberRepositories(ApiOptions)"/>
-        public static IPaginatedList<Issue> GetAllForOwnedAndMemberRepositoriesAsync(this IIssuesClient t, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Issue>(t.GetAllForOwnedAndMemberRepositories, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IIssuesClient.GetAllForOwnedAndMemberRepositories(IssueRequest, ApiOptions)"/>
-        public static IPaginatedList<Issue> GetAllForOwnedAndMemberRepositoriesAsync(this IIssuesClient t, IssueRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForOwnedAndMemberRepositories(request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IIssuesClient.GetAllForOrganization(string, ApiOptions)"/>
-        public static IPaginatedList<Issue> GetAllForOrganizationAsync(this IIssuesClient t, string organization, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForOrganization(organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IIssuesClient.GetAllForOrganization(string, IssueRequest, ApiOptions)"/>
-        public static IPaginatedList<Issue> GetAllForOrganizationAsync(this IIssuesClient t, string organization, IssueRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForOrganization(organization, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IIssuesClient.GetAllForRepository(string, string, ApiOptions)"/>
-        public static IPaginatedList<Issue> GetAllForRepositoryAsync(this IIssuesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IIssuesClient.GetAllForRepository(long, ApiOptions)"/>
-        public static IPaginatedList<Issue> GetAllForRepositoryAsync(this IIssuesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IIssuesClient.GetAllForRepository(string, string, RepositoryIssueRequest, ApiOptions)"/>
-        public static IPaginatedList<Issue> GetAllForRepositoryAsync(this IIssuesClient t, string owner, string name, RepositoryIssueRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IIssuesClient.GetAllForRepository(long, RepositoryIssueRequest, ApiOptions)"/>
-        public static IPaginatedList<Issue> GetAllForRepositoryAsync(this IIssuesClient t, long repositoryId, RepositoryIssueRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IIssuesEventsClient.GetAllForIssue(string, string, int, ApiOptions)"/>
-        public static IPaginatedList<IssueEvent> GetAllForIssueAsync(this IIssuesEventsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllForIssue(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IIssuesEventsClient.GetAllForIssue(long, int, ApiOptions)"/>
-        public static IPaginatedList<IssueEvent> GetAllForIssueAsync(this IIssuesEventsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllForIssue(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IIssuesEventsClient.GetAllForRepository(string, string, ApiOptions)"/>
-        public static IPaginatedList<IssueEvent> GetAllForRepositoryAsync(this IIssuesEventsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IIssuesEventsClient.GetAllForRepository(long, ApiOptions)"/>
-        public static IPaginatedList<IssueEvent> GetAllForRepositoryAsync(this IIssuesEventsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IIssuesLabelsClient.GetAllForIssue(string, string, int, ApiOptions)"/>
-        public static IPaginatedList<Label> GetAllForIssueAsync(this IIssuesLabelsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForIssue(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IIssuesLabelsClient.GetAllForIssue(long, int, ApiOptions)"/>
-        public static IPaginatedList<Label> GetAllForIssueAsync(this IIssuesLabelsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForIssue(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IIssuesLabelsClient.GetAllForRepository(string, string, ApiOptions)"/>
-        public static IPaginatedList<Label> GetAllForRepositoryAsync(this IIssuesLabelsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IIssuesLabelsClient.GetAllForRepository(long, ApiOptions)"/>
-        public static IPaginatedList<Label> GetAllForRepositoryAsync(this IIssuesLabelsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IIssuesLabelsClient.GetAllForMilestone(string, string, int, ApiOptions)"/>
-        public static IPaginatedList<Label> GetAllForMilestoneAsync(this IIssuesLabelsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForMilestone(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IIssuesLabelsClient.GetAllForMilestone(long, int, ApiOptions)"/>
-        public static IPaginatedList<Label> GetAllForMilestoneAsync(this IIssuesLabelsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForMilestone(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IIssueTimelineClient.GetAllForIssue(string, string, int, ApiOptions)"/>
-        public static IPaginatedList<TimelineEventInfo> GetAllForIssueAsync(this IIssueTimelineClient t, string owner, string repo, int number, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<TimelineEventInfo>(options => t.GetAllForIssue(owner, repo, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IIssueTimelineClient.GetAllForIssue(long, int, ApiOptions)"/>
-        public static IPaginatedList<TimelineEventInfo> GetAllForIssueAsync(this IIssueTimelineClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<TimelineEventInfo>(options => t.GetAllForIssue(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IMilestonesClient.GetAllForRepository(string, string, ApiOptions)"/>
-        public static IPaginatedList<Milestone> GetAllForRepositoryAsync(this IMilestonesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Milestone>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IMilestonesClient.GetAllForRepository(long, ApiOptions)"/>
-        public static IPaginatedList<Milestone> GetAllForRepositoryAsync(this IMilestonesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Milestone>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IMilestonesClient.GetAllForRepository(string, string, MilestoneRequest, ApiOptions)"/>
-        public static IPaginatedList<Milestone> GetAllForRepositoryAsync(this IMilestonesClient t, string owner, string name, MilestoneRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Milestone>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IMilestonesClient.GetAllForRepository(long, MilestoneRequest, ApiOptions)"/>
-        public static IPaginatedList<Milestone> GetAllForRepositoryAsync(this IMilestonesClient t, long repositoryId, MilestoneRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Milestone>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IMiscellaneousClient.GetAllLicenses(ApiOptions)"/>
-        public static IPaginatedList<LicenseMetadata> GetAllLicensesAsync(this IMiscellaneousClient t, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<LicenseMetadata>(t.GetAllLicenses, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="INotificationsClient.GetAllForCurrent(ApiOptions)"/>
-        public static IPaginatedList<Notification> GetAllForCurrentAsync(this INotificationsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Notification>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="INotificationsClient.GetAllForCurrent(NotificationsRequest, ApiOptions)"/>
-        public static IPaginatedList<Notification> GetAllForCurrentAsync(this INotificationsClient t, NotificationsRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Notification>(options => t.GetAllForCurrent(request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="INotificationsClient.GetAllForRepository(string, string, ApiOptions)"/>
-        public static IPaginatedList<Notification> GetAllForRepositoryAsync(this INotificationsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Notification>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="INotificationsClient.GetAllForRepository(long, ApiOptions)"/>
-        public static IPaginatedList<Notification> GetAllForRepositoryAsync(this INotificationsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Notification>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="INotificationsClient.GetAllForRepository(string, string, NotificationsRequest, ApiOptions)"/>
-        public static IPaginatedList<Notification> GetAllForRepositoryAsync(this INotificationsClient t, string owner, string name, NotificationsRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Notification>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="INotificationsClient.GetAllForRepository(long, NotificationsRequest, ApiOptions)"/>
-        public static IPaginatedList<Notification> GetAllForRepositoryAsync(this INotificationsClient t, long repositoryId, NotificationsRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Notification>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IOrganizationHooksClient.GetAll(string, ApiOptions)"/>
-        public static IPaginatedList<OrganizationHook> GetAllAsync(this IOrganizationHooksClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<OrganizationHook>(options => t.GetAll(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IOrganizationMembersClient.GetAll(string, ApiOptions)"/>
-        public static IPaginatedList<User> GetAllAsync(this IOrganizationMembersClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IOrganizationMembersClient.GetAll(string, OrganizationMembersFilter, ApiOptions)"/>
-        public static IPaginatedList<User> GetAllAsync(this IOrganizationMembersClient t, string org, OrganizationMembersFilter filter, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, filter, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IOrganizationMembersClient.GetAll(string, OrganizationMembersRole, ApiOptions)"/>
-        public static IPaginatedList<User> GetAllAsync(this IOrganizationMembersClient t, string org, OrganizationMembersRole role, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, role, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IOrganizationMembersClient.GetAll(string, OrganizationMembersFilter, OrganizationMembersRole, ApiOptions)"/>
-        public static IPaginatedList<User> GetAllAsync(this IOrganizationMembersClient t, string org, OrganizationMembersFilter filter, OrganizationMembersRole role, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, filter, role, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IOrganizationMembersClient.GetAllPublic(string, ApiOptions)"/>
-        public static IPaginatedList<User> GetAllPublicAsync(this IOrganizationMembersClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllPublic(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IOrganizationMembersClient.GetAllPendingInvitations(string, ApiOptions)"/>
-        public static IPaginatedList<OrganizationMembershipInvitation> GetAllPendingInvitationsAsync(this IOrganizationMembersClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<OrganizationMembershipInvitation>(options => t.GetAllPendingInvitations(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IOrganizationOutsideCollaboratorsClient.GetAll(string, ApiOptions)"/>
-        public static IPaginatedList<User> GetAllAsync(this IOrganizationOutsideCollaboratorsClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IOrganizationOutsideCollaboratorsClient.GetAll(string, OrganizationMembersFilter, ApiOptions)"/>
-        public static IPaginatedList<User> GetAllAsync(this IOrganizationOutsideCollaboratorsClient t, string org, OrganizationMembersFilter filter, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, filter, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IOrganizationsClient.GetAllForCurrent(ApiOptions)"/>
-        public static IPaginatedList<Organization> GetAllForCurrentAsync(this IOrganizationsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Organization>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IOrganizationsClient.GetAllForUser(string, ApiOptions)"/>
-        public static IPaginatedList<Organization> GetAllForUserAsync(this IOrganizationsClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Organization>(options => t.GetAllForUser(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IProjectCardsClient.GetAll(int, ApiOptions)"/>
-        public static IPaginatedList<ProjectCard> GetAllAsync(this IProjectCardsClient t, int columnId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<ProjectCard>(options => t.GetAll(columnId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IProjectCardsClient.GetAll(int, ProjectCardRequest, ApiOptions)"/>
-        public static IPaginatedList<ProjectCard> GetAllAsync(this IProjectCardsClient t, int columnId, ProjectCardRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<ProjectCard>(options => t.GetAll(columnId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IProjectColumnsClient.GetAll(int, ApiOptions)"/>
-        public static IPaginatedList<ProjectColumn> GetAllAsync(this IProjectColumnsClient t, int projectId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<ProjectColumn>(options => t.GetAll(projectId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IProjectsClient.GetAllForRepository(string, string, ApiOptions)"/>
-        public static IPaginatedList<Project> GetAllForRepositoryAsync(this IProjectsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IProjectsClient.GetAllForRepository(string, string, ProjectRequest, ApiOptions)"/>
-        public static IPaginatedList<Project> GetAllForRepositoryAsync(this IProjectsClient t, string owner, string name, ProjectRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IProjectsClient.GetAllForRepository(long, ApiOptions)"/>
-        public static IPaginatedList<Project> GetAllForRepositoryAsync(this IProjectsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IProjectsClient.GetAllForRepository(long, ProjectRequest, ApiOptions)"/>
-        public static IPaginatedList<Project> GetAllForRepositoryAsync(this IProjectsClient t, long repositoryId, ProjectRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IProjectsClient.GetAllForOrganization(string, ApiOptions)"/>
-        public static IPaginatedList<Project> GetAllForOrganizationAsync(this IProjectsClient t, string organization, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForOrganization(organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IProjectsClient.GetAllForOrganization(string, ProjectRequest, ApiOptions)"/>
-        public static IPaginatedList<Project> GetAllForOrganizationAsync(this IProjectsClient t, string organization, ProjectRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForOrganization(organization, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IPullRequestReviewCommentReactionsClient.GetAll(string, string, int, ApiOptions)"/>
-        public static IPaginatedList<Reaction> GetAllAsync(this IPullRequestReviewCommentReactionsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IPullRequestReviewCommentReactionsClient.GetAll(long, int, ApiOptions)"/>
-        public static IPaginatedList<Reaction> GetAllAsync(this IPullRequestReviewCommentReactionsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IPullRequestReviewCommentsClient.GetAll(string, string, int, ApiOptions)"/>
-        public static IPaginatedList<PullRequestReviewComment> GetAllAsync(this IPullRequestReviewCommentsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAll(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IPullRequestReviewCommentsClient.GetAll(long, int, ApiOptions)"/>
-        public static IPaginatedList<PullRequestReviewComment> GetAllAsync(this IPullRequestReviewCommentsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAll(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IPullRequestReviewCommentsClient.GetAllForRepository(string, string, ApiOptions)"/>
-        public static IPaginatedList<PullRequestReviewComment> GetAllForRepositoryAsync(this IPullRequestReviewCommentsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IPullRequestReviewCommentsClient.GetAllForRepository(long, ApiOptions)"/>
-        public static IPaginatedList<PullRequestReviewComment> GetAllForRepositoryAsync(this IPullRequestReviewCommentsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IPullRequestReviewCommentsClient.GetAllForRepository(string, string, PullRequestReviewCommentRequest, ApiOptions)"/>
-        public static IPaginatedList<PullRequestReviewComment> GetAllForRepositoryAsync(this IPullRequestReviewCommentsClient t, string owner, string name, PullRequestReviewCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IPullRequestReviewCommentsClient.GetAllForRepository(long, PullRequestReviewCommentRequest, ApiOptions)"/>
-        public static IPaginatedList<PullRequestReviewComment> GetAllForRepositoryAsync(this IPullRequestReviewCommentsClient t, long repositoryId, PullRequestReviewCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IPullRequestReviewsClient.GetAll(string, string, int, ApiOptions)"/>
-        public static IPaginatedList<PullRequestReview> GetAllAsync(this IPullRequestReviewsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<PullRequestReview>(options => t.GetAll(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IPullRequestReviewsClient.GetAll(long, int, ApiOptions)"/>
-        public static IPaginatedList<PullRequestReview> GetAllAsync(this IPullRequestReviewsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<PullRequestReview>(options => t.GetAll(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IPullRequestReviewsClient.GetAllComments(string, string, int, long, ApiOptions)"/>
-        public static IPaginatedList<PullRequestReviewComment> GetAllCommentsAsync(this IPullRequestReviewsClient t, string owner, string name, int number, long reviewId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllComments(owner, name, number, reviewId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IPullRequestReviewsClient.GetAllComments(long, int, long, ApiOptions)"/>
-        public static IPaginatedList<PullRequestReviewComment> GetAllCommentsAsync(this IPullRequestReviewsClient t, long repositoryId, int number, long reviewId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllComments(repositoryId, number, reviewId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IPullRequestsClient.GetAllForRepository(string, string, ApiOptions)"/>
-        public static IPaginatedList<PullRequest> GetAllForRepositoryAsync(this IPullRequestsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<PullRequest>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IPullRequestsClient.GetAllForRepository(long, ApiOptions)"/>
-        public static IPaginatedList<PullRequest> GetAllForRepositoryAsync(this IPullRequestsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<PullRequest>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IPullRequestsClient.GetAllForRepository(string, string, PullRequestRequest, ApiOptions)"/>
-        public static IPaginatedList<PullRequest> GetAllForRepositoryAsync(this IPullRequestsClient t, string owner, string name, PullRequestRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<PullRequest>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IPullRequestsClient.GetAllForRepository(long, PullRequestRequest, ApiOptions)"/>
-        public static IPaginatedList<PullRequest> GetAllForRepositoryAsync(this IPullRequestsClient t, long repositoryId, PullRequestRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<PullRequest>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IReferencesClient.GetAll(string, string, ApiOptions)"/>
-        public static IPaginatedList<Reference> GetAllAsync(this IReferencesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Reference>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IReferencesClient.GetAll(long, ApiOptions)"/>
-        public static IPaginatedList<Reference> GetAllAsync(this IReferencesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Reference>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IReferencesClient.GetAllForSubNamespace(string, string, string, ApiOptions)"/>
-        public static IPaginatedList<Reference> GetAllForSubNamespaceAsync(this IReferencesClient t, string owner, string name, string subNamespace, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Reference>(options => t.GetAllForSubNamespace(owner, name, subNamespace, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IReferencesClient.GetAllForSubNamespace(long, string, ApiOptions)"/>
-        public static IPaginatedList<Reference> GetAllForSubNamespaceAsync(this IReferencesClient t, long repositoryId, string subNamespace, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Reference>(options => t.GetAllForSubNamespace(repositoryId, subNamespace, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IReleasesClient.GetAll(string, string, ApiOptions)"/>
-        public static IPaginatedList<Release> GetAllAsync(this IReleasesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Release>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IReleasesClient.GetAll(long, ApiOptions)"/>
-        public static IPaginatedList<Release> GetAllAsync(this IReleasesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Release>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IReleasesClient.GetAllAssets(string, string, int, ApiOptions)"/>
-        public static IPaginatedList<ReleaseAsset> GetAllAssetsAsync(this IReleasesClient t, string owner, string name, int id, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<ReleaseAsset>(options => t.GetAllAssets(owner, name, id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IReleasesClient.GetAllAssets(long, int, ApiOptions)"/>
-        public static IPaginatedList<ReleaseAsset> GetAllAssetsAsync(this IReleasesClient t, long repositoryId, int id, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<ReleaseAsset>(options => t.GetAllAssets(repositoryId, id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IRepoCollaboratorsClient.GetAll(string, string, ApiOptions)"/>
-        public static IPaginatedList<User> GetAllAsync(this IRepoCollaboratorsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IRepoCollaboratorsClient.GetAll(long, ApiOptions)"/>
-        public static IPaginatedList<User> GetAllAsync(this IRepoCollaboratorsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IRepoCollaboratorsClient.GetAll(string, string, RepositoryCollaboratorListRequest, ApiOptions)"/>
-        public static IPaginatedList<User> GetAllAsync(this IRepoCollaboratorsClient t, string owner, string name, RepositoryCollaboratorListRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IRepoCollaboratorsClient.GetAll(long, RepositoryCollaboratorListRequest, ApiOptions)"/>
-        public static IPaginatedList<User> GetAllAsync(this IRepoCollaboratorsClient t, long repositoryId, RepositoryCollaboratorListRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IRepositoriesClient.GetAllForCurrent(ApiOptions)"/>
-        public static IPaginatedList<Repository> GetAllForCurrentAsync(this IRepositoriesClient t, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Repository>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IRepositoriesClient.GetAllForCurrent(RepositoryRequest, ApiOptions)"/>
-        public static IPaginatedList<Repository> GetAllForCurrentAsync(this IRepositoriesClient t, RepositoryRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForCurrent(request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IRepositoriesClient.GetAllForUser(string, ApiOptions)"/>
-        public static IPaginatedList<Repository> GetAllForUserAsync(this IRepositoriesClient t, string login, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForUser(login, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IRepositoriesClient.GetAllForOrg(string, ApiOptions)"/>
-        public static IPaginatedList<Repository> GetAllForOrgAsync(this IRepositoriesClient t, string organization, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForOrg(organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IRepositoriesClient.GetAllContributors(string, string, ApiOptions)"/>
-        public static IPaginatedList<RepositoryContributor> GetAllContributorsAsync(this IRepositoriesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<RepositoryContributor>(options => t.GetAllContributors(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IRepositoriesClient.GetAllContributors(long, ApiOptions)"/>
-        public static IPaginatedList<RepositoryContributor> GetAllContributorsAsync(this IRepositoriesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<RepositoryContributor>(options => t.GetAllContributors(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IRepositoriesClient.GetAllContributors(string, string, bool, ApiOptions)"/>
-        public static IPaginatedList<RepositoryContributor> GetAllContributorsAsync(this IRepositoriesClient t, string owner, string name, bool includeAnonymous, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<RepositoryContributor>(options => t.GetAllContributors(owner, name, includeAnonymous, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IRepositoriesClient.GetAllContributors(long, bool, ApiOptions)"/>
-        public static IPaginatedList<RepositoryContributor> GetAllContributorsAsync(this IRepositoriesClient t, long repositoryId, bool includeAnonymous, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<RepositoryContributor>(options => t.GetAllContributors(repositoryId, includeAnonymous, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IRepositoriesClient.GetAllTeams(string, string, ApiOptions)"/>
-        public static IPaginatedList<Team> GetAllTeamsAsync(this IRepositoriesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Team>(options => t.GetAllTeams(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IRepositoriesClient.GetAllTeams(long, ApiOptions)"/>
-        public static IPaginatedList<Team> GetAllTeamsAsync(this IRepositoriesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Team>(options => t.GetAllTeams(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IRepositoriesClient.GetAllTags(string, string, ApiOptions)"/>
-        public static IPaginatedList<RepositoryTag> GetAllTagsAsync(this IRepositoriesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<RepositoryTag>(options => t.GetAllTags(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IRepositoriesClient.GetAllTags(long, ApiOptions)"/>
-        public static IPaginatedList<RepositoryTag> GetAllTagsAsync(this IRepositoriesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<RepositoryTag>(options => t.GetAllTags(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IRepositoryBranchesClient.GetAll(string, string, ApiOptions)"/>
-        public static IPaginatedList<Branch> GetAllAsync(this IRepositoryBranchesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Branch>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IRepositoryBranchesClient.GetAll(long, ApiOptions)"/>
-        public static IPaginatedList<Branch> GetAllAsync(this IRepositoryBranchesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Branch>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IRepositoryCommentsClient.GetAllForRepository(string, string, ApiOptions)"/>
-        public static IPaginatedList<CommitComment> GetAllForRepositoryAsync(this IRepositoryCommentsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<CommitComment>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IRepositoryCommentsClient.GetAllForRepository(long, ApiOptions)"/>
-        public static IPaginatedList<CommitComment> GetAllForRepositoryAsync(this IRepositoryCommentsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<CommitComment>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IRepositoryCommentsClient.GetAllForCommit(string, string, string, ApiOptions)"/>
-        public static IPaginatedList<CommitComment> GetAllForCommitAsync(this IRepositoryCommentsClient t, string owner, string name, string sha, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<CommitComment>(options => t.GetAllForCommit(owner, name, sha, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IRepositoryCommentsClient.GetAllForCommit(long, string, ApiOptions)"/>
-        public static IPaginatedList<CommitComment> GetAllForCommitAsync(this IRepositoryCommentsClient t, long repositoryId, string sha, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<CommitComment>(options => t.GetAllForCommit(repositoryId, sha, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IRepositoryCommitsClient.GetAll(string, string, ApiOptions)"/>
-        public static IPaginatedList<GitHubCommit> GetAllAsync(this IRepositoryCommitsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<GitHubCommit>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IRepositoryCommitsClient.GetAll(long, ApiOptions)"/>
-        public static IPaginatedList<GitHubCommit> GetAllAsync(this IRepositoryCommitsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<GitHubCommit>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IRepositoryCommitsClient.GetAll(string, string, CommitRequest, ApiOptions)"/>
-        public static IPaginatedList<GitHubCommit> GetAllAsync(this IRepositoryCommitsClient t, string owner, string name, CommitRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<GitHubCommit>(options => t.GetAll(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IRepositoryCommitsClient.GetAll(long, CommitRequest, ApiOptions)"/>
-        public static IPaginatedList<GitHubCommit> GetAllAsync(this IRepositoryCommitsClient t, long repositoryId, CommitRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<GitHubCommit>(options => t.GetAll(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IRepositoryDeployKeysClient.GetAll(string, string, ApiOptions)"/>
-        public static IPaginatedList<DeployKey> GetAllAsync(this IRepositoryDeployKeysClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<DeployKey>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IRepositoryDeployKeysClient.GetAll(long, ApiOptions)"/>
-        public static IPaginatedList<DeployKey> GetAllAsync(this IRepositoryDeployKeysClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<DeployKey>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IRepositoryForksClient.GetAll(string, string, ApiOptions)"/>
-        public static IPaginatedList<Repository> GetAllAsync(this IRepositoryForksClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IRepositoryForksClient.GetAll(long, ApiOptions)"/>
-        public static IPaginatedList<Repository> GetAllAsync(this IRepositoryForksClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IRepositoryForksClient.GetAll(string, string, RepositoryForksListRequest, ApiOptions)"/>
-        public static IPaginatedList<Repository> GetAllAsync(this IRepositoryForksClient t, string owner, string name, RepositoryForksListRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAll(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IRepositoryForksClient.GetAll(long, RepositoryForksListRequest, ApiOptions)"/>
-        public static IPaginatedList<Repository> GetAllAsync(this IRepositoryForksClient t, long repositoryId, RepositoryForksListRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAll(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IRepositoryHooksClient.GetAll(string, string, ApiOptions)"/>
-        public static IPaginatedList<RepositoryHook> GetAllAsync(this IRepositoryHooksClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<RepositoryHook>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IRepositoryHooksClient.GetAll(long, ApiOptions)"/>
-        public static IPaginatedList<RepositoryHook> GetAllAsync(this IRepositoryHooksClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<RepositoryHook>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IRepositoryInvitationsClient.GetAllForCurrent(ApiOptions)"/>
-        public static IPaginatedList<RepositoryInvitation> GetAllForCurrentAsync(this IRepositoryInvitationsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<RepositoryInvitation>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IRepositoryInvitationsClient.GetAllForRepository(long, ApiOptions)"/>
-        public static IPaginatedList<RepositoryInvitation> GetAllForRepositoryAsync(this IRepositoryInvitationsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<RepositoryInvitation>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IRepositoryPagesClient.GetAll(string, string, ApiOptions)"/>
-        public static IPaginatedList<PagesBuild> GetAllAsync(this IRepositoryPagesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<PagesBuild>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IRepositoryPagesClient.GetAll(long, ApiOptions)"/>
-        public static IPaginatedList<PagesBuild> GetAllAsync(this IRepositoryPagesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<PagesBuild>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IStarredClient.GetAllStargazers(string, string, ApiOptions)"/>
-        public static IPaginatedList<User> GetAllStargazersAsync(this IStarredClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllStargazers(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IStarredClient.GetAllStargazers(long, ApiOptions)"/>
-        public static IPaginatedList<User> GetAllStargazersAsync(this IStarredClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllStargazers(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IStarredClient.GetAllStargazersWithTimestamps(string, string, ApiOptions)"/>
-        public static IPaginatedList<UserStar> GetAllStargazersWithTimestampsAsync(this IStarredClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<UserStar>(options => t.GetAllStargazersWithTimestamps(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IStarredClient.GetAllStargazersWithTimestamps(long, ApiOptions)"/>
-        public static IPaginatedList<UserStar> GetAllStargazersWithTimestampsAsync(this IStarredClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<UserStar>(options => t.GetAllStargazersWithTimestamps(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IStarredClient.GetAllForCurrent(ApiOptions)"/>
-        public static IPaginatedList<Repository> GetAllForCurrentAsync(this IStarredClient t, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Repository>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IStarredClient.GetAllForCurrentWithTimestamps(ApiOptions)"/>
-        public static IPaginatedList<RepositoryStar> GetAllForCurrentWithTimestampsAsync(this IStarredClient t, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<RepositoryStar>(t.GetAllForCurrentWithTimestamps, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IStarredClient.GetAllForCurrent(StarredRequest, ApiOptions)"/>
-        public static IPaginatedList<Repository> GetAllForCurrentAsync(this IStarredClient t, StarredRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForCurrent(request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IStarredClient.GetAllForCurrentWithTimestamps(StarredRequest, ApiOptions)"/>
-        public static IPaginatedList<RepositoryStar> GetAllForCurrentWithTimestampsAsync(this IStarredClient t, StarredRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<RepositoryStar>(options => t.GetAllForCurrentWithTimestamps(request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IStarredClient.GetAllForUser(string, ApiOptions)"/>
-        public static IPaginatedList<Repository> GetAllForUserAsync(this IStarredClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForUser(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IStarredClient.GetAllForUserWithTimestamps(string, ApiOptions)"/>
-        public static IPaginatedList<RepositoryStar> GetAllForUserWithTimestampsAsync(this IStarredClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<RepositoryStar>(options => t.GetAllForUserWithTimestamps(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IStarredClient.GetAllForUser(string, StarredRequest, ApiOptions)"/>
-        public static IPaginatedList<Repository> GetAllForUserAsync(this IStarredClient t, string user, StarredRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForUser(user, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IStarredClient.GetAllForUserWithTimestamps(string, StarredRequest, ApiOptions)"/>
-        public static IPaginatedList<RepositoryStar> GetAllForUserWithTimestampsAsync(this IStarredClient t, string user, StarredRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<RepositoryStar>(options => t.GetAllForUserWithTimestamps(user, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="ITeamsClient.GetAll(string, ApiOptions)"/>
-        public static IPaginatedList<Team> GetAllAsync(this ITeamsClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Team>(options => t.GetAll(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="ITeamsClient.GetAllForCurrent(ApiOptions)"/>
-        public static IPaginatedList<Team> GetAllForCurrentAsync(this ITeamsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Team>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="ITeamsClient.GetAllChildTeams(int, ApiOptions)"/>
-        public static IPaginatedList<Team> GetAllChildTeamsAsync(this ITeamsClient t, int id, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Team>(options => t.GetAllChildTeams(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="ITeamsClient.GetAllMembers(int, ApiOptions)"/>
-        public static IPaginatedList<User> GetAllMembersAsync(this ITeamsClient t, int id, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllMembers(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="ITeamsClient.GetAllMembers(int, TeamMembersRequest, ApiOptions)"/>
-        public static IPaginatedList<User> GetAllMembersAsync(this ITeamsClient t, int id, TeamMembersRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllMembers(id, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="ITeamsClient.GetAllRepositories(int, ApiOptions)"/>
-        public static IPaginatedList<Repository> GetAllRepositoriesAsync(this ITeamsClient t, int id, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllRepositories(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="ITeamsClient.GetAllPendingInvitations(int, ApiOptions)"/>
-        public static IPaginatedList<OrganizationMembershipInvitation> GetAllPendingInvitationsAsync(this ITeamsClient t, int id, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<OrganizationMembershipInvitation>(options => t.GetAllPendingInvitations(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IUserEmailsClient.GetAll(ApiOptions)"/>
-        public static IPaginatedList<EmailAddress> GetAllAsync(this IUserEmailsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<EmailAddress>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IUserGpgKeysClient.GetAllForCurrent(ApiOptions)"/>
-        public static IPaginatedList<GpgKey> GetAllForCurrentAsync(this IUserGpgKeysClient t, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<GpgKey>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IUserKeysClient.GetAll(string, ApiOptions)"/>
-        public static IPaginatedList<PublicKey> GetAllAsync(this IUserKeysClient t, string userName, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<PublicKey>(options => t.GetAll(userName, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IUserKeysClient.GetAllForCurrent(ApiOptions)"/>
-        public static IPaginatedList<PublicKey> GetAllForCurrentAsync(this IUserKeysClient t, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<PublicKey>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IWatchedClient.GetAllWatchers(string, string, ApiOptions)"/>
-        public static IPaginatedList<User> GetAllWatchersAsync(this IWatchedClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllWatchers(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IWatchedClient.GetAllWatchers(long, ApiOptions)"/>
-        public static IPaginatedList<User> GetAllWatchersAsync(this IWatchedClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllWatchers(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IWatchedClient.GetAllForCurrent(ApiOptions)"/>
-        public static IPaginatedList<Repository> GetAllForCurrentAsync(this IWatchedClient t, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Repository>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IWatchedClient.GetAllForUser(string, ApiOptions)"/>
-        public static IPaginatedList<Repository> GetAllForUserAsync(this IWatchedClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForUser(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IApiConnection.GetAll(Uri, ApiOptions)"/>
-        public static IPaginatedList<T> GetAllAsync<T>(this IApiConnection t, Uri uri, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<T>(options => t.GetAll<T>(uri, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IApiConnection.GetAll(Uri, IDictionary{string, string}, ApiOptions)"/>
-        public static IPaginatedList<T> GetAllAsync<T>(this IApiConnection t, Uri uri, IDictionary<string, string> parameters, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<T>(options => t.GetAll<T>(uri, parameters, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-        /// <inheritdoc cref="IApiConnection.GetAll(Uri, IDictionary{string, string}, string, ApiOptions)"/>
-        public static IPaginatedList<T> GetAllAsync<T>(this IApiConnection t, Uri uri, IDictionary<string, string> parameters, string accepts, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<T>(options => t.GetAll<T>(uri, parameters, accepts, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IEnterprisePreReceiveEnvironmentsClient.GetAll(ApiOptions)"/>
-        public static IPaginatedList<PreReceiveEnvironment> GetAllAsync(this IEnterprisePreReceiveEnvironmentsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<PreReceiveEnvironment>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-
-        /// <inheritdoc cref="IEnterprisePreReceiveHooksClient.GetAll(ApiOptions)"/>
-        public static IPaginatedList<PreReceiveHook> GetAllAsync(this IEnterprisePreReceiveHooksClient t, int pageSize = DEFAULT_PAGE_SIZE)
-            => pageSize > 0 ? new PaginatedList<PreReceiveHook>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    }
+  /// <summary>
+  /// Provides all extensions for pagination.
+  /// </summary>
+  /// <remarks>
+  /// The <code>pageSize</code> parameter at the end of all methods allows for specifying the amount of elements to be fetched per page.
+  /// Only useful to optimize the amount of API calls made.
+  /// </remarks>
+  public static class Extensions
+  {
+    private const int DEFAULT_PAGE_SIZE = 30;
+  
+    /// <inheritdoc cref="IIssueReactionsClient.GetAll(string, string, int, ApiOptions)"/>
+    public static IPaginatedList<Reaction> GetAllAsync(this IIssueReactionsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssueReactionsClient.GetAll(long, int, ApiOptions)"/>
+    public static IPaginatedList<Reaction> GetAllAsync(this IIssueReactionsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="ITeamsClient.GetAll(string, ApiOptions)"/>
+    public static IPaginatedList<Team> GetAllAsync(this ITeamsClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Team>(options => t.GetAll(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="ITeamsClient.GetAllForCurrent(ApiOptions)"/>
+    public static IPaginatedList<Team> GetAllForCurrentAsync(this ITeamsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Team>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="ITeamsClient.GetAllChildTeams(int, ApiOptions)"/>
+    public static IPaginatedList<Team> GetAllChildTeamsAsync(this ITeamsClient t, int id, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Team>(options => t.GetAllChildTeams(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="ITeamsClient.GetAllMembers(int, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllMembersAsync(this ITeamsClient t, int id, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllMembers(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="ITeamsClient.GetAllMembers(int, TeamMembersRequest, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllMembersAsync(this ITeamsClient t, int id, TeamMembersRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllMembers(id, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="ITeamsClient.GetAllRepositories(int, ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllRepositoriesAsync(this ITeamsClient t, int id, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllRepositories(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="ITeamsClient.GetAllPendingInvitations(int, ApiOptions)"/>
+    public static IPaginatedList<OrganizationMembershipInvitation> GetAllPendingInvitationsAsync(this ITeamsClient t, int id, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<OrganizationMembershipInvitation>(options => t.GetAllPendingInvitations(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepoCollaboratorsClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllAsync(this IRepoCollaboratorsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepoCollaboratorsClient.GetAll(long, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllAsync(this IRepoCollaboratorsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepoCollaboratorsClient.GetAll(string, string, RepositoryCollaboratorListRequest, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllAsync(this IRepoCollaboratorsClient t, string owner, string name, RepositoryCollaboratorListRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepoCollaboratorsClient.GetAll(long, RepositoryCollaboratorListRequest, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllAsync(this IRepoCollaboratorsClient t, long repositoryId, RepositoryCollaboratorListRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="ICommitStatusClient.GetAll(string, string, string, ApiOptions)"/>
+    public static IPaginatedList<CommitStatus> GetAllAsync(this ICommitStatusClient t, string owner, string name, string reference, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<CommitStatus>(options => t.GetAll(owner, name, reference, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="ICommitStatusClient.GetAll(long, string, ApiOptions)"/>
+    public static IPaginatedList<CommitStatus> GetAllAsync(this ICommitStatusClient t, long repositoryId, string reference, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<CommitStatus>(options => t.GetAll(repositoryId, reference, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IPullRequestReviewCommentReactionsClient.GetAll(string, string, int, ApiOptions)"/>
+    public static IPaginatedList<Reaction> GetAllAsync(this IPullRequestReviewCommentReactionsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IPullRequestReviewCommentReactionsClient.GetAll(long, int, ApiOptions)"/>
+    public static IPaginatedList<Reaction> GetAllAsync(this IPullRequestReviewCommentReactionsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IMilestonesClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<Milestone> GetAllForRepositoryAsync(this IMilestonesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Milestone>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IMilestonesClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<Milestone> GetAllForRepositoryAsync(this IMilestonesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Milestone>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IMilestonesClient.GetAllForRepository(string, string, MilestoneRequest, ApiOptions)"/>
+    public static IPaginatedList<Milestone> GetAllForRepositoryAsync(this IMilestonesClient t, string owner, string name, MilestoneRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Milestone>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IMilestonesClient.GetAllForRepository(long, MilestoneRequest, ApiOptions)"/>
+    public static IPaginatedList<Milestone> GetAllForRepositoryAsync(this IMilestonesClient t, long repositoryId, MilestoneRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Milestone>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssueCommentReactionsClient.GetAll(string, string, int, ApiOptions)"/>
+    public static IPaginatedList<Reaction> GetAllAsync(this IIssueCommentReactionsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssueCommentReactionsClient.GetAll(long, int, ApiOptions)"/>
+    public static IPaginatedList<Reaction> GetAllAsync(this IIssueCommentReactionsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IAuthorizationsClient.GetAll(ApiOptions)"/>
+    public static IPaginatedList<Authorization> GetAllAsync(this IAuthorizationsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Authorization>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoriesClient.GetAllForCurrent(ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllForCurrentAsync(this IRepositoriesClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoriesClient.GetAllForCurrent(RepositoryRequest, ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllForCurrentAsync(this IRepositoriesClient t, RepositoryRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForCurrent(request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoriesClient.GetAllForUser(string, ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllForUserAsync(this IRepositoriesClient t, string login, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForUser(login, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoriesClient.GetAllForOrg(string, ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllForOrgAsync(this IRepositoriesClient t, string organization, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForOrg(organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoriesClient.GetAllContributors(string, string, ApiOptions)"/>
+    public static IPaginatedList<RepositoryContributor> GetAllContributorsAsync(this IRepositoriesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryContributor>(options => t.GetAllContributors(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoriesClient.GetAllContributors(long, ApiOptions)"/>
+    public static IPaginatedList<RepositoryContributor> GetAllContributorsAsync(this IRepositoriesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryContributor>(options => t.GetAllContributors(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoriesClient.GetAllContributors(string, string, bool, ApiOptions)"/>
+    public static IPaginatedList<RepositoryContributor> GetAllContributorsAsync(this IRepositoriesClient t, string owner, string name, bool includeAnonymous, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryContributor>(options => t.GetAllContributors(owner, name, includeAnonymous, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoriesClient.GetAllContributors(long, bool, ApiOptions)"/>
+    public static IPaginatedList<RepositoryContributor> GetAllContributorsAsync(this IRepositoriesClient t, long repositoryId, bool includeAnonymous, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryContributor>(options => t.GetAllContributors(repositoryId, includeAnonymous, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoriesClient.GetAllTeams(string, string, ApiOptions)"/>
+    public static IPaginatedList<Team> GetAllTeamsAsync(this IRepositoriesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Team>(options => t.GetAllTeams(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoriesClient.GetAllTeams(long, ApiOptions)"/>
+    public static IPaginatedList<Team> GetAllTeamsAsync(this IRepositoriesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Team>(options => t.GetAllTeams(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoriesClient.GetAllTags(string, string, ApiOptions)"/>
+    public static IPaginatedList<RepositoryTag> GetAllTagsAsync(this IRepositoriesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryTag>(options => t.GetAllTags(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoriesClient.GetAllTags(long, ApiOptions)"/>
+    public static IPaginatedList<RepositoryTag> GetAllTagsAsync(this IRepositoriesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryTag>(options => t.GetAllTags(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IReferencesClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<Reference> GetAllAsync(this IReferencesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reference>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IReferencesClient.GetAll(long, ApiOptions)"/>
+    public static IPaginatedList<Reference> GetAllAsync(this IReferencesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reference>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IReferencesClient.GetAllForSubNamespace(string, string, string, ApiOptions)"/>
+    public static IPaginatedList<Reference> GetAllForSubNamespaceAsync(this IReferencesClient t, string owner, string name, string subNamespace, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reference>(options => t.GetAllForSubNamespace(owner, name, subNamespace, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IReferencesClient.GetAllForSubNamespace(long, string, ApiOptions)"/>
+    public static IPaginatedList<Reference> GetAllForSubNamespaceAsync(this IReferencesClient t, long repositoryId, string subNamespace, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reference>(options => t.GetAllForSubNamespace(repositoryId, subNamespace, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IOrganizationHooksClient.GetAll(string, ApiOptions)"/>
+    public static IPaginatedList<OrganizationHook> GetAllAsync(this IOrganizationHooksClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<OrganizationHook>(options => t.GetAll(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IOrganizationMembersClient.GetAll(string, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllAsync(this IOrganizationMembersClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IOrganizationMembersClient.GetAll(string, OrganizationMembersFilter, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllAsync(this IOrganizationMembersClient t, string org, OrganizationMembersFilter filter, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, filter, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IOrganizationMembersClient.GetAll(string, OrganizationMembersRole, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllAsync(this IOrganizationMembersClient t, string org, OrganizationMembersRole role, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, role, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IOrganizationMembersClient.GetAll(string, OrganizationMembersFilter, OrganizationMembersRole, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllAsync(this IOrganizationMembersClient t, string org, OrganizationMembersFilter filter, OrganizationMembersRole role, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, filter, role, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IOrganizationMembersClient.GetAllPublic(string, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllPublicAsync(this IOrganizationMembersClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllPublic(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IOrganizationMembersClient.GetAllPendingInvitations(string, ApiOptions)"/>
+    public static IPaginatedList<OrganizationMembershipInvitation> GetAllPendingInvitationsAsync(this IOrganizationMembersClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<OrganizationMembershipInvitation>(options => t.GetAllPendingInvitations(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IOrganizationMembersClient.GetAllFailedInvitations(string, ApiOptions)"/>
+    public static IPaginatedList<OrganizationMembershipInvitation> GetAllFailedInvitationsAsync(this IOrganizationMembersClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<OrganizationMembershipInvitation>(options => t.GetAllFailedInvitations(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoryBranchesClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<Branch> GetAllAsync(this IRepositoryBranchesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Branch>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoryBranchesClient.GetAll(long, ApiOptions)"/>
+    public static IPaginatedList<Branch> GetAllAsync(this IRepositoryBranchesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Branch>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IGistsClient.GetAll(ApiOptions)"/>
+    public static IPaginatedList<Gist> GetAllAsync(this IGistsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Gist>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IGistsClient.GetAll(DateTimeOffset, ApiOptions)"/>
+    public static IPaginatedList<Gist> GetAllAsync(this IGistsClient t, DateTimeOffset since, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Gist>(options => t.GetAll(since, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IGistsClient.GetAllPublic(ApiOptions)"/>
+    public static IPaginatedList<Gist> GetAllPublicAsync(this IGistsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Gist>(t.GetAllPublic, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IGistsClient.GetAllPublic(DateTimeOffset, ApiOptions)"/>
+    public static IPaginatedList<Gist> GetAllPublicAsync(this IGistsClient t, DateTimeOffset since, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Gist>(options => t.GetAllPublic(since, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IGistsClient.GetAllStarred(ApiOptions)"/>
+    public static IPaginatedList<Gist> GetAllStarredAsync(this IGistsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Gist>(t.GetAllStarred, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IGistsClient.GetAllStarred(DateTimeOffset, ApiOptions)"/>
+    public static IPaginatedList<Gist> GetAllStarredAsync(this IGistsClient t, DateTimeOffset since, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Gist>(options => t.GetAllStarred(since, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IGistsClient.GetAllForUser(string, ApiOptions)"/>
+    public static IPaginatedList<Gist> GetAllForUserAsync(this IGistsClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Gist>(options => t.GetAllForUser(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IGistsClient.GetAllForUser(string, DateTimeOffset, ApiOptions)"/>
+    public static IPaginatedList<Gist> GetAllForUserAsync(this IGistsClient t, string user, DateTimeOffset since, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Gist>(options => t.GetAllForUser(user, since, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IGistsClient.GetAllCommits(string, ApiOptions)"/>
+    public static IPaginatedList<GistHistory> GetAllCommitsAsync(this IGistsClient t, string id, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<GistHistory>(options => t.GetAllCommits(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IGistsClient.GetAllForks(string, ApiOptions)"/>
+    public static IPaginatedList<GistFork> GetAllForksAsync(this IGistsClient t, string id, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<GistFork>(options => t.GetAllForks(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoryInvitationsClient.GetAllForCurrent(ApiOptions)"/>
+    public static IPaginatedList<RepositoryInvitation> GetAllForCurrentAsync(this IRepositoryInvitationsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryInvitation>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoryInvitationsClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<RepositoryInvitation> GetAllForRepositoryAsync(this IRepositoryInvitationsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryInvitation>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IReleasesClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<Release> GetAllAsync(this IReleasesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Release>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IReleasesClient.GetAll(long, ApiOptions)"/>
+    public static IPaginatedList<Release> GetAllAsync(this IReleasesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Release>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IReleasesClient.GetAllAssets(string, string, int, ApiOptions)"/>
+    public static IPaginatedList<ReleaseAsset> GetAllAssetsAsync(this IReleasesClient t, string owner, string name, int id, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<ReleaseAsset>(options => t.GetAllAssets(owner, name, id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IReleasesClient.GetAllAssets(long, int, ApiOptions)"/>
+    public static IPaginatedList<ReleaseAsset> GetAllAssetsAsync(this IReleasesClient t, long repositoryId, int id, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<ReleaseAsset>(options => t.GetAllAssets(repositoryId, id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IPullRequestReviewsClient.GetAll(string, string, int, ApiOptions)"/>
+    public static IPaginatedList<PullRequestReview> GetAllAsync(this IPullRequestReviewsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequestReview>(options => t.GetAll(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IPullRequestReviewsClient.GetAll(long, int, ApiOptions)"/>
+    public static IPaginatedList<PullRequestReview> GetAllAsync(this IPullRequestReviewsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequestReview>(options => t.GetAll(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IPullRequestReviewsClient.GetAllComments(string, string, int, long, ApiOptions)"/>
+    public static IPaginatedList<PullRequestReviewComment> GetAllCommentsAsync(this IPullRequestReviewsClient t, string owner, string name, int number, long reviewId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllComments(owner, name, number, reviewId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IPullRequestReviewsClient.GetAllComments(long, int, long, ApiOptions)"/>
+    public static IPaginatedList<PullRequestReviewComment> GetAllCommentsAsync(this IPullRequestReviewsClient t, long repositoryId, int number, long reviewId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllComments(repositoryId, number, reviewId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IOrganizationOutsideCollaboratorsClient.GetAll(string, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllAsync(this IOrganizationOutsideCollaboratorsClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IOrganizationOutsideCollaboratorsClient.GetAll(string, OrganizationMembersFilter, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllAsync(this IOrganizationOutsideCollaboratorsClient t, string org, OrganizationMembersFilter filter, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, filter, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IDeploymentsClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<Deployment> GetAllAsync(this IDeploymentsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Deployment>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IDeploymentsClient.GetAll(long, ApiOptions)"/>
+    public static IPaginatedList<Deployment> GetAllAsync(this IDeploymentsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Deployment>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="INotificationsClient.GetAllForCurrent(ApiOptions)"/>
+    public static IPaginatedList<Notification> GetAllForCurrentAsync(this INotificationsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Notification>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="INotificationsClient.GetAllForCurrent(NotificationsRequest, ApiOptions)"/>
+    public static IPaginatedList<Notification> GetAllForCurrentAsync(this INotificationsClient t, NotificationsRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Notification>(options => t.GetAllForCurrent(request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="INotificationsClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<Notification> GetAllForRepositoryAsync(this INotificationsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Notification>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="INotificationsClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<Notification> GetAllForRepositoryAsync(this INotificationsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Notification>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="INotificationsClient.GetAllForRepository(string, string, NotificationsRequest, ApiOptions)"/>
+    public static IPaginatedList<Notification> GetAllForRepositoryAsync(this INotificationsClient t, string owner, string name, NotificationsRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Notification>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="INotificationsClient.GetAllForRepository(long, NotificationsRequest, ApiOptions)"/>
+    public static IPaginatedList<Notification> GetAllForRepositoryAsync(this INotificationsClient t, long repositoryId, NotificationsRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Notification>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IUserEmailsClient.GetAll(ApiOptions)"/>
+    public static IPaginatedList<EmailAddress> GetAllAsync(this IUserEmailsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<EmailAddress>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IPullRequestReviewCommentsClient.GetAll(string, string, int, ApiOptions)"/>
+    public static IPaginatedList<PullRequestReviewComment> GetAllAsync(this IPullRequestReviewCommentsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAll(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IPullRequestReviewCommentsClient.GetAll(long, int, ApiOptions)"/>
+    public static IPaginatedList<PullRequestReviewComment> GetAllAsync(this IPullRequestReviewCommentsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAll(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IPullRequestReviewCommentsClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<PullRequestReviewComment> GetAllForRepositoryAsync(this IPullRequestReviewCommentsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IPullRequestReviewCommentsClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<PullRequestReviewComment> GetAllForRepositoryAsync(this IPullRequestReviewCommentsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IPullRequestReviewCommentsClient.GetAllForRepository(string, string, PullRequestReviewCommentRequest, ApiOptions)"/>
+    public static IPaginatedList<PullRequestReviewComment> GetAllForRepositoryAsync(this IPullRequestReviewCommentsClient t, string owner, string name, PullRequestReviewCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IPullRequestReviewCommentsClient.GetAllForRepository(long, PullRequestReviewCommentRequest, ApiOptions)"/>
+    public static IPaginatedList<PullRequestReviewComment> GetAllForRepositoryAsync(this IPullRequestReviewCommentsClient t, long repositoryId, PullRequestReviewCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IUserKeysClient.GetAll(string, ApiOptions)"/>
+    public static IPaginatedList<PublicKey> GetAllAsync(this IUserKeysClient t, string userName, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PublicKey>(options => t.GetAll(userName, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IUserKeysClient.GetAllForCurrent(ApiOptions)"/>
+    public static IPaginatedList<PublicKey> GetAllForCurrentAsync(this IUserKeysClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PublicKey>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssueCommentsClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<IssueComment> GetAllForRepositoryAsync(this IIssueCommentsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssueCommentsClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<IssueComment> GetAllForRepositoryAsync(this IIssueCommentsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssueCommentsClient.GetAllForRepository(string, string, IssueCommentRequest, ApiOptions)"/>
+    public static IPaginatedList<IssueComment> GetAllForRepositoryAsync(this IIssueCommentsClient t, string owner, string name, IssueCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssueCommentsClient.GetAllForRepository(long, IssueCommentRequest, ApiOptions)"/>
+    public static IPaginatedList<IssueComment> GetAllForRepositoryAsync(this IIssueCommentsClient t, long repositoryId, IssueCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssueCommentsClient.GetAllForIssue(string, string, int, ApiOptions)"/>
+    public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForIssue(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssueCommentsClient.GetAllForIssue(long, int, ApiOptions)"/>
+    public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForIssue(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssueCommentsClient.GetAllForIssue(string, string, int, IssueCommentRequest, ApiOptions)"/>
+    public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, string owner, string name, int number, IssueCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForIssue(owner, name, number, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssueCommentsClient.GetAllForIssue(long, int, IssueCommentRequest, ApiOptions)"/>
+    public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, long repositoryId, int number, IssueCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForIssue(repositoryId, number, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForIssue(string, string, int, ApiOptions)"/>
+    public static IPaginatedList<Label> GetAllForIssueAsync(this IIssuesLabelsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForIssue(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForIssue(long, int, ApiOptions)"/>
+    public static IPaginatedList<Label> GetAllForIssueAsync(this IIssuesLabelsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForIssue(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<Label> GetAllForRepositoryAsync(this IIssuesLabelsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<Label> GetAllForRepositoryAsync(this IIssuesLabelsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForMilestone(string, string, int, ApiOptions)"/>
+    public static IPaginatedList<Label> GetAllForMilestoneAsync(this IIssuesLabelsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForMilestone(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForMilestone(long, int, ApiOptions)"/>
+    public static IPaginatedList<Label> GetAllForMilestoneAsync(this IIssuesLabelsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForMilestone(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IGistCommentsClient.GetAllForGist(string, ApiOptions)"/>
+    public static IPaginatedList<GistComment> GetAllForGistAsync(this IGistCommentsClient t, string gistId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<GistComment>(options => t.GetAllForGist(gistId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IProjectCardsClient.GetAll(int, ApiOptions)"/>
+    public static IPaginatedList<ProjectCard> GetAllAsync(this IProjectCardsClient t, int columnId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<ProjectCard>(options => t.GetAll(columnId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IProjectCardsClient.GetAll(int, ProjectCardRequest, ApiOptions)"/>
+    public static IPaginatedList<ProjectCard> GetAllAsync(this IProjectCardsClient t, int columnId, ProjectCardRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<ProjectCard>(options => t.GetAll(columnId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IMiscellaneousClient.GetAllLicenses(ApiOptions)"/>
+    public static IPaginatedList<LicenseMetadata> GetAllLicensesAsync(this IMiscellaneousClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<LicenseMetadata>(t.GetAllLicenses, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoryDeployKeysClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<DeployKey> GetAllAsync(this IRepositoryDeployKeysClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<DeployKey>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoryDeployKeysClient.GetAll(long, ApiOptions)"/>
+    public static IPaginatedList<DeployKey> GetAllAsync(this IRepositoryDeployKeysClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<DeployKey>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IProjectsClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<Project> GetAllForRepositoryAsync(this IProjectsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IProjectsClient.GetAllForRepository(string, string, ProjectRequest, ApiOptions)"/>
+    public static IPaginatedList<Project> GetAllForRepositoryAsync(this IProjectsClient t, string owner, string name, ProjectRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IProjectsClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<Project> GetAllForRepositoryAsync(this IProjectsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IProjectsClient.GetAllForRepository(long, ProjectRequest, ApiOptions)"/>
+    public static IPaginatedList<Project> GetAllForRepositoryAsync(this IProjectsClient t, long repositoryId, ProjectRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IProjectsClient.GetAllForOrganization(string, ApiOptions)"/>
+    public static IPaginatedList<Project> GetAllForOrganizationAsync(this IProjectsClient t, string organization, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForOrganization(organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IProjectsClient.GetAllForOrganization(string, ProjectRequest, ApiOptions)"/>
+    public static IPaginatedList<Project> GetAllForOrganizationAsync(this IProjectsClient t, string organization, ProjectRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForOrganization(organization, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoryCommentsClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<CommitComment> GetAllForRepositoryAsync(this IRepositoryCommentsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<CommitComment>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoryCommentsClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<CommitComment> GetAllForRepositoryAsync(this IRepositoryCommentsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<CommitComment>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoryCommentsClient.GetAllForCommit(string, string, string, ApiOptions)"/>
+    public static IPaginatedList<CommitComment> GetAllForCommitAsync(this IRepositoryCommentsClient t, string owner, string name, string sha, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<CommitComment>(options => t.GetAllForCommit(owner, name, sha, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoryCommentsClient.GetAllForCommit(long, string, ApiOptions)"/>
+    public static IPaginatedList<CommitComment> GetAllForCommitAsync(this IRepositoryCommentsClient t, long repositoryId, string sha, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<CommitComment>(options => t.GetAllForCommit(repositoryId, sha, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IDeploymentStatusClient.GetAll(string, string, int, ApiOptions)"/>
+    public static IPaginatedList<DeploymentStatus> GetAllAsync(this IDeploymentStatusClient t, string owner, string name, int deploymentId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<DeploymentStatus>(options => t.GetAll(owner, name, deploymentId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IDeploymentStatusClient.GetAll(long, int, ApiOptions)"/>
+    public static IPaginatedList<DeploymentStatus> GetAllAsync(this IDeploymentStatusClient t, long repositoryId, int deploymentId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<DeploymentStatus>(options => t.GetAll(repositoryId, deploymentId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoryCommitsClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<GitHubCommit> GetAllAsync(this IRepositoryCommitsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<GitHubCommit>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoryCommitsClient.GetAll(long, ApiOptions)"/>
+    public static IPaginatedList<GitHubCommit> GetAllAsync(this IRepositoryCommitsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<GitHubCommit>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoryCommitsClient.GetAll(string, string, CommitRequest, ApiOptions)"/>
+    public static IPaginatedList<GitHubCommit> GetAllAsync(this IRepositoryCommitsClient t, string owner, string name, CommitRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<GitHubCommit>(options => t.GetAll(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoryCommitsClient.GetAll(long, CommitRequest, ApiOptions)"/>
+    public static IPaginatedList<GitHubCommit> GetAllAsync(this IRepositoryCommitsClient t, long repositoryId, CommitRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<GitHubCommit>(options => t.GetAll(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="ICommitCommentReactionsClient.GetAll(string, string, int, ApiOptions)"/>
+    public static IPaginatedList<Reaction> GetAllAsync(this ICommitCommentReactionsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="ICommitCommentReactionsClient.GetAll(long, int, ApiOptions)"/>
+    public static IPaginatedList<Reaction> GetAllAsync(this ICommitCommentReactionsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoryPagesClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<PagesBuild> GetAllAsync(this IRepositoryPagesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PagesBuild>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoryPagesClient.GetAll(long, ApiOptions)"/>
+    public static IPaginatedList<PagesBuild> GetAllAsync(this IRepositoryPagesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PagesBuild>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IProjectColumnsClient.GetAll(int, ApiOptions)"/>
+    public static IPaginatedList<ProjectColumn> GetAllAsync(this IProjectColumnsClient t, int projectId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<ProjectColumn>(options => t.GetAll(projectId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IEventsClient.GetAll(ApiOptions)"/>
+    public static IPaginatedList<Activity> GetAllAsync(this IEventsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Activity>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IEventsClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<Activity> GetAllForRepositoryAsync(this IEventsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IEventsClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<Activity> GetAllForRepositoryAsync(this IEventsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IEventsClient.GetAllIssuesForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<IssueEvent> GetAllIssuesForRepositoryAsync(this IEventsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllIssuesForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IEventsClient.GetAllIssuesForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<IssueEvent> GetAllIssuesForRepositoryAsync(this IEventsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllIssuesForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IEventsClient.GetAllForRepositoryNetwork(string, string, ApiOptions)"/>
+    public static IPaginatedList<Activity> GetAllForRepositoryNetworkAsync(this IEventsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllForRepositoryNetwork(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IEventsClient.GetAllForOrganization(string, ApiOptions)"/>
+    public static IPaginatedList<Activity> GetAllForOrganizationAsync(this IEventsClient t, string organization, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllForOrganization(organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IEventsClient.GetAllUserReceived(string, ApiOptions)"/>
+    public static IPaginatedList<Activity> GetAllUserReceivedAsync(this IEventsClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllUserReceived(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IEventsClient.GetAllUserReceivedPublic(string, ApiOptions)"/>
+    public static IPaginatedList<Activity> GetAllUserReceivedPublicAsync(this IEventsClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllUserReceivedPublic(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IEventsClient.GetAllUserPerformed(string, ApiOptions)"/>
+    public static IPaginatedList<Activity> GetAllUserPerformedAsync(this IEventsClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllUserPerformed(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IEventsClient.GetAllUserPerformedPublic(string, ApiOptions)"/>
+    public static IPaginatedList<Activity> GetAllUserPerformedPublicAsync(this IEventsClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllUserPerformedPublic(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IEventsClient.GetAllForAnOrganization(string, string, ApiOptions)"/>
+    public static IPaginatedList<Activity> GetAllForAnOrganizationAsync(this IEventsClient t, string user, string organization, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllForAnOrganization(user, organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IPullRequestsClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<PullRequest> GetAllForRepositoryAsync(this IPullRequestsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequest>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IPullRequestsClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<PullRequest> GetAllForRepositoryAsync(this IPullRequestsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequest>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IPullRequestsClient.GetAllForRepository(string, string, PullRequestRequest, ApiOptions)"/>
+    public static IPaginatedList<PullRequest> GetAllForRepositoryAsync(this IPullRequestsClient t, string owner, string name, PullRequestRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequest>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IPullRequestsClient.GetAllForRepository(long, PullRequestRequest, ApiOptions)"/>
+    public static IPaginatedList<PullRequest> GetAllForRepositoryAsync(this IPullRequestsClient t, long repositoryId, PullRequestRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequest>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssuesClient.GetAllForCurrent(ApiOptions)"/>
+    public static IPaginatedList<Issue> GetAllForCurrentAsync(this IIssuesClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Issue>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssuesClient.GetAllForCurrent(IssueRequest, ApiOptions)"/>
+    public static IPaginatedList<Issue> GetAllForCurrentAsync(this IIssuesClient t, IssueRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForCurrent(request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssuesClient.GetAllForOwnedAndMemberRepositories(ApiOptions)"/>
+    public static IPaginatedList<Issue> GetAllForOwnedAndMemberRepositoriesAsync(this IIssuesClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Issue>(t.GetAllForOwnedAndMemberRepositories, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssuesClient.GetAllForOwnedAndMemberRepositories(IssueRequest, ApiOptions)"/>
+    public static IPaginatedList<Issue> GetAllForOwnedAndMemberRepositoriesAsync(this IIssuesClient t, IssueRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForOwnedAndMemberRepositories(request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssuesClient.GetAllForOrganization(string, ApiOptions)"/>
+    public static IPaginatedList<Issue> GetAllForOrganizationAsync(this IIssuesClient t, string organization, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForOrganization(organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssuesClient.GetAllForOrganization(string, IssueRequest, ApiOptions)"/>
+    public static IPaginatedList<Issue> GetAllForOrganizationAsync(this IIssuesClient t, string organization, IssueRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForOrganization(organization, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssuesClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<Issue> GetAllForRepositoryAsync(this IIssuesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssuesClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<Issue> GetAllForRepositoryAsync(this IIssuesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssuesClient.GetAllForRepository(string, string, RepositoryIssueRequest, ApiOptions)"/>
+    public static IPaginatedList<Issue> GetAllForRepositoryAsync(this IIssuesClient t, string owner, string name, RepositoryIssueRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssuesClient.GetAllForRepository(long, RepositoryIssueRequest, ApiOptions)"/>
+    public static IPaginatedList<Issue> GetAllForRepositoryAsync(this IIssuesClient t, long repositoryId, RepositoryIssueRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IOrganizationsClient.GetAllForCurrent(ApiOptions)"/>
+    public static IPaginatedList<Organization> GetAllForCurrentAsync(this IOrganizationsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Organization>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IOrganizationsClient.GetAllForUser(string, ApiOptions)"/>
+    public static IPaginatedList<Organization> GetAllForUserAsync(this IOrganizationsClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Organization>(options => t.GetAllForUser(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IUserGpgKeysClient.GetAllForCurrent(ApiOptions)"/>
+    public static IPaginatedList<GpgKey> GetAllForCurrentAsync(this IUserGpgKeysClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<GpgKey>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoryForksClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllAsync(this IRepositoryForksClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoryForksClient.GetAll(long, ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllAsync(this IRepositoryForksClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoryForksClient.GetAll(string, string, RepositoryForksListRequest, ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllAsync(this IRepositoryForksClient t, string owner, string name, RepositoryForksListRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAll(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoryForksClient.GetAll(long, RepositoryForksListRequest, ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllAsync(this IRepositoryForksClient t, long repositoryId, RepositoryForksListRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAll(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IGitHubAppsClient.GetAllInstallationsForCurrent(ApiOptions)"/>
+    public static IPaginatedList<Installation> GetAllInstallationsForCurrentAsync(this IGitHubAppsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Installation>(t.GetAllInstallationsForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssuesEventsClient.GetAllForIssue(string, string, int, ApiOptions)"/>
+    public static IPaginatedList<IssueEvent> GetAllForIssueAsync(this IIssuesEventsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllForIssue(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssuesEventsClient.GetAllForIssue(long, int, ApiOptions)"/>
+    public static IPaginatedList<IssueEvent> GetAllForIssueAsync(this IIssuesEventsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllForIssue(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssuesEventsClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<IssueEvent> GetAllForRepositoryAsync(this IIssuesEventsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssuesEventsClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<IssueEvent> GetAllForRepositoryAsync(this IIssuesEventsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IAssigneesClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllForRepositoryAsync(this IAssigneesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IAssigneesClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllForRepositoryAsync(this IAssigneesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="ICheckRunsClient.GetAllAnnotations(string, string, long, ApiOptions)"/>
+    public static IPaginatedList<CheckRunAnnotation> GetAllAnnotationsAsync(this ICheckRunsClient t, string owner, string name, long checkRunId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<CheckRunAnnotation>(options => t.GetAllAnnotations(owner, name, checkRunId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="ICheckRunsClient.GetAllAnnotations(long, long, ApiOptions)"/>
+    public static IPaginatedList<CheckRunAnnotation> GetAllAnnotationsAsync(this ICheckRunsClient t, long repositoryId, long checkRunId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<CheckRunAnnotation>(options => t.GetAllAnnotations(repositoryId, checkRunId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoryHooksClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<RepositoryHook> GetAllAsync(this IRepositoryHooksClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryHook>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IRepositoryHooksClient.GetAll(long, ApiOptions)"/>
+    public static IPaginatedList<RepositoryHook> GetAllAsync(this IRepositoryHooksClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryHook>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IWatchedClient.GetAllWatchers(string, string, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllWatchersAsync(this IWatchedClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllWatchers(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IWatchedClient.GetAllWatchers(long, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllWatchersAsync(this IWatchedClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllWatchers(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IWatchedClient.GetAllForCurrent(ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllForCurrentAsync(this IWatchedClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IWatchedClient.GetAllForUser(string, ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllForUserAsync(this IWatchedClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForUser(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IStarredClient.GetAllStargazers(string, string, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllStargazersAsync(this IStarredClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllStargazers(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IStarredClient.GetAllStargazers(long, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllStargazersAsync(this IStarredClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllStargazers(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IStarredClient.GetAllStargazersWithTimestamps(string, string, ApiOptions)"/>
+    public static IPaginatedList<UserStar> GetAllStargazersWithTimestampsAsync(this IStarredClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<UserStar>(options => t.GetAllStargazersWithTimestamps(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IStarredClient.GetAllStargazersWithTimestamps(long, ApiOptions)"/>
+    public static IPaginatedList<UserStar> GetAllStargazersWithTimestampsAsync(this IStarredClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<UserStar>(options => t.GetAllStargazersWithTimestamps(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IStarredClient.GetAllForCurrent(ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllForCurrentAsync(this IStarredClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IStarredClient.GetAllForCurrentWithTimestamps(ApiOptions)"/>
+    public static IPaginatedList<RepositoryStar> GetAllForCurrentWithTimestampsAsync(this IStarredClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryStar>(t.GetAllForCurrentWithTimestamps, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IStarredClient.GetAllForCurrent(StarredRequest, ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllForCurrentAsync(this IStarredClient t, StarredRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForCurrent(request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IStarredClient.GetAllForCurrentWithTimestamps(StarredRequest, ApiOptions)"/>
+    public static IPaginatedList<RepositoryStar> GetAllForCurrentWithTimestampsAsync(this IStarredClient t, StarredRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryStar>(options => t.GetAllForCurrentWithTimestamps(request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IStarredClient.GetAllForUser(string, ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllForUserAsync(this IStarredClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForUser(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IStarredClient.GetAllForUserWithTimestamps(string, ApiOptions)"/>
+    public static IPaginatedList<RepositoryStar> GetAllForUserWithTimestampsAsync(this IStarredClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryStar>(options => t.GetAllForUserWithTimestamps(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IStarredClient.GetAllForUser(string, StarredRequest, ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllForUserAsync(this IStarredClient t, string user, StarredRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForUser(user, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IStarredClient.GetAllForUserWithTimestamps(string, StarredRequest, ApiOptions)"/>
+    public static IPaginatedList<RepositoryStar> GetAllForUserWithTimestampsAsync(this IStarredClient t, string user, StarredRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryStar>(options => t.GetAllForUserWithTimestamps(user, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IFollowersClient.GetAllForCurrent(ApiOptions)"/>
+    public static IPaginatedList<User> GetAllForCurrentAsync(this IFollowersClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IFollowersClient.GetAll(string, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllAsync(this IFollowersClient t, string login, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(login, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IFollowersClient.GetAllFollowingForCurrent(ApiOptions)"/>
+    public static IPaginatedList<User> GetAllFollowingForCurrentAsync(this IFollowersClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(t.GetAllFollowingForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IFollowersClient.GetAllFollowing(string, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllFollowingAsync(this IFollowersClient t, string login, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllFollowing(login, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssueTimelineClient.GetAllForIssue(string, string, int, ApiOptions)"/>
+    public static IPaginatedList<TimelineEventInfo> GetAllForIssueAsync(this IIssueTimelineClient t, string owner, string repo, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<TimelineEventInfo>(options => t.GetAllForIssue(owner, repo, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IIssueTimelineClient.GetAllForIssue(long, int, ApiOptions)"/>
+    public static IPaginatedList<TimelineEventInfo> GetAllForIssueAsync(this IIssueTimelineClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<TimelineEventInfo>(options => t.GetAllForIssue(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IApiConnection.GetAll(Uri, ApiOptions)"/>
+    public static IPaginatedList<T> GetAllAsync<T>(this IApiConnection t, Uri uri, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<T>(options => t.GetAll<T>(uri, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IApiConnection.GetAll(Uri, IDictionary{string, string}, ApiOptions)"/>
+    public static IPaginatedList<T> GetAllAsync<T>(this IApiConnection t, Uri uri, IDictionary<string, string> parameters, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<T>(options => t.GetAll<T>(uri, parameters, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IApiConnection.GetAll(Uri, IDictionary{string, string}, string, ApiOptions)"/>
+    public static IPaginatedList<T> GetAllAsync<T>(this IApiConnection t, Uri uri, IDictionary<string, string> parameters, string accepts, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<T>(options => t.GetAll<T>(uri, parameters, accepts, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IEnterprisePreReceiveEnvironmentsClient.GetAll(ApiOptions)"/>
+    public static IPaginatedList<PreReceiveEnvironment> GetAllAsync(this IEnterprisePreReceiveEnvironmentsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PreReceiveEnvironment>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+    /// <inheritdoc cref="IEnterprisePreReceiveHooksClient.GetAll(ApiOptions)"/>
+    public static IPaginatedList<PreReceiveHook> GetAllAsync(this IEnterprisePreReceiveHooksClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PreReceiveHook>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    
+  }
 }

--- a/Octokit.AsyncPaginationExtension/Octokit.AsyncPaginationExtension.csproj
+++ b/Octokit.AsyncPaginationExtension/Octokit.AsyncPaginationExtension.csproj
@@ -18,23 +18,23 @@
     <PackageTags>GitHub API Octokit linqpad-samples dotnetcore</PackageTags>
     <Copyright>Copyright GitHub 2017</Copyright>
     <LangVersion>9</LangVersion>
-	  <Nullable>enable</Nullable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
-	<PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-		<NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
-	</PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
+  </PropertyGroup>
 
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
-	</ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
+  </ItemGroup>
 
-	<ItemGroup>
-	  <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+  </ItemGroup>
 
-	<ItemGroup>
-	  <ProjectReference Include="..\Octokit\Octokit.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Octokit\Octokit.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/Octokit.Generators/AsyncPaginationExtensionsGenerator.cs
+++ b/Octokit.Generators/AsyncPaginationExtensionsGenerator.cs
@@ -1,0 +1,119 @@
+﻿using System.Linq;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Data;
+using System.Text;
+
+namespace Octokit.Generators
+{
+
+  /// <summary>
+  /// AsyncPaginationExtensionsGenerator for generating pagination extensions for Octokit.net Clients that return collections.
+  /// </summary>
+  /// <remarks>
+  /// This generator originally appeared in https://github.com/octokit/octokit.net/pull/2516
+  /// The generator solves a small part of a larger effort that is being discussed:
+  ///  https://github.com/octokit/octokit.net/discussions/2499
+  ///  https://github.com/octokit/octokit.net/discussions/2495
+  ///  https://github.com/octokit/octokit.net/issues/2517
+  ///  In the future, we should be able to unify generation for
+  ///   * models (request and response)
+  ///   * clients
+  ///   * routing and related helpers
+  ///   TODO: Convert to use Rosyln source generators
+  /// </remarks>
+  class AsyncPaginationExtensionsGenerator
+  {
+
+  private const string HEADER = (
+@"using System;
+using System.Collections.Generic;
+
+namespace Octokit.AsyncPaginationExtension
+{
+  /// <summary>
+  /// Provides all extensions for pagination.
+  /// </summary>
+  /// <remarks>
+  /// The <code>pageSize</code> parameter at the end of all methods allows for specifying the amount of elements to be fetched per page.
+  /// Only useful to optimize the amount of API calls made.
+  /// </remarks>
+  public static class Extensions
+  {
+    private const int DEFAULT_PAGE_SIZE = 30;
+  ");
+
+  private const string FOOTER = (
+@"
+  }
+}");
+
+    /// <summary>
+    /// GenerateAsync static entry point for generating pagination extensions.
+    /// </summary>
+    /// <remarks>
+    /// This defaults the search path to the root of the project
+    /// This expects to generate the resulting code and put it in Octokit.AsyncPaginationExtension
+    /// This does a wholesale overwrite on ./Octokit.AsyncPaginationExtension/Extensions.cs
+    /// </remarks>
+    public static async Task GenerateAsync(string root = "./")
+    {
+      var sb = new StringBuilder(HEADER);
+      var enumOptions = new EnumerationOptions { RecurseSubdirectories = true };
+      var paginatedCallRegex = new Regex(@".*Task<IReadOnlyList<(?<returnType>\w+)>>\s*(?<name>\w+)(?<template><.*>)?\((?<arg>.*?)(, )?ApiOptions \w*\);");
+
+      foreach (var file in Directory.EnumerateFiles(root, "I*.cs", enumOptions)) {
+          var type = Path.GetFileNameWithoutExtension(file);
+
+          foreach (var line in File.ReadAllLines(file)) {
+              var match = paginatedCallRegex.Match(line);
+
+              if (!match.Success) { continue; }
+              sb.Append(BuildBodyFromTemplate(match, type));
+          }
+      }
+
+      sb.Append(FOOTER);
+
+      await File.WriteAllTextAsync("./Octokit.AsyncPaginationExtension/Extensions.cs", sb.ToString());
+    }
+
+    /// <summary>
+    /// BuildBodyFromTemplate uses the match from the regex search and parses values from the given source
+    /// to use to generate the paging implementations.
+    /// </summary>
+    /// <remarks>
+    /// TODO: This should be reworked to use source templates
+    /// </remarks>
+    private static string BuildBodyFromTemplate(Match match, string type)
+    {
+      var argSplitRegex = new Regex(@" (?![^<]*>)");
+      var returnType = match.Groups["returnType"].Value;
+      var name = match.Groups["name"].Value;
+      var arg = match.Groups["arg"].Value;
+      var template = match.Groups["template"];
+      var templateStr = template.Success ? template.Value : string.Empty;
+      var splitArgs = argSplitRegex.Split(arg).ToArray();
+
+      var lambda = arg.Length == 0
+          ? $"t.{name}{templateStr}"
+          : $"options => t.{name}{templateStr}({string.Join(' ', splitArgs.Where((_, i) => i % 2 == 1))}, options)";
+
+      var docArgs = string.Join(", ", splitArgs.Where((_, i) => i % 2 == 0)).Replace('<', '{').Replace('>', '}');
+      if (docArgs.Length != 0) {
+          docArgs += ", ";
+      }
+
+      if (arg.Length != 0) {
+          arg += ", ";
+      }
+
+      return ($@"
+    /// <inheritdoc cref=""{type}.{name}({docArgs}ApiOptions)""/>
+    public static IPaginatedList<{returnType}> {name}Async{templateStr}(this {type} t, {arg}int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<{returnType}>({lambda}, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, ""The page size must be positive."");
+    ");
+    }
+  }
+}

--- a/Octokit.Generators/Generator.cs
+++ b/Octokit.Generators/Generator.cs
@@ -1,0 +1,29 @@
+using System.Threading.Tasks;
+
+namespace Octokit.Generators
+{
+  /// <summary>
+  /// Provides an entry point for code generation of various types.
+  /// </summary>
+  /// <remarks>
+  /// The backing source for generation will either be the source files in this repo or
+  /// the OpenAPI Descriptions from the GitHub REST API: https://github.com/github/rest-api-description
+  /// </remarks>
+  class Generator
+    {
+
+        static void Main(string[] args)
+        {
+
+          var operation = args.Length != 0 ? args[0] : "AsyncPaginationExtensions";
+
+          if (operation == "AsyncPaginationExtensions")
+          {
+            Task task = Task.Run( () => AsyncPaginationExtensionsGenerator.GenerateAsync());
+            task.Wait();
+          }
+
+          // Put more generation operations here, convert to case when needed.
+        }
+    }
+}

--- a/Octokit.Generators/Octokit.Generators.csproj
+++ b/Octokit.Generators/Octokit.Generators.csproj
@@ -6,7 +6,7 @@
     <Version>0.0.0-dev</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AssemblyName>Octokit.Generators</AssemblyName>
     <PackageId>Octokit.Generators</PackageId>
     <DebugType>embedded</DebugType>

--- a/Octokit.Generators/Octokit.Generators.csproj
+++ b/Octokit.Generators/Octokit.Generators.csproj
@@ -6,7 +6,7 @@
     <Version>0.0.0-dev</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Octokit.Generators</AssemblyName>
     <PackageId>Octokit.Generators</PackageId>
     <DebugType>embedded</DebugType>
@@ -18,6 +18,6 @@
     <PackageTags>GitHub API Octokit dotnetcore dotnetstandard2.0</PackageTags>
     <Copyright>Copyright GitHub 2022</Copyright>
     <LangVersion>9</LangVersion>
-	  <Nullable>enable</Nullable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 </Project>

--- a/Octokit.Generators/Octokit.Generators.csproj
+++ b/Octokit.Generators/Octokit.Generators.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Description>A set of code generators for Octokit.NET backed by the GitHub REST API Open API descriptions</Description>
+    <AssemblyTitle>Octokit.Generators</AssemblyTitle>
+    <Authors>GitHub</Authors>
+    <Version>0.0.0-dev</Version>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <AssemblyName>Octokit.Generators</AssemblyName>
+    <PackageId>Octokit.Generators</PackageId>
+    <DebugType>embedded</DebugType>
+    <RepositoryUrl>https://github.com/octokit/octokit.net</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/octokit/octokit.net</PackageProjectUrl>
+    <PackageIconUrl>https://f.cloud.github.com/assets/19977/1510987/64af2b26-4a9d-11e3-89fc-96a185171c75.png</PackageIconUrl>
+    <PackageIcon>octokit.png</PackageIcon>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageTags>GitHub API Octokit dotnetcore dotnetstandard2.0</PackageTags>
+    <Copyright>Copyright GitHub 2022</Copyright>
+    <LangVersion>9</LangVersion>
+	  <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/Octokit.Generators/README.md
+++ b/Octokit.Generators/README.md
@@ -1,0 +1,58 @@
+# Octokit.net Generators
+
+## About
+
+We've been discussing and thinking about code generators for a [while now](https://github.com/octokit/octokit.net/discussions/2527) and they are part of the [future vision](https://github.com/octokit/octokit.net/discussions/2495) for where we'd like to head with this SDK.
+
+Consider this to be iteration 0.  Meaning while we want to potentially move to source generators, templates, and using the features that Rosyln offers we need to do some functional experiments and solve our current needs while iterating on the future.  Acknoledging that code generation is a solved problem (menaing there is existing work out there) we should be intentional with the direction we take.
+
+----
+
+## Getting started
+
+From the Octokit .NET root run:
+
+`dotnet run --project Octokit.Generators`
+
+----
+
+## Debugging
+
+There is a launch config defined for this project named `Run Generator`
+
+----
+
+## CI/Actions
+
+Currently no generation is automatically run as a build/release step.  Once the vision solidifies here a bit we'll begin introducing automation so that whatever is generated is always up to date.
+
+----
+
+## Notes and thoughts on code generation for Octokit.net
+
+### Code generation, interpreters, and language interpolation
+
+Hoisted from this [discussion](https://github.com/octokit/octokit.net/discussions/2495)
+
+As you know there are loads of things that we can do here - especially given the power of .NET, reflection, and Rosyln. Just two thoughts on the cautious side of things here:
+
+1. Just because we can generate things, it does not mean we should. As we roll through discovery on all of this we might find out some areas where generation would be trying to put a square peg in a round hole. We need to have the courage to stand down when needed.
+2. Our long-term goal should be language and platform independence. Meaning, we might nail down incredible generative aspects for the .NET SDK but we should always be targeting things like versioned, package distributed, models that the core SDK can reference as well as a generative engine that could potentially generate the models and implementations based on language templates, RFCs, and the like for any reference language - so generating models and SDK methods should be doable for both .NET and Go (for instance) using the same "engine" if possible. It's lofty but I feel that it could be possible.
+
+So what might the future look like for code generation given the above statements? Let's have a look a what might be a really naive/potential roadmap (again we need the community's input and involvement here - which is why I am grateful for the questions):
+
+1. Make sure our current solution addresses the community needs: All SDKs have been synchronized with the current API surface
+2. Standardize implementations - testing, models, API methods, etc... (this is a critical step to get us to generation)
+3. As we go through the above we will learn more about what works and what doesn't. Armed with that knowledge, begin prototyping generative models for each SDK
+4. Solve OpenAPI generation for at least 1 SDK and implement - again with our sights on other languages
+5. Publish (but don't reference yet) SDK models to packaging platforms (in this case nuget)
+6. Work on Generative API implementations - methods etc..
+7. Model generation is unified in the SDK (i.e. we used the published / versioned models in the SDK) and published to package platforms.
+
+
+After this point, things get really interesting with things like:
+
+- Recipe and workflow generation - think of things like plugins for the SDKs to do things like instantiating project boards with teams and referenced repos all in one SDK call. SDKs shouldn't be reflective API implementations, but rather tools that simplify our approach to getting things done.
+- We could start generating SDKs using language specifications - imagine pairing our OpenAPI specification with a language RFC to spit out a baseline SDK that could be extended.
+- Generating language agnostic SDKs - what if we could maximize code reuse by implementing interpreted recipes or code
+- Building workflow interpolation based on user patterns present in GitHub - this comes back to the community and GitHub joining up to make consistent workflows no matter where the users are - in community apps or GitHub proper.

--- a/Octokit.Generators/README.md
+++ b/Octokit.Generators/README.md
@@ -4,7 +4,7 @@
 
 We've been discussing and thinking about code generators for a [while now](https://github.com/octokit/octokit.net/discussions/2527) and they are part of the [future vision](https://github.com/octokit/octokit.net/discussions/2495) for where we'd like to head with this SDK.
 
-Consider this to be iteration 0.  Meaning while we want to potentially move to source generators, templates, and using the features that Rosyln offers we need to do some functional experiments and solve our current needs while iterating on the future.  Acknoledging that code generation is a solved problem (menaing there is existing work out there) we should be intentional with the direction we take.
+Consider this to be iteration 0, meaning while we want to potentially move to source generators, templates, and using the features that Rosyln offers we need to do some functional experiments and solve our current needs while iterating on the future.  Acknowledging that code generation is a solved problem (menaing there is existing work out there) we should be intentional with the direction we take.
 
 ----
 

--- a/Octokit.sln
+++ b/Octokit.sln
@@ -17,6 +17,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{64FD6CD6
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Octokit.AsyncPaginationExtension", "Octokit.AsyncPaginationExtension\Octokit.AsyncPaginationExtension.csproj", "{0E8013E0-0CCF-4433-9E01-51AC288824C5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Octokit.Generators", "Octokit.Generators\Octokit.Generators.csproj", "{6A577AD0-2319-4FFC-8EF2-3CCDD31B0CD9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -47,6 +49,10 @@ Global
 		{0E8013E0-0CCF-4433-9E01-51AC288824C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0E8013E0-0CCF-4433-9E01-51AC288824C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0E8013E0-0CCF-4433-9E01-51AC288824C5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A577AD0-2319-4FFC-8EF2-3CCDD31B0CD9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A577AD0-2319-4FFC-8EF2-3CCDD31B0CD9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A577AD0-2319-4FFC-8EF2-3CCDD31B0CD9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A577AD0-2319-4FFC-8EF2-3CCDD31B0CD9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Fixes: https://github.com/octokit/octokit.net/issues/2534

This PR intends to add an iteration 0 for code generation. The initial generator was sourced from the work @Saalvage did when adding the [AsyncPaginationExtensions](https://github.com/octokit/octokit.net/pull/2516).

This PR:
- [x] Adds the generator project
- [x] Adds the first generator - AsyncPaginationExtensions (initial approach - future iterations will dive into using things such as Rosyln and source templates
- [x] Adds a readme explaining how to use this project and why we are doing it
- [x] Regenerates the extensions - there are deltas due to white space, some template modification, and ordinality of the generated implementations

Note: The existing test coverage for the extensions is still intact, and I intentionally left testing off of the generations project because:
1. It was redundant to test the generated extensions
2. This project is effectively a prototype for code generation and is proven through compiling the source it has generated