### PR TITLE
Fix failure with 201 status code on adding a collaborator

### DIFF
--- a/Octokit.Reactive/Clients/IObservableRepoCollaboratorsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepoCollaboratorsClient.cs
@@ -172,7 +172,7 @@ namespace Octokit.Reactive
         /// <param name="user">Username of the new collaborator</param>
         /// <param name="permission">The permission to set. Only valid on organization-owned repositories.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<bool> Add(string owner, string name, string user, CollaboratorRequest permission);
+        IObservable<RepositoryInvitation> Add(string owner, string name, string user, CollaboratorRequest permission);
 
         /// <summary>
         /// Adds a new collaborator to the repository.
@@ -195,7 +195,7 @@ namespace Octokit.Reactive
         /// <param name="user">Username of the new collaborator</param>
         /// <param name="permission">The permission to set. Only valid on organization-owned repositories.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<bool> Add(long repositoryId, string user, CollaboratorRequest permission);
+        IObservable<RepositoryInvitation> Add(long repositoryId, string user, CollaboratorRequest permission);
 
         /// <summary>
         /// Invites a user as a collaborator to a repository.

--- a/Octokit.Reactive/Clients/ObservableRepoCollaboratorsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepoCollaboratorsClient.cs
@@ -267,7 +267,7 @@ namespace Octokit.Reactive
         /// <param name="user">Username of the new collaborator</param>
         /// <param name="permission">The permission to set. Only valid on organization-owned repositories.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public IObservable<bool> Add(string owner, string name, string user, CollaboratorRequest permission)
+        public IObservable<RepositoryInvitation> Add(string owner, string name, string user, CollaboratorRequest permission)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -303,7 +303,7 @@ namespace Octokit.Reactive
         /// <param name="user">Username of the new collaborator</param>
         /// <param name="permission">The permission to set. Only valid on organization-owned repositories.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public IObservable<bool> Add(long repositoryId, string user, CollaboratorRequest permission)
+        public IObservable<RepositoryInvitation> Add(long repositoryId, string user, CollaboratorRequest permission)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
             Ensure.ArgumentNotNull(permission, nameof(permission));

--- a/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
+++ b/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
@@ -391,7 +391,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepoCollaboratorsClient(connection);
 
-                connection.Connection.Put<object>(Arg.Any<Uri>(), Arg.Any<object>()).ThrowsAsync(new AuthorizationException());
+                connection.Put<RepositoryInvitation>(Arg.Any<Uri>(), Arg.Any<object>()).ThrowsAsync(new AuthorizationException());
 
                 await Assert.ThrowsAsync<AuthorizationException>(() => client.Add("owner", "test", "user1", new CollaboratorRequest(Permission.Pull)));
                 await Assert.ThrowsAsync<AuthorizationException>(() => client.Add(1, "user1", new CollaboratorRequest(Permission.Pull)));

--- a/Octokit/Clients/IRepoCollaboratorsClient.cs
+++ b/Octokit/Clients/IRepoCollaboratorsClient.cs
@@ -172,7 +172,7 @@ namespace Octokit
         /// <param name="user">Username of the new collaborator</param>
         /// <param name="permission">The permission to set. Only valid on organization-owned repositories.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<bool> Add(string owner, string name, string user, CollaboratorRequest permission);
+        Task<RepositoryInvitation> Add(string owner, string name, string user, CollaboratorRequest permission);
 
         /// <summary>
         /// Adds a new collaborator to the repository.
@@ -195,7 +195,7 @@ namespace Octokit
         /// <param name="user">Username of the new collaborator</param>
         /// <param name="permission">The permission to set. Only valid on organization-owned repositories.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<bool> Add(long repositoryId, string user, CollaboratorRequest permission);
+        Task<RepositoryInvitation> Add(long repositoryId, string user, CollaboratorRequest permission);
 
         /// <summary>
         /// Invites a new collaborator to the repo

--- a/Octokit/Clients/RepoCollaboratorsClient.cs
+++ b/Octokit/Clients/RepoCollaboratorsClient.cs
@@ -292,21 +292,13 @@ namespace Octokit
         /// <param name="permission">The permission to set. Only valid on organization-owned repositories.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         [ManualRoute("PUT", "/repos/{owner}/{repo}/collaborators/{username}")]
-        public async Task<bool> Add(string owner, string name, string user, CollaboratorRequest permission)
+        public async Task<RepositoryInvitation> Add(string owner, string name, string user, CollaboratorRequest permission)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
-
-            try
-            {
-                var response = await Connection.Put<object>(ApiUrls.RepoCollaborator(owner, name, user), permission).ConfigureAwait(false);
-                return response.HttpResponse.IsTrue();
-            }
-            catch (NotFoundException)
-            {
-                return false;
-            }
+            
+            return await ApiConnection.Put<RepositoryInvitation>(ApiUrls.RepoCollaborator(owner, name, user), permission).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -337,19 +329,11 @@ namespace Octokit
         /// <param name="permission">The permission to set. Only valid on organization-owned repositories.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         [ManualRoute("PUT", "/repository/{id}/collaborators/{username}")]
-        public async Task<bool> Add(long repositoryId, string user, CollaboratorRequest permission)
+        public async Task<RepositoryInvitation> Add(long repositoryId, string user, CollaboratorRequest permission)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
 
-            try
-            {
-                var response = await Connection.Put<object>(ApiUrls.RepoCollaborator(repositoryId, user), permission).ConfigureAwait(false);
-                return response.HttpResponse.IsTrue();
-            }
-            catch (NotFoundException)
-            {
-                return false;
-            }
+            return await ApiConnection.Put<RepositoryInvitation>(ApiUrls.RepoCollaborator(repositoryId, user), permission).ConfigureAwait(false);
         }
 
         /// <summary>


### PR DESCRIPTION
Close #2558 and close #2373 too.

I wrote such a local test:

```csharp
[Fact]
public async Task AddCollaborator_ThrowsNoException()
{
    GitHubClient client = new GitHubClient(new ProductHeaderValue("name"))
    {
        Credentials = new Credentials("token")
    };

    var response = await client.Repository.Collaborator.Add("owner", "name", "user", new CollaboratorRequest(Permission.Admin));
}
```

There was no exception and response was valid. An old version of this method throws ApiException (this case I have also covered with the corresponding test).