### PR TITLE
Add Cancellation token for GetRawContent api

### DIFF
--- a/Octokit/Clients/IRepositoryContentsClient.cs
+++ b/Octokit/Clients/IRepositoryContentsClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Octokit.Internal;
 
@@ -34,7 +35,8 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The content path</param>
-        Task<byte[]> GetRawContent(string owner, string name, string path);
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
+        Task<byte[]> GetRawContent(string owner, string name, string path, CancellationToken cancellationToken);
 
         /// <summary>
         /// Returns the contents of a file or directory in a repository.
@@ -77,7 +79,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The content path</param>
-        /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually main)</param>
+        /// <param name="reference">The name of the commit/branch/tag. Default: the repositoryï¿½s default branch (usually main)</param>
         [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string path, string reference);
 
@@ -101,7 +103,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The content path</param>
-        /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually main)</param>
+        /// <param name="reference">The name of the commit/branch/tag. Default: the repositoryï¿½s default branch (usually main)</param>
         [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(long repositoryId, string path, string reference);
 
@@ -114,7 +116,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually main)</param>
+        /// <param name="reference">The name of the commit/branch/tag. Default: the repositoryï¿½s default branch (usually main)</param>
         [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string reference);
 
@@ -126,7 +128,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually main)</param>
+        /// <param name="reference">The name of the commit/branch/tag. Default: the repositoryï¿½s default branch (usually main)</param>
         [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(long repositoryId, string reference);
 

--- a/Octokit/Clients/RepositoryContentsClient.cs
+++ b/Octokit/Clients/RepositoryContentsClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Octokit
@@ -51,7 +52,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The content path</param>
         [ManualRoute("GET", "repos/{owner}/{repo}/contents/{path}")]
-        public Task<byte[]> GetRawContent(string owner, string name, string path)
+        public Task<byte[]> GetRawContent(string owner, string name, string path, CancellationToken cancellationToken)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -59,7 +60,7 @@ namespace Octokit
 
             var url = ApiUrls.RepositoryContent(owner, name, path);
 
-            return ApiConnection.GetRaw(url, null);
+            return ApiConnection.GetRaw(url, null, cancellationToken);
         }
 
         /// <summary>

--- a/Octokit/Http/ApiConnection.cs
+++ b/Octokit/Http/ApiConnection.cs
@@ -111,13 +111,14 @@ namespace Octokit
         /// </summary>
         /// <param name="uri">URI of the API resource to get</param>
         /// <param name="parameters">Parameters to add to the API request</param>
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
         /// <returns>The API resource's raw content or <c>null</c> if the <paramref name="uri"/> points to a directory.</returns>
         /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
-        public async Task<byte[]> GetRaw(Uri uri, IDictionary<string, string> parameters)
+        public async Task<byte[]> GetRaw(Uri uri, IDictionary<string, string> parameters, CancellationToken cancellationToken = default)
         {
             Ensure.ArgumentNotNull(uri, nameof(uri));
 
-            var response = await Connection.GetRaw(uri, parameters).ConfigureAwait(false);
+            var response = await Connection.GetRaw(uri, parameters, cancellationToken).ConfigureAwait(false);
             return response.Body;
         }
 
@@ -569,7 +570,7 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Executes a GET to the API object at the specified URI. This operation is appropriate for API calls which 
+        /// Executes a GET to the API object at the specified URI. This operation is appropriate for API calls which
         /// queue long running calculations and return a collection of a resource.
         /// It expects the API to respond with an initial 202 Accepted, and queries again until a 200 OK is received.
         /// It returns an empty collection if it receives a 204 No Content response.

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -221,8 +221,9 @@ namespace Octokit
         /// <param name="uri">URI endpoint to send request to</param>
         /// <param name="parameters">Querystring parameters for the request</param>
         /// <returns><seealso cref="IResponse"/> representing the received HTTP response</returns>
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
         /// <remarks>The <see cref="IResponse.Body"/> property will be <c>null</c> if the <paramref name="uri"/> points to a directory instead of a file</remarks>
-        public Task<IApiResponse<byte[]>> GetRaw(Uri uri, IDictionary<string, string> parameters)
+        public Task<IApiResponse<byte[]>> GetRaw(Uri uri, IDictionary<string, string> parameters, CancellationToken cancellationToken = default)
         {
             Ensure.ArgumentNotNull(uri, nameof(uri));
 
@@ -657,10 +658,10 @@ namespace Octokit
             return new ApiResponse<string>(response, response.Body as string);
         }
 
-        async Task<IApiResponse<byte[]>> GetRaw(IRequest request)
+        async Task<IApiResponse<byte[]>> GetRaw(IRequest request, CancellationToken cancellationToken = default)
         {
             request.Headers.Add("Accept", AcceptHeaders.RawContentMediaType);
-            var response = await RunRequest(request, CancellationToken.None).ConfigureAwait(false);
+            var response = await RunRequest(request, cancellationToken).ConfigureAwait(false);
             return new ApiResponse<byte[]>(response, response.Body as byte[]);
         }
 

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -232,7 +232,7 @@ namespace Octokit
                 Method = HttpMethod.Get,
                 BaseAddress = BaseAddress,
                 Endpoint = uri.ApplyParameters(parameters)
-            });
+            }, cancellationToken);
         }
 
         public Task<IApiResponse<T>> Patch<T>(Uri uri, object body)

--- a/Octokit/Http/IApiConnection.cs
+++ b/Octokit/Http/IApiConnection.cs
@@ -67,9 +67,10 @@ namespace Octokit
         /// </summary>
         /// <param name="uri">URI of the API resource to get</param>
         /// <param name="parameters">Parameters to add to the API request</param>
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
         /// <returns>The API resource's raw content or <c>null</c> if the <paramref name="uri"/> points to a directory.</returns>
         /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
-        Task<byte[]> GetRaw(Uri uri, IDictionary<string, string> parameters);
+        Task<byte[]> GetRaw(Uri uri, IDictionary<string, string> parameters, CancellationToken cancellationToken);
 
         /// <summary>
         /// Gets all API resources in the list at the specified URI.
@@ -366,7 +367,7 @@ namespace Octokit
         Task<T> Delete<T>(Uri uri, object data, string accepts);
 
         /// <summary>
-        /// Executes a GET to the API object at the specified URI. This operation is appropriate for API calls which 
+        /// Executes a GET to the API object at the specified URI. This operation is appropriate for API calls which
         /// queue long running calculations and return a collection of a resource.
         /// It expects the API to respond with an initial 202 Accepted, and queries again until a 200 OK is received.
         /// It returns an empty collection if it receives a 204 No Content response.

--- a/Octokit/Http/IConnection.cs
+++ b/Octokit/Http/IConnection.cs
@@ -26,8 +26,9 @@ namespace Octokit
         /// <param name="uri">URI endpoint to send request to</param>
         /// <param name="parameters">Querystring parameters for the request</param>
         /// <returns><seealso cref="IResponse"/> representing the received HTTP response</returns>
+        /// <param name="cancellationToken">An optional token to monitor for cancellation requests</param>
         /// <remarks>The <see cref="IResponse.Body"/> property will be <c>null</c> if the <paramref name="uri"/> points to a directory instead of a file</remarks>
-        Task<IApiResponse<byte[]>> GetRaw(Uri uri, IDictionary<string, string> parameters);
+        Task<IApiResponse<byte[]>> GetRaw(Uri uri, IDictionary<string, string> parameters, CancellationToken cancellationToken);
 
         /// <summary>
         /// Performs an asynchronous HTTP GET request.
@@ -302,7 +303,7 @@ namespace Octokit
         /// <typeparam name="T">The type to map the response to</typeparam>
         /// <param name="uri">URI endpoint to send request to</param>
         /// <param name="data">The object to serialize as the body of the request</param>
-        /// <param name="accepts">Specifies accept response media type</param>        
+        /// <param name="accepts">Specifies accept response media type</param>
         Task<IApiResponse<T>> Delete<T>(Uri uri, object data, string accepts);
 
         /// <summary>
@@ -319,9 +320,9 @@ namespace Octokit
         /// Gets or sets the credentials used by the connection.
         /// </summary>
         /// <remarks>
-        /// You can use this property if you only have a single hard-coded credential. Otherwise, pass in an 
-        /// <see cref="ICredentialStore"/> to the constructor. 
-        /// Setting this property will change the <see cref="ICredentialStore"/> to use 
+        /// You can use this property if you only have a single hard-coded credential. Otherwise, pass in an
+        /// <see cref="ICredentialStore"/> to the constructor.
+        /// Setting this property will change the <see cref="ICredentialStore"/> to use
         /// the default <see cref="InMemoryCredentialStore"/> with just these credentials.
         /// </remarks>
         Credentials Credentials { get; set; }


### PR DESCRIPTION
There's currently no way to cancel a file download since the api doesn't expose a cancellation token param. Adding it so downloads can be interrupted/cancelled.