### PR TITLE
Add ability to pass ApiOptions to PullRequestsClient.Files

### DIFF
--- a/Octokit.Reactive/Clients/IObservablePullRequestsClient.cs
+++ b/Octokit.Reactive/Clients/IObservablePullRequestsClient.cs
@@ -238,7 +238,26 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
+        /// <param name="options">Options for changing the API response</param>
+        IObservable<PullRequestFile> Files(string owner, string name, int number, ApiOptions options);
+
+        /// <summary>
+        /// Get the list of files on a pull request.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The pull request number</param>
         IObservable<PullRequestFile> Files(string owner, string name, int number);
+
+        /// <summary>
+        /// Get the list of files on a pull request.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <param name="options">Options for changing the API response</param>
+        IObservable<PullRequestFile> Files(long repositoryId, int number, ApiOptions options);
 
         /// <summary>
         /// Get the list of files on a pull request.

--- a/Octokit.Reactive/Clients/ObservablePullRequestsClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePullRequestsClient.cs
@@ -359,12 +359,37 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        public IObservable<PullRequestFile> Files(string owner, string name, int number)
+        /// <param name="options">Options for changing the API response</param>
+        public IObservable<PullRequestFile> Files(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return _connection.GetAndFlattenAllPages<PullRequestFile>(ApiUrls.PullRequestFiles(owner, name, number));
+            return _connection.GetAndFlattenAllPages<PullRequestFile>(ApiUrls.PullRequestFiles(owner, name, number), options);
+        }
+
+        /// <summary>
+        /// Get the list of files on a pull request.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The pull request number</param>
+        public IObservable<PullRequestFile> Files(string owner, string name, int number)
+        {
+            return Files(owner, name, number, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Get the list of files on a pull request.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <param name="options">Options for changing the API response</param>
+        public IObservable<PullRequestFile> Files(long repositoryId, int number, ApiOptions options)
+        {
+            return _connection.GetAndFlattenAllPages<PullRequestFile>(ApiUrls.PullRequestFiles(repositoryId, number), options);
         }
 
         /// <summary>
@@ -375,7 +400,7 @@ namespace Octokit.Reactive
         /// <param name="number">The pull request number</param>
         public IObservable<PullRequestFile> Files(long repositoryId, int number)
         {
-            return _connection.GetAndFlattenAllPages<PullRequestFile>(ApiUrls.PullRequestFiles(repositoryId, number));
+            return Files(repositoryId, number, ApiOptions.None);
         }
     }
 }

--- a/Octokit.Tests/Clients/PullRequestsClientTests.cs
+++ b/Octokit.Tests/Clients/PullRequestsClientTests.cs
@@ -461,7 +461,7 @@ namespace Octokit.Tests.Clients
                 await client.Files("fake", "repo", 42);
 
                 connection.Received()
-                    .GetAll<PullRequestFile>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pulls/42/files"));
+                    .GetAll<PullRequestFile>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pulls/42/files"), Args.ApiOptions);
             }
 
             [Fact]
@@ -473,7 +473,7 @@ namespace Octokit.Tests.Clients
                 await client.Files(1, 42);
 
                 connection.Received()
-                    .GetAll<PullRequestFile>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls/42/files"));
+                    .GetAll<PullRequestFile>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls/42/files"), Args.ApiOptions);
             }
 
             [Fact]

--- a/Octokit.Tests/Reactive/ObservablePullRequestsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservablePullRequestsClientTests.cs
@@ -704,7 +704,7 @@ namespace Octokit.Tests.Reactive
                     CreateResponse(HttpStatusCode.OK),
                     new List<PullRequestFile> { file }
                 );
-                connection.Get<List<PullRequestFile>>(Args.Uri, null)
+                connection.Get<List<PullRequestFile>>(Args.Uri, Arg.Any<IDictionary<string, string>>())
                     .Returns(Task.FromResult(response));
                 gitHubClient.Connection.Returns(connection);
                 var client = new ObservablePullRequestsClient(gitHubClient);
@@ -713,7 +713,7 @@ namespace Octokit.Tests.Reactive
 
                 Assert.Equal(1, files.Count);
                 Assert.Same(file, files[0]);
-                connection.Received().Get<List<PullRequestFile>>(new Uri(expectedUrl, UriKind.Relative), null);
+                connection.Received().Get<List<PullRequestFile>>(new Uri(expectedUrl, UriKind.Relative), Arg.Any<IDictionary<string, string>>());
             }
 
             [Fact]
@@ -728,7 +728,7 @@ namespace Octokit.Tests.Reactive
                     CreateResponse(HttpStatusCode.OK),
                     new List<PullRequestFile> { file }
                 );
