### PR TITLE
add active lock reason to PR

### DIFF
--- a/Octokit.Reactive/Clients/IObservableIssuesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssuesClient.cs
@@ -45,6 +45,11 @@ namespace Octokit.Reactive
         IObservableIssueTimelineClient Timeline { get; }
 
         /// <summary>
+        /// Client for locking/unlocking conversation on an issue
+        /// </summary>
+        IObservableLockUnlockClient LockUnlock { get; }
+
+        /// <summary>
         /// Gets a single Issue by number.
         /// </summary>
         /// <remarks>
@@ -316,41 +321,5 @@ namespace Octokit.Reactive
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
         IObservable<Issue> Update(long repositoryId, int number, IssueUpdate issueUpdate);
-
-        /// <summary>
-        /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
-        /// <param name="lockReason">The reason for locking the issue</param>
-        IObservable<Unit> Lock(string owner, string name, int number, LockReason? lockReason = null);
-
-        /// <summary>
-        /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
-        /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
-        /// <param name="lockReason">The reason for locking the issue</param>
-        IObservable<Unit> Lock(long repositoryId, int number, LockReason? lockReason = null);
-
-        /// <summary>
-        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
-        IObservable<Unit> Unlock(string owner, string name, int number);
-
-        /// <summary>
-        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
-        /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
-        IObservable<Unit> Unlock(long repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableLockUnlockClient.cs
+++ b/Octokit.Reactive/Clients/IObservableLockUnlockClient.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Reactive;
+
+namespace Octokit.Reactive
+{
+    /// <summary>
+    /// Client to manage locking/unlocking a conversation for an Issue or a Pull request
+    /// </summary>
+    public interface IObservableLockUnlockClient
+    {
+        /// <summary>
+        /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="lockReason">The reason for locking the issue</param>
+        IObservable<Unit> Lock(string owner, string name, int number, LockReason? lockReason = null);
+
+        /// <summary>
+        /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="lockReason">The reason for locking the issue</param>
+        IObservable<Unit> Lock(long repositoryId, int number, LockReason? lockReason = null);
+
+        /// <summary>
+        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue number</param>
+        IObservable<Unit> Unlock(string owner, string name, int number);
+
+        /// <summary>
+        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="number">The issue number</param>
+        IObservable<Unit> Unlock(long repositoryId, int number);
+    }
+}

--- a/Octokit.Reactive/Clients/IObservablePullRequestsClient.cs
+++ b/Octokit.Reactive/Clients/IObservablePullRequestsClient.cs
@@ -27,6 +27,11 @@ namespace Octokit.Reactive
         IObservablePullRequestReviewRequestsClient ReviewRequest { get; }
 
         /// <summary>
+        /// Client for locking/unlocking a conversation on a pull request
+        /// </summary>
+        IObservableLockUnlockClient LockUnlock { get; }
+
+        /// <summary>
         /// Gets a single Pull Request by number.
         /// </summary>
         /// <remarks>

--- a/Octokit.Reactive/Clients/ObservableIssuesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssuesClient.cs
@@ -486,7 +486,7 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return _client.Lock(owner, name, number, lockReason).ToObservable();
+            return _client.LockUnlock.Lock(owner, name, number, lockReason).ToObservable();
         }
 
         /// <summary>
@@ -498,7 +498,7 @@ namespace Octokit.Reactive
         /// <param name="lockReason">The reason for locking the issue</param>
         public IObservable<Unit> Lock(long repositoryId, int number, LockReason? lockReason = null)
         {
-            return _client.Lock(repositoryId, number, lockReason).ToObservable();
+            return _client.LockUnlock.Lock(repositoryId, number, lockReason).ToObservable();
         }
 
         /// <summary>
@@ -513,7 +513,7 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return _client.Unlock(owner, name, number).ToObservable();
+            return _client.LockUnlock.Unlock(owner, name, number).ToObservable();
         }
 
         /// <summary>
@@ -524,7 +524,7 @@ namespace Octokit.Reactive
         /// <param name="number">The issue number</param>
         public IObservable<Unit> Unlock(long repositoryId, int number)
         {
-            return _client.Unlock(repositoryId, number).ToObservable();
+            return _client.LockUnlock.Unlock(repositoryId, number).ToObservable();
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableIssuesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssuesClient.cs
@@ -48,6 +48,11 @@ namespace Octokit.Reactive
         /// </summary>
         public IObservableIssueTimelineClient Timeline { get; private set; }
 
+        /// <summary>
+        /// Client for locking/unlocking conversation on an issue
+        /// </summary>
+        public IObservableLockUnlockClient LockUnlock { get; protected set; }
+
         public ObservableIssuesClient(IGitHubClient client)
         {
             Ensure.ArgumentNotNull(client, nameof(client));
@@ -60,6 +65,7 @@ namespace Octokit.Reactive
             Milestone = new ObservableMilestonesClient(client);
             Comment = new ObservableIssueCommentsClient(client);
             Timeline = new ObservableIssueTimelineClient(client);
+            LockUnlock = new ObservableLockUnlockClient(client);
         }
 
         /// <summary>
@@ -473,58 +479,6 @@ namespace Octokit.Reactive
             return _client.Update(repositoryId, number, issueUpdate).ToObservable();
         }
 
-        /// <summary>
-        /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
-        /// <param name="lockReason">The reason for locking the issue</param>
-        public IObservable<Unit> Lock(string owner, string name, int number, LockReason? lockReason = null)
-        {
-            Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
-            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
-
-            return _client.LockUnlock.Lock(owner, name, number, lockReason).ToObservable();
-        }
-
-        /// <summary>
-        /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
-        /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
-        /// <param name="lockReason">The reason for locking the issue</param>
-        public IObservable<Unit> Lock(long repositoryId, int number, LockReason? lockReason = null)
-        {
-            return _client.LockUnlock.Lock(repositoryId, number, lockReason).ToObservable();
-        }
-
-        /// <summary>
-        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
-        public IObservable<Unit> Unlock(string owner, string name, int number)
-        {
-            Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
-            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
-
-            return _client.LockUnlock.Unlock(owner, name, number).ToObservable();
-        }
-
-        /// <summary>
-        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
-        /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
-        public IObservable<Unit> Unlock(long repositoryId, int number)
-        {
-            return _client.LockUnlock.Unlock(repositoryId, number).ToObservable();
-        }
+        
     }
 }

--- a/Octokit.Reactive/Clients/ObservableLockUnlockClient.cs
+++ b/Octokit.Reactive/Clients/ObservableLockUnlockClient.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Reactive;
+using System.Reactive.Threading.Tasks;
+
+namespace Octokit.Reactive
+{
+    /// <summary>
+    /// Client to manage locking/unlocking a conversation for an Issue or a Pull request
+    /// </summary>
+    public class ObservableLockUnlockClient : IObservableLockUnlockClient
+    {
+        readonly ILockUnlockClient _client;
+
+        public ObservableLockUnlockClient(IGitHubClient client)
+        {
+            Ensure.ArgumentNotNull(client, nameof(client));
+
+            _client = client.Issue.LockUnlock;
+        }
+
+        /// <summary>
+        /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="lockReason">The reason for locking the issue</param>
+        public IObservable<Unit> Lock(string owner, string name, int number, LockReason? lockReason = null)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+
+            return _client.Lock(owner, name, number, lockReason).ToObservable();
+        }
+
+        /// <summary>
+        /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="lockReason">The reason for locking the issue</param>
+        public IObservable<Unit> Lock(long repositoryId, int number, LockReason? lockReason = null)
+        {
+            return _client.Lock(repositoryId, number, lockReason).ToObservable();
+        }
+
+        /// <summary>
+        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue number</param>
+        public IObservable<Unit> Unlock(string owner, string name, int number)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+
+            return _client.Unlock(owner, name, number).ToObservable();
+        }
+
+        /// <summary>
+        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="number">The issue number</param>
+        public IObservable<Unit> Unlock(long repositoryId, int number)
+        {
+            return _client.Unlock(repositoryId, number).ToObservable();
+        }
+    }
+}

--- a/Octokit.Reactive/Clients/ObservablePullRequestsClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePullRequestsClient.cs
@@ -30,6 +30,11 @@ namespace Octokit.Reactive
         /// </summary>
         public IObservablePullRequestReviewRequestsClient ReviewRequest { get; private set; }
 
+        /// <summary>
+        /// Client for locking/unlocking a conversation on a pull request
+        /// </summary>
+        public IObservableLockUnlockClient LockUnlock { get; private set; }
+
         public ObservablePullRequestsClient(IGitHubClient client)
         {
             Ensure.ArgumentNotNull(client, nameof(client));
@@ -39,6 +44,7 @@ namespace Octokit.Reactive
             Review = new ObservablePullRequestReviewsClient(client);
             ReviewComment = new ObservablePullRequestReviewCommentsClient(client);
             ReviewRequest = new ObservablePullRequestReviewRequestsClient(client);
+            LockUnlock = new ObservableLockUnlockClient(client);
         }
 
         /// <summary>

--- a/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
@@ -241,12 +241,12 @@ public class IssuesClientTests : IDisposable
         var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
         Assert.False(issue.Locked);
 
-        await _issuesClient.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
         var retrieved = await _issuesClient.Get(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
         Assert.NotNull(retrieved);
         Assert.True(retrieved.Locked);
 
-        await _issuesClient.Unlock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Unlock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
         retrieved = await _issuesClient.Get(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
         Assert.NotNull(retrieved);
         Assert.False(retrieved.Locked);
@@ -259,7 +259,7 @@ public class IssuesClientTests : IDisposable
         var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
         Assert.False(issue.Locked);
 
-        await _issuesClient.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number, LockReason.OffTopic);
+        await _issuesClient.LockUnlock.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number, LockReason.OffTopic);
         var retrieved = await _issuesClient.Get(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
         Assert.NotNull(retrieved);
         Assert.True(retrieved.Locked);
@@ -273,12 +273,12 @@ public class IssuesClientTests : IDisposable
         var issue = await _issuesClient.Create(_context.Repository.Id, newIssue);
         Assert.False(issue.Locked);
 
-        await _issuesClient.Lock(_context.Repository.Id, issue.Number);
+        await _issuesClient.LockUnlock.Lock(_context.Repository.Id, issue.Number);
         var retrieved = await _issuesClient.Get(_context.Repository.Id, issue.Number);
         Assert.NotNull(retrieved);
         Assert.True(retrieved.Locked);
 
-        await _issuesClient.Unlock(_context.Repository.Id, issue.Number);
+        await _issuesClient.LockUnlock.Unlock(_context.Repository.Id, issue.Number);
         retrieved = await _issuesClient.Get(_context.Repository.Id, issue.Number);
         Assert.NotNull(retrieved);
         Assert.False(retrieved.Locked);

--- a/Octokit.Tests.Integration/Clients/IssuesEventsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssuesEventsClientTests.cs
@@ -63,9 +63,9 @@ public class IssuesEventsClientTests : IDisposable
     {
         var newIssue = new NewIssue("issue 1") { Body = "A new unassigned issue" };
         var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
-        await _issuesClient.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
-        await _issuesClient.Unlock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
-        await _issuesClient.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Unlock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
 
         var options = new ApiOptions
         {
@@ -83,9 +83,9 @@ public class IssuesEventsClientTests : IDisposable
     {
         var newIssue = new NewIssue("issue 1") { Body = "A new unassigned issue" };
         var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
-        await _issuesClient.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
-        await _issuesClient.Unlock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
-        await _issuesClient.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Unlock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
 
         var options = new ApiOptions
         {
@@ -103,9 +103,9 @@ public class IssuesEventsClientTests : IDisposable
     {
         var newIssue = new NewIssue("issue 1") { Body = "A new unassigned issue" };
         var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
-        await _issuesClient.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
-        await _issuesClient.Unlock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
-        await _issuesClient.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Unlock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
 
         var options = new ApiOptions
         {
@@ -124,9 +124,9 @@ public class IssuesEventsClientTests : IDisposable
     {
         var newIssue = new NewIssue("issue 1") { Body = "A new unassigned issue" };
         var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
-        await _issuesClient.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
-        await _issuesClient.Unlock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
-        await _issuesClient.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Unlock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
 
         var options = new ApiOptions
         {
@@ -145,9 +145,9 @@ public class IssuesEventsClientTests : IDisposable
     {
         var newIssue = new NewIssue("issue 1") { Body = "A new unassigned issue" };
         var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
-        await _issuesClient.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
-        await _issuesClient.Unlock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
-        await _issuesClient.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Unlock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
 
         var startOptions = new ApiOptions
         {
@@ -174,9 +174,9 @@ public class IssuesEventsClientTests : IDisposable
     {
         var newIssue = new NewIssue("issue 1") { Body = "A new unassigned issue" };
         var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
-        await _issuesClient.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
-        await _issuesClient.Unlock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
-        await _issuesClient.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Unlock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
 
         var startOptions = new ApiOptions
         {
@@ -259,9 +259,9 @@ public class IssuesEventsClientTests : IDisposable
     {
         var newIssue = new NewIssue("issue 1") { Body = "A new unassigned issue" };
         var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
-        await _issuesClient.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
-        await _issuesClient.Unlock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
-        await _issuesClient.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Unlock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
 
         var options = new ApiOptions
         {
@@ -279,9 +279,9 @@ public class IssuesEventsClientTests : IDisposable
     {
         var newIssue = new NewIssue("issue 1") { Body = "A new unassigned issue" };
         var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
-        await _issuesClient.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
-        await _issuesClient.Unlock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
-        await _issuesClient.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Unlock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
 
         var options = new ApiOptions
         {
@@ -299,9 +299,9 @@ public class IssuesEventsClientTests : IDisposable
     {
         var newIssue = new NewIssue("issue 1") { Body = "A new unassigned issue" };
         var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
-        await _issuesClient.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
-        await _issuesClient.Unlock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
-        await _issuesClient.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Unlock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
 
         var options = new ApiOptions
         {
@@ -320,9 +320,9 @@ public class IssuesEventsClientTests : IDisposable
     {
         var newIssue = new NewIssue("issue 1") { Body = "A new unassigned issue" };
         var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
-        await _issuesClient.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
-        await _issuesClient.Unlock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
-        await _issuesClient.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Unlock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
 
         var options = new ApiOptions
         {
@@ -341,9 +341,9 @@ public class IssuesEventsClientTests : IDisposable
     {
         var newIssue = new NewIssue("issue 1") { Body = "A new unassigned issue" };
         var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
-        await _issuesClient.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
-        await _issuesClient.Unlock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
-        await _issuesClient.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Unlock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
 
         var startOptions = new ApiOptions
         {
@@ -370,9 +370,9 @@ public class IssuesEventsClientTests : IDisposable
     {
         var newIssue = new NewIssue("issue 1") { Body = "A new unassigned issue" };
         var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
-        await _issuesClient.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
-        await _issuesClient.Unlock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
-        await _issuesClient.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Unlock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        await _issuesClient.LockUnlock.Lock(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
 
         var startOptions = new ApiOptions
         {

--- a/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
@@ -669,7 +669,7 @@ public class PullRequestsClientTests : IDisposable
         await _fixture.LockUnlock.Unlock(Helper.UserName, _context.RepositoryName, pullRequest.Number);
         var unlocked = await _fixture.Get(Helper.UserName, _context.RepositoryName, pullRequest.Number);
 
-        Assert.Equal(unlocked.ActiveLockReason, null);
+        Assert.Null(unlocked.ActiveLockReason);
     }
 
     [IntegrationTest]

--- a/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
@@ -654,6 +654,25 @@ public class PullRequestsClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task CanLockAndUnlock()
+    {
+        await CreateTheWorld();
+
+        var newPullRequest = new NewPullRequest("a pull request to lock", branchName, "main");
+        var pullRequest = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
+
+        await _fixture.LockUnlock.Lock(Helper.UserName, _context.RepositoryName, pullRequest.Number, LockReason.OffTopic);
+        var retrived = await _fixture.Get(Helper.UserName, _context.RepositoryName, pullRequest.Number);
+
+        Assert.Equal(retrived.ActiveLockReason, LockReason.OffTopic);
+
+        await _fixture.LockUnlock.Unlock(Helper.UserName, _context.RepositoryName, pullRequest.Number);
+        var unlocked = await _fixture.Get(Helper.UserName, _context.RepositoryName, pullRequest.Number);
+
+        Assert.Equal(unlocked.ActiveLockReason, null);
+    }
+
+    [IntegrationTest]
     public async Task CanFindClosedPullRequest()
     {
         await CreateTheWorld();

--- a/Octokit.Tests.Integration/Reactive/ObservableIssuesClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableIssuesClientTests.cs
@@ -118,11 +118,11 @@ public class ObservableIssuesClientTests : IDisposable
         var createResult = await _client.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
         Assert.False(createResult.Locked);
 
-        await _client.Lock(_context.RepositoryOwner, _context.RepositoryName, createResult.Number);
+        await _client.LockUnlock.Lock(_context.RepositoryOwner, _context.RepositoryName, createResult.Number);
         var lockResult = await _client.Get(_context.RepositoryOwner, _context.RepositoryName, createResult.Number);
         Assert.True(lockResult.Locked);
 
-        await _client.Unlock(_context.RepositoryOwner, _context.RepositoryName, createResult.Number);
+        await _client.LockUnlock.Unlock(_context.RepositoryOwner, _context.RepositoryName, createResult.Number);
         var unlockIssueResult = await _client.Get(_context.RepositoryOwner, _context.RepositoryName, createResult.Number);
         Assert.False(unlockIssueResult.Locked);
     }

--- a/Octokit.Tests/Clients/IssuesClientTests.cs
+++ b/Octokit.Tests/Clients/IssuesClientTests.cs
@@ -478,7 +478,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new IssuesClient(connection);
 
-                client.Lock("fake", "repo", 42);
+                client.LockUnlock.Lock("fake", "repo", 42);
 
                 connection.Received().Put<Issue>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/lock"), Arg.Any<object>());
             }
@@ -489,7 +489,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new IssuesClient(connection);
 
-                client.Lock(1, 42);
+                client.LockUnlock.Lock(1, 42);
 
                 connection.Received().Put<Issue>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/lock"), Arg.Any<object>());
             }
@@ -500,11 +500,11 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new IssuesClient(connection);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Lock(null, "name", 1));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Lock("owner", null, 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.LockUnlock.Lock(null, "name", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.LockUnlock.Lock("owner", null, 1));
 
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Lock("", "name", 1));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Lock("owner", "", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.LockUnlock.Lock("", "name", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.LockUnlock.Lock("owner", "", 1));
             }
         }
 
@@ -516,7 +516,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new IssuesClient(connection);
 
-                client.Unlock("fake", "repo", 42);
+                client.LockUnlock.Unlock("fake", "repo", 42);
 
                 connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/lock"));
             }
@@ -527,7 +527,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new IssuesClient(connection);
 
-                client.Unlock(1, 42);
+                client.LockUnlock.Unlock(1, 42);
 
                 connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/lock"));
             }
@@ -538,11 +538,11 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new IssuesClient(connection);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Unlock(null, "name", 1));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Unlock("owner", null, 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.LockUnlock.Unlock(null, "name", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.LockUnlock.Unlock("owner", null, 1));
 
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Unlock("", "name", 1));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Unlock("owner", "", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.LockUnlock.Unlock("", "name", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.LockUnlock.Unlock("owner", "", 1));
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableIssuesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssuesClientTests.cs
@@ -647,7 +647,7 @@ public class ObservableIssuesClientTests
 
             client.Lock("fake", "repo", 42);
 
-            gitHubClient.Issue.Received().Lock("fake", "repo", 42);
+            gitHubClient.Issue.Received().LockUnlock.Lock("fake", "repo", 42);
         }
 
         [Fact]
@@ -658,7 +658,7 @@ public class ObservableIssuesClientTests
 
             client.Lock(1, 42);
 
-            gitHubClient.Issue.Received().Lock(1, 42);
+            gitHubClient.Issue.Received().LockUnlock.Lock(1, 42);
         }
 
         [Fact]
@@ -685,7 +685,7 @@ public class ObservableIssuesClientTests
 
             client.Unlock("fake", "repo", 42);
 
-            gitHubClient.Issue.Received().Unlock("fake", "repo", 42);
+            gitHubClient.Issue.Received().LockUnlock.Unlock("fake", "repo", 42);
         }
 
         [Fact]
@@ -696,7 +696,7 @@ public class ObservableIssuesClientTests
 
             client.Unlock(1, 42);
 
-            gitHubClient.Issue.Received().Unlock(1, 42);
+            gitHubClient.Issue.Received().LockUnlock.Unlock(1, 42);
         }
 
         [Fact]

--- a/Octokit.Tests/Reactive/ObservableIssuesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssuesClientTests.cs
@@ -645,7 +645,7 @@ public class ObservableIssuesClientTests
             var gitHubClient = Substitute.For<IGitHubClient>();
             var client = new ObservableIssuesClient(gitHubClient);
 
-            client.Lock("fake", "repo", 42);
+            client.LockUnlock.Lock("fake", "repo", 42);
 
             gitHubClient.Issue.Received().LockUnlock.Lock("fake", "repo", 42);
         }
@@ -656,7 +656,7 @@ public class ObservableIssuesClientTests
             var gitHubClient = Substitute.For<IGitHubClient>();
             var client = new ObservableIssuesClient(gitHubClient);
 
-            client.Lock(1, 42);
+            client.LockUnlock.Lock(1, 42);
 
             gitHubClient.Issue.Received().LockUnlock.Lock(1, 42);
         }
@@ -667,11 +667,11 @@ public class ObservableIssuesClientTests
             var gitHubClient = Substitute.For<IGitHubClient>();
             var client = new ObservableIssuesClient(gitHubClient);
 
-            Assert.Throws<ArgumentNullException>(() => client.Lock(null, "name", 42));
-            Assert.Throws<ArgumentNullException>(() => client.Lock("owner", null, 42));
+            Assert.Throws<ArgumentNullException>(() => client.LockUnlock.Lock(null, "name", 42));
+            Assert.Throws<ArgumentNullException>(() => client.LockUnlock.Lock("owner", null, 42));
 
-            Assert.Throws<ArgumentException>(() => client.Lock("", "name", 42));
-            Assert.Throws<ArgumentException>(() => client.Lock("owner", "", 42));
+            Assert.Throws<ArgumentException>(() => client.LockUnlock.Lock("", "name", 42));
+            Assert.Throws<ArgumentException>(() => client.LockUnlock.Lock("owner", "", 42));
         }
     }
 
@@ -683,7 +683,7 @@ public class ObservableIssuesClientTests
             var gitHubClient = Substitute.For<IGitHubClient>();
             var client = new ObservableIssuesClient(gitHubClient);
 
-            client.Unlock("fake", "repo", 42);
+            client.LockUnlock.Unlock("fake", "repo", 42);
 
             gitHubClient.Issue.Received().LockUnlock.Unlock("fake", "repo", 42);
         }
@@ -694,7 +694,7 @@ public class ObservableIssuesClientTests
             var gitHubClient = Substitute.For<IGitHubClient>();
             var client = new ObservableIssuesClient(gitHubClient);
 
-            client.Unlock(1, 42);
+            client.LockUnlock.Unlock(1, 42);
 
             gitHubClient.Issue.Received().LockUnlock.Unlock(1, 42);
         }
@@ -705,11 +705,11 @@ public class ObservableIssuesClientTests
             var gitHubClient = Substitute.For<IGitHubClient>();
             var client = new ObservableIssuesClient(gitHubClient);
 
-            Assert.Throws<ArgumentNullException>(() => client.Unlock(null, "name", 42));
-            Assert.Throws<ArgumentNullException>(() => client.Unlock("owner", null, 42));
+            Assert.Throws<ArgumentNullException>(() => client.LockUnlock.Unlock(null, "name", 42));
+            Assert.Throws<ArgumentNullException>(() => client.LockUnlock.Unlock("owner", null, 42));
 
-            Assert.Throws<ArgumentException>(() => client.Unlock("", "name", 42));
-            Assert.Throws<ArgumentException>(() => client.Unlock("owner", "", 42));
+            Assert.Throws<ArgumentException>(() => client.LockUnlock.Unlock("", "name", 42));
+            Assert.Throws<ArgumentException>(() => client.LockUnlock.Unlock("owner", "", 42));
         }
     }
 

--- a/Octokit/Clients/IIssuesClient.cs
+++ b/Octokit/Clients/IIssuesClient.cs
@@ -41,6 +41,8 @@ namespace Octokit
 
         IIssueTimelineClient Timeline { get; }
 
+        ILockUnlockClient LockUnlock { get; }
+
         /// <summary>
         /// Gets a single Issue by number.
         /// </summary>
@@ -314,40 +316,5 @@ namespace Octokit
         /// </param>
         Task<Issue> Update(long repositoryId, int number, IssueUpdate issueUpdate);
 
-        /// <summary>
-        /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue or pull request's conversation.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
-        /// <param name="lockReason">The reason for locking the issue</param>
-        Task Lock(string owner, string name, int number, LockReason? lockReason = null);
-
-        /// <summary>
-        /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue or pull request's conversation.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
-        /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
-        /// <param name="lockReason">The reason for locking the issue</param>
-        Task Lock(long repositoryId, int number, LockReason? lockReason = null);
-
-        /// <summary>
-        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue or pull request's conversation.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
-        Task Unlock(string owner, string name, int number);
-
-        /// <summary>
-        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue or pull request's conversation.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
-        /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
-        Task Unlock(long repositoryId, int number);
     }
 }

--- a/Octokit/Clients/IIssuesClient.cs
+++ b/Octokit/Clients/IIssuesClient.cs
@@ -315,7 +315,7 @@ namespace Octokit
         Task<Issue> Update(long repositoryId, int number, IssueUpdate issueUpdate);
 
         /// <summary>
-        /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue.
+        /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue or pull request's conversation.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
@@ -325,7 +325,7 @@ namespace Octokit
         Task Lock(string owner, string name, int number, LockReason? lockReason = null);
 
         /// <summary>
-        /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue.
+        /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue or pull request's conversation.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
@@ -334,7 +334,7 @@ namespace Octokit
         Task Lock(long repositoryId, int number, LockReason? lockReason = null);
 
         /// <summary>
-        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
+        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue or pull request's conversation.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
@@ -343,7 +343,7 @@ namespace Octokit
         Task Unlock(string owner, string name, int number);
 
         /// <summary>
-        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
+        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue or pull request's conversation.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>

--- a/Octokit/Clients/ILockUnlockClient.cs
+++ b/Octokit/Clients/ILockUnlockClient.cs
@@ -1,0 +1,47 @@
+﻿using System.Threading.Tasks;
+
+namespace Octokit
+{
+    /// <summary>
+    /// Client to manage locking/unlocking a conversation for an Issue or a Pull request
+    /// </summary>
+    public interface ILockUnlockClient
+    {
+        /// <summary>
+        /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue or pull request's conversation.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="lockReason">The reason for locking the issue</param>
+        Task Lock(string owner, string name, int number, LockReason? lockReason = null);
+
+        /// <summary>
+        /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue or pull request's conversation.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="lockReason">The reason for locking the issue</param>
+        Task Lock(long repositoryId, int number, LockReason? lockReason = null);
+
+        /// <summary>
+        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue or pull request's conversation.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue number</param>
+        Task Unlock(string owner, string name, int number);
+
+        /// <summary>
+        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue or pull request's conversation.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="number">The issue number</param>
+        Task Unlock(long repositoryId, int number);
+
+    }
+}

--- a/Octokit/Clients/IPullRequestsClient.cs
+++ b/Octokit/Clients/IPullRequestsClient.cs
@@ -29,6 +29,11 @@ namespace Octokit
         IPullRequestReviewRequestsClient ReviewRequest { get; }
 
         /// <summary>
+        /// Client for locking/unlocking a coversation on a pull request
+        /// </summary>
+        ILockUnlockClient LockUnlock { get; }
+
+        /// <summary>
         /// Get a pull request by number.
         /// </summary>
         /// <remarks>

--- a/Octokit/Clients/IssuesClient.cs
+++ b/Octokit/Clients/IssuesClient.cs
@@ -23,6 +23,7 @@ namespace Octokit
             Milestone = new MilestonesClient(apiConnection);
             Comment = new IssueCommentsClient(apiConnection);
             Timeline = new IssueTimelineClient(apiConnection);
+            LockUnlock = new LockUnlockClient(apiConnection);
         }
 
         /// <summary>
@@ -56,6 +57,11 @@ namespace Octokit
         /// Client for reading the timeline of events for an issue
         /// </summary>
         public IIssueTimelineClient Timeline { get; private set; }
+
+        /// <summary>
+        /// Client for locking and unlocking a conversation on a Issue or Pull request
+        /// </summary>
+        public ILockUnlockClient LockUnlock { get; private set; }
 
         /// <summary>
         /// Gets a single Issue by number.
@@ -491,64 +497,6 @@ namespace Octokit
             Ensure.ArgumentNotNull(issueUpdate, nameof(issueUpdate));
 
             return ApiConnection.Patch<Issue>(ApiUrls.Issue(repositoryId, number), issueUpdate);
-        }
-
-        /// <summary>
-        /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue or pull request's conversation.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
-        /// <param name="lockReason">The reason for locking the issue</param>
-        [ManualRoute("PUT", "/repos/{owner}/{repo}/issues/{issue_number}/lock")]
-        public Task Lock(string owner, string name, int number, LockReason? lockReason = null)
-        {
-            Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
-            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
-
-            return ApiConnection.Put<Issue>(ApiUrls.IssueLock(owner, name, number), lockReason.HasValue ? new { LockReason = lockReason } : new object());
-        }
-
-        /// <summary>
-        /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue or pull request's conversation.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
-        /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
-        /// <param name="lockReason">The reason for locking the issue</param>
-        [ManualRoute("PUT", "/repositories/{id}/issues/{number}/lock")]
-        public Task Lock(long repositoryId, int number, LockReason? lockReason = null)
-        {
-            return ApiConnection.Put<Issue>(ApiUrls.IssueLock(repositoryId, number), lockReason.HasValue ? new { LockReaons = lockReason } : new object());
-        }
-
-        /// <summary>
-        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue or pull request's conversation.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
-        [ManualRoute("DELETE", "/repos/{owner}/{repo}/issues/{issue_number}/lock")]
-        public Task Unlock(string owner, string name, int number)
-        {
-            Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
-            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
-
-            return ApiConnection.Delete(ApiUrls.IssueLock(owner, name, number));
-        }
-
-        /// <summary>
-        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue or pull request's conversation.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
-        /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
-        [ManualRoute("DELETE", "/repositories/{id}/issues/{number}/lock")]
-        public Task Unlock(long repositoryId, int number)
-        {
-            return ApiConnection.Delete(ApiUrls.IssueLock(repositoryId, number));
-        }
+        }        
     }
 }

--- a/Octokit/Clients/IssuesClient.cs
+++ b/Octokit/Clients/IssuesClient.cs
@@ -494,7 +494,7 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue  or pull request's conversation.
+        /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue or pull request's conversation.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
@@ -540,7 +540,7 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue  or pull request's conversation.
+        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue or pull request's conversation.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>

--- a/Octokit/Clients/IssuesClient.cs
+++ b/Octokit/Clients/IssuesClient.cs
@@ -494,7 +494,7 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue.
+        /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue  or pull request's conversation.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
@@ -511,7 +511,7 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue.
+        /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue or pull request's conversation.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
@@ -524,7 +524,7 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
+        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue or pull request's conversation.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
@@ -540,7 +540,7 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
+        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue  or pull request's conversation.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>

--- a/Octokit/Clients/LockUnlockClient.cs
+++ b/Octokit/Clients/LockUnlockClient.cs
@@ -1,0 +1,76 @@
+﻿using System.Threading.Tasks;
+
+namespace Octokit
+{
+    /// <summary>
+    /// Client to manage locking/unlocking a conversation for an Issue or a Pull request
+    /// </summary>
+    public class LockUnlockClient : ApiClient, ILockUnlockClient
+    {
+        /// <summary>
+        /// Instantiates a new GitHub Issue Lock API client.
+        /// </summary>
+        /// <param name="apiConnection">An API connection</param>
+        public LockUnlockClient(IApiConnection apiConnection) : base(apiConnection)
+        {
+
+        }
+        /// <summary>
+        /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue or pull request's conversation.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="lockReason">The reason for locking the issue</param>
+        [ManualRoute("PUT", "/repos/{owner}/{repo}/issues/{issue_number}/lock")]
+        public Task Lock(string owner, string name, int number, LockReason? lockReason = null)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+
+            return ApiConnection.Put<Issue>(ApiUrls.IssueLock(owner, name, number), lockReason.HasValue ? new { LockReason = lockReason } : new object());
+        }
+
+        /// <summary>
+        /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue or pull request's conversation.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="lockReason">The reason for locking the issue</param>
+        [ManualRoute("PUT", "/repositories/{id}/issues/{number}/lock")]
+        public Task Lock(long repositoryId, int number, LockReason? lockReason = null)
+        {
+            return ApiConnection.Put<Issue>(ApiUrls.IssueLock(repositoryId, number), lockReason.HasValue ? new { LockReaons = lockReason } : new object());
+        }
+
+        /// <summary>
+        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue or pull request's conversation.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue number</param>
+        [ManualRoute("DELETE", "/repos/{owner}/{repo}/issues/{issue_number}/lock")]
+        public Task Unlock(string owner, string name, int number)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+
+            return ApiConnection.Delete(ApiUrls.IssueLock(owner, name, number));
+        }
+
+        /// <summary>
+        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue or pull request's conversation.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="number">The issue number</param>
+        [ManualRoute("DELETE", "/repositories/{id}/issues/{number}/lock")]
+        public Task Unlock(long repositoryId, int number)
+        {
+            return ApiConnection.Delete(ApiUrls.IssueLock(repositoryId, number));
+        }
+    }
+}

--- a/Octokit/Clients/PullRequestsClient.cs
+++ b/Octokit/Clients/PullRequestsClient.cs
@@ -18,6 +18,7 @@ namespace Octokit
             Review = new PullRequestReviewsClient(apiConnection);
             ReviewComment = new PullRequestReviewCommentsClient(apiConnection);
             ReviewRequest = new PullRequestReviewRequestsClient(apiConnection);
+            LockUnlock = new LockUnlockClient(apiConnection);
         }
 
         /// <summary>
@@ -34,6 +35,11 @@ namespace Octokit
         /// Client for managing review requests.
         /// </summary>
         public IPullRequestReviewRequestsClient ReviewRequest { get; set; }
+
+        /// <summary>
+        /// Client for locking/unlocking a coversation on a pull request
+        /// </summary>
+        public ILockUnlockClient LockUnlock { get; set; }
 
         /// <summary>
         /// Get a pull request by number.

--- a/Octokit/Models/Response/PullRequest.cs
+++ b/Octokit/Models/Response/PullRequest.cs
@@ -16,7 +16,7 @@ namespace Octokit
             Number = number;
         }
 
-        public PullRequest(long id, string nodeId, string url, string htmlUrl, string diffUrl, string patchUrl, string issueUrl, string statusesUrl, int number, ItemState state, string title, string body, DateTimeOffset createdAt, DateTimeOffset updatedAt, DateTimeOffset? closedAt, DateTimeOffset? mergedAt, GitReference head, GitReference @base, User user, User assignee, IReadOnlyList<User> assignees, bool draft, bool? mergeable, MergeableState? mergeableState, User mergedBy, string mergeCommitSha, int comments, int commits, int additions, int deletions, int changedFiles, Milestone milestone, bool locked, bool? maintainerCanModify, IReadOnlyList<User> requestedReviewers, IReadOnlyList<Team> requestedTeams, IReadOnlyList<Label> labels)
+        public PullRequest(long id, string nodeId, string url, string htmlUrl, string diffUrl, string patchUrl, string issueUrl, string statusesUrl, int number, ItemState state, string title, string body, DateTimeOffset createdAt, DateTimeOffset updatedAt, DateTimeOffset? closedAt, DateTimeOffset? mergedAt, GitReference head, GitReference @base, User user, User assignee, IReadOnlyList<User> assignees, bool draft, bool? mergeable, MergeableState? mergeableState, User mergedBy, string mergeCommitSha, int comments, int commits, int additions, int deletions, int changedFiles, Milestone milestone, bool locked, bool? maintainerCanModify, IReadOnlyList<User> requestedReviewers, IReadOnlyList<Team> requestedTeams, IReadOnlyList<Label> labels, LockReason? activeLockReason)
         {
             Id = id;
             NodeId = nodeId;
@@ -55,6 +55,7 @@ namespace Octokit
             RequestedReviewers = requestedReviewers;
             RequestedTeams = requestedTeams;
             Labels = labels;
+            ActiveLockReason = activeLockReason;
         }
 
         /// <summary>