-                connection.Get<List<PullRequestFile>>(Args.Uri, null)
+                connection.Get<List<PullRequestFile>>(Args.Uri, Arg.Any<IDictionary<string, string>>())
                     .Returns(Task.FromResult(response));
                 gitHubClient.Connection.Returns(connection);
                 var client = new ObservablePullRequestsClient(gitHubClient);
@@ -737,7 +737,7 @@ namespace Octokit.Tests.Reactive
 
                 Assert.Equal(1, files.Count);
                 Assert.Same(file, files[0]);
-                connection.Received().Get<List<PullRequestFile>>(new Uri(expectedUrl, UriKind.Relative), null);
+                connection.Received().Get<List<PullRequestFile>>(new Uri(expectedUrl, UriKind.Relative), Arg.Any<IDictionary<string, string>>());
             }
 
             [Fact]

--- a/Octokit/Clients/IPullRequestsClient.cs
+++ b/Octokit/Clients/IPullRequestsClient.cs
@@ -235,7 +235,26 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
+        /// <param name="options">Options for changing the API response</param>
+        Task<IReadOnlyList<PullRequestFile>> Files(string owner, string name, int number, ApiOptions options);
+
+        /// <summary>
+        /// Get the list of files on a pull request.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The pull request number</param>
         Task<IReadOnlyList<PullRequestFile>> Files(string owner, string name, int number);
+
+        /// <summary>
+        /// Get the list of files on a pull request.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <param name="options">Options for changing the API response</param>
+        Task<IReadOnlyList<PullRequestFile>> Files(long repositoryId, int number, ApiOptions options);
 
         /// <summary>
         /// Get the list of files on a pull request.

--- a/Octokit/Clients/PullRequestsClient.cs
+++ b/Octokit/Clients/PullRequestsClient.cs
@@ -443,7 +443,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return ApiConnection.GetAll<PullRequestFile>(ApiUrls.PullRequestFiles(owner, name, number), null, options);
+            return ApiConnection.GetAll<PullRequestFile>(ApiUrls.PullRequestFiles(owner, name, number), options);
         }
 
         /// <summary>
@@ -468,7 +468,7 @@ namespace Octokit
         [ManualRoute("GET", "/repositories/{id}/pulls/{number}/files")]
         public Task<IReadOnlyList<PullRequestFile>> Files(long repositoryId, int number, ApiOptions options)
         {
-            return ApiConnection.GetAll<PullRequestFile>(ApiUrls.PullRequestFiles(repositoryId, number), null, options);
+            return ApiConnection.GetAll<PullRequestFile>(ApiUrls.PullRequestFiles(repositoryId, number), options);
         }
     }
 }

--- a/Octokit/Clients/PullRequestsClient.cs
+++ b/Octokit/Clients/PullRequestsClient.cs
@@ -426,10 +426,24 @@ namespace Octokit
         [ManualRoute("GET", "/repos/{owner}/{repo}/pulls/{pull_number}/files")]
         public Task<IReadOnlyList<PullRequestFile>> Files(string owner, string name, int number)
         {
+            return Files(owner, name, number, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Get the list of files on a pull request.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{repo}/pulls/{pull_number}/files")]
+        public Task<IReadOnlyList<PullRequestFile>> Files(string owner, string name, int number, ApiOptions options)
+        {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return ApiConnection.GetAll<PullRequestFile>(ApiUrls.PullRequestFiles(owner, name, number));
+            return ApiConnection.GetAll<PullRequestFile>(ApiUrls.PullRequestFiles(owner, name, number), null, options);
         }
 
         /// <summary>
@@ -441,7 +455,20 @@ namespace Octokit
         [ManualRoute("GET", "/repositories/{id}/pulls/{number}/files")]
         public Task<IReadOnlyList<PullRequestFile>> Files(long repositoryId, int number)
         {
-            return ApiConnection.GetAll<PullRequestFile>(ApiUrls.PullRequestFiles(repositoryId, number));
+            return Files(repositoryId, number, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Get the list of files on a pull request.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/pulls/{number}/files")]
+        public Task<IReadOnlyList<PullRequestFile>> Files(long repositoryId, int number, ApiOptions options)
+        {
+            return ApiConnection.GetAll<PullRequestFile>(ApiUrls.PullRequestFiles(repositoryId, number), null, options);
         }
     }
 }


### PR DESCRIPTION
This fixes #2552 by allowing you to pass an ApiOptions object to the Files method of PullRequestsClient.
Files can still be called without ApiOptions and will simply pass on ApiOptions.None then.