@@ -250,6 +251,11 @@ namespace Octokit
         public IReadOnlyList<Team> RequestedTeams { get; protected set; }
 
         public IReadOnlyList<Label> Labels { get; protected set; }
+
+        /// <summary>
+        /// Reason that the conversation was locked
+        /// </summary>
+        public StringEnum<LockReason>? ActiveLockReason { get; protected set; }
 
         internal string DebuggerDisplay
         {

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -120,3 +120,23 @@ Label changes probably requires some explanation:
 
 If you're trying to populate the `Labels` collection by hand, you might hit
 some exceptional behaviour due to these rules.
+
+### Lock / Unlock
+
+The lock and unlock methods are available on the ILockUnlockClient on IIssuesClient.
+
+Heres a sample code for locking an issue:
+
+```csharp
+var issue = await client.Issue.Get("octokit", "octokit.net", 405);
+await client.LockUnlock.Lock("octokit", "octokit.net", 405, LockReason.OffTopic);
+```
+
+The active lock reason can be accessed via the LockReason property on Issues class.
+
+The code below demonstrates how to unlock an issue:
+
+```csharp
+var issue = await client.Issue.Get("octokit", "octokit.net", 405);
+await client.LockUnlock.Unlock("octokit", "octokit.net", 405);
+```


### PR DESCRIPTION
add active lock reason to PR. 
Since every pull request is an issue and the lock and unlock are on the IIssuesClient, updates the docs to reflect the design.
Fixes #2248 