### PR TITLE
Convert response model property accessors from protected to the more appropriate private for consistency

### DIFF
--- a/Octokit/Models/Response/AccessToken.cs
+++ b/Octokit/Models/Response/AccessToken.cs
@@ -18,12 +18,12 @@ namespace Octokit
         /// <summary>
         /// The access token
         /// </summary>
-        public string Token { get; protected set; }
+        public string Token { get; private set; }
 
         /// <summary>
         /// The expiration date
         /// </summary>
-        public DateTimeOffset ExpiresAt { get; protected set; }
+        public DateTimeOffset ExpiresAt { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/Activity.cs
+++ b/Octokit/Models/Response/Activity.cs
@@ -29,42 +29,42 @@ namespace Octokit
         /// The type of the activity.
         /// </summary>
         [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods")]
-        public string Type { get; protected set; }
+        public string Type { get; private set; }
 
         /// <summary>
         /// Whether the activity event is public or not.
         /// </summary>
-        public bool Public { get; protected set; }
+        public bool Public { get; private set; }
 
         /// <summary>
         /// The repository associated with the activity event.
         /// </summary>
-        public Repository Repo { get; protected set; }
+        public Repository Repo { get; private set; }
 
         /// <summary>
         /// The user associated with the activity event.
         /// </summary>
-        public User Actor { get; protected set; }
+        public User Actor { get; private set; }
 
         /// <summary>
         /// The organization associated with the activity event.
         /// </summary>
-        public Organization Org { get; protected set; }
+        public Organization Org { get; private set; }
 
         /// <summary>
         /// The date the activity event was created.
         /// </summary>
-        public DateTimeOffset CreatedAt { get; protected set; }
+        public DateTimeOffset CreatedAt { get; private set; }
 
         /// <summary>
         /// The activity event Id.
         /// </summary>
-        public string Id { get; protected set; }
+        public string Id { get; private set; }
 
         /// <summary>
         /// The payload associated with the activity event.
         /// </summary>
-        public ActivityPayload Payload { get; protected set; }
+        public ActivityPayload Payload { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/ActivityPayloads/ActivityPayload.cs
+++ b/Octokit/Models/Response/ActivityPayloads/ActivityPayload.cs
@@ -15,9 +15,9 @@ namespace Octokit
             Installation = installation;
         }
 
-        public Repository Repository { get; protected set; }
-        public User Sender { get; protected set; }
-        public InstallationId Installation { get; protected set; }
+        public Repository Repository { get; private set; }
+        public User Sender { get; private set; }
+        public InstallationId Installation { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/ActivityPayloads/CheckRunEventPayload.cs
+++ b/Octokit/Models/Response/ActivityPayloads/CheckRunEventPayload.cs
@@ -5,8 +5,8 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class CheckRunEventPayload : ActivityPayload
     {
-        public string Action { get; protected set; }
-        public CheckRun CheckRun { get; protected set; }
-        public CheckRunRequestedAction RequestedAction { get; protected set; }
+        public string Action { get; private set; }
+        public CheckRun CheckRun { get; private set; }
+        public CheckRunRequestedAction RequestedAction { get; private set; }
     }
 }

--- a/Octokit/Models/Response/ActivityPayloads/CheckSuiteEventPayload.cs
+++ b/Octokit/Models/Response/ActivityPayloads/CheckSuiteEventPayload.cs
@@ -5,7 +5,7 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class CheckSuiteEventPayload : ActivityPayload
     {
-        public string Action { get; protected set; }
-        public CheckSuite CheckSuite { get; protected set; }
+        public string Action { get; private set; }
+        public CheckSuite CheckSuite { get; private set; }
     }
 }

--- a/Octokit/Models/Response/ActivityPayloads/CommitCommentPayload.cs
+++ b/Octokit/Models/Response/ActivityPayloads/CommitCommentPayload.cs
@@ -5,6 +5,6 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class CommitCommentPayload : ActivityPayload
     {
-        public CommitComment Comment { get; protected set; }
+        public CommitComment Comment { get; private set; }
     }
 }

--- a/Octokit/Models/Response/ActivityPayloads/CreateEventPayload.cs
+++ b/Octokit/Models/Response/ActivityPayloads/CreateEventPayload.cs
@@ -6,12 +6,12 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class CreateEventPayload : ActivityPayload
     {
-        public string Ref { get; protected set; }
+        public string Ref { get; private set; }
 
-        public StringEnum<RefType> RefType { get; protected set; }
+        public StringEnum<RefType> RefType { get; private set; }
 
-        public string MasterBranch { get; protected set; }
+        public string MasterBranch { get; private set; }
 
-        public string Description { get; protected set; }
+        public string Description { get; private set; }
     }
 }

--- a/Octokit/Models/Response/ActivityPayloads/DeleteEventPayload.cs
+++ b/Octokit/Models/Response/ActivityPayloads/DeleteEventPayload.cs
@@ -6,8 +6,8 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class DeleteEventPayload : ActivityPayload
     {
-        public string Ref { get; protected set; }
+        public string Ref { get; private set; }
 
-        public StringEnum<RefType> RefType { get; protected set; }
+        public StringEnum<RefType> RefType { get; private set; }
     }
 }

--- a/Octokit/Models/Response/ActivityPayloads/ForkEventPayload.cs
+++ b/Octokit/Models/Response/ActivityPayloads/ForkEventPayload.cs
@@ -5,6 +5,6 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class ForkEventPayload : ActivityPayload
     {
-        public Repository Forkee { get; protected set; }
+        public Repository Forkee { get; private set; }
     }
 }

--- a/Octokit/Models/Response/ActivityPayloads/IssueCommentPayload.cs
+++ b/Octokit/Models/Response/ActivityPayloads/IssueCommentPayload.cs
@@ -6,8 +6,8 @@ namespace Octokit
     public class IssueCommentPayload : ActivityPayload
     {
         // should always be "created" according to github api docs
-        public string Action { get; protected set; }
-        public Issue Issue { get; protected set; }
-        public IssueComment Comment { get; protected set; }
+        public string Action { get; private set; }
+        public Issue Issue { get; private set; }
+        public IssueComment Comment { get; private set; }
     }
 }

--- a/Octokit/Models/Response/ActivityPayloads/IssueEventPayload.cs
+++ b/Octokit/Models/Response/ActivityPayloads/IssueEventPayload.cs
@@ -5,7 +5,7 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class IssueEventPayload : ActivityPayload
     {
-        public string Action { get; protected set; }
-        public Issue Issue { get; protected set; }
+        public string Action { get; private set; }
+        public Issue Issue { get; private set; }
     }
 }

--- a/Octokit/Models/Response/ActivityPayloads/PullRequestCommentPayload.cs
+++ b/Octokit/Models/Response/ActivityPayloads/PullRequestCommentPayload.cs
@@ -5,8 +5,8 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class PullRequestCommentPayload : ActivityPayload
     {
-        public string Action { get; protected set; }
-        public PullRequest PullRequest { get; protected set; }
-        public PullRequestReviewComment Comment { get; protected set; }
+        public string Action { get; private set; }
+        public PullRequest PullRequest { get; private set; }
+        public PullRequestReviewComment Comment { get; private set; }
     }
 }

--- a/Octokit/Models/Response/ActivityPayloads/PullRequestEventPayload.cs
+++ b/Octokit/Models/Response/ActivityPayloads/PullRequestEventPayload.cs
@@ -5,9 +5,9 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class PullRequestEventPayload : ActivityPayload
     {
-        public string Action { get; protected set; }
-        public int Number { get; protected set; }
+        public string Action { get; private set; }
+        public int Number { get; private set; }
 
-        public PullRequest PullRequest { get; protected set; }
+        public PullRequest PullRequest { get; private set; }
     }
 }

--- a/Octokit/Models/Response/ActivityPayloads/PullRequestReviewEventPayload.cs
+++ b/Octokit/Models/Response/ActivityPayloads/PullRequestReviewEventPayload.cs
@@ -5,8 +5,8 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class PullRequestReviewEventPayload : ActivityPayload
     {
-        public string Action { get; protected set; }
-        public PullRequest PullRequest { get; protected set; }
-        public PullRequestReview Review { get; protected set; }
+        public string Action { get; private set; }
+        public PullRequest PullRequest { get; private set; }
+        public PullRequestReview Review { get; private set; }
     }
 }

--- a/Octokit/Models/Response/ActivityPayloads/PushEventPayload.cs
+++ b/Octokit/Models/Response/ActivityPayloads/PushEventPayload.cs
@@ -6,9 +6,9 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class PushEventPayload : ActivityPayload
     {
-        public string Head { get; protected set; }
-        public string Ref { get; protected set; }
-        public int Size { get; protected set; }
-        public IReadOnlyList<Commit> Commits { get; protected set; }
+        public string Head { get; private set; }
+        public string Ref { get; private set; }
+        public int Size { get; private set; }
+        public IReadOnlyList<Commit> Commits { get; private set; }
     }
 }

--- a/Octokit/Models/Response/ActivityPayloads/PushWebhookCommit.cs
+++ b/Octokit/Models/Response/ActivityPayloads/PushWebhookCommit.cs
@@ -8,27 +8,27 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class PushWebhookCommit
     {
-        public string Id { get; protected set; }
+        public string Id { get; private set; }
 
-        public string TreeId { get; protected set; }
+        public string TreeId { get; private set; }
 
-        public bool Distinct { get; protected set; }
+        public bool Distinct { get; private set; }
 
-        public string Message { get; protected set; }
+        public string Message { get; private set; }
 
-        public DateTimeOffset Timestamp { get; protected set; }
+        public DateTimeOffset Timestamp { get; private set; }
 
-        public Uri Url { get; protected set; }
+        public Uri Url { get; private set; }
 
-        public Committer Author { get; protected set; }
+        public Committer Author { get; private set; }
 
-        public Committer Committer { get; protected set; }
+        public Committer Committer { get; private set; }
 
-        public IReadOnlyList<string> Added { get; protected set; }
+        public IReadOnlyList<string> Added { get; private set; }
 
-        public IReadOnlyList<string> Removed { get; protected set; }
+        public IReadOnlyList<string> Removed { get; private set; }
 
-        public IReadOnlyList<string> Modified { get; protected set; }
+        public IReadOnlyList<string> Modified { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/ActivityPayloads/PushWebhookCommitter.cs
+++ b/Octokit/Models/Response/ActivityPayloads/PushWebhookCommitter.cs
@@ -35,7 +35,7 @@ namespace Octokit
         /// <value>
         /// The name.
         /// </value>
-        public string Name { get; protected set; }
+        public string Name { get; private set; }
 
         /// <summary>
         /// Gets the email of the author or committer.
@@ -43,7 +43,7 @@ namespace Octokit
         /// <value>
         /// The email.
         /// </value>
-        public string Email { get; protected set; }
+        public string Email { get; private set; }
 
         /// <summary>
         /// Gets the GitHub username associated with the commit
@@ -51,7 +51,7 @@ namespace Octokit
         /// <value>
         /// The username.
         /// </value>
-        public string Username { get; protected set; }
+        public string Username { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/ActivityPayloads/PushWebhookPayload.cs
+++ b/Octokit/Models/Response/ActivityPayloads/PushWebhookPayload.cs
@@ -6,17 +6,17 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class PushWebhookPayload : ActivityPayload
     {
-        public string Head { get; protected set; }
-        public string Before { get; protected set; }
-        public string After { get; protected set; }
-        public string Ref { get; protected set; }
-        public string BaseRef { get; protected set; }
-        public bool Created { get; protected set; }
-        public bool Deleted { get; protected set; }
-        public bool Forced { get; protected set; }
-        public string Compare { get; protected set; }
-        public int Size { get; protected set; }
-        public IReadOnlyList<PushWebhookCommit> Commits { get; protected set; }
-        public PushWebhookCommit HeadCommit { get; protected set; }
+        public string Head { get; private set; }
+        public string Before { get; private set; }
+        public string After { get; private set; }
+        public string Ref { get; private set; }
+        public string BaseRef { get; private set; }
+        public bool Created { get; private set; }
+        public bool Deleted { get; private set; }
+        public bool Forced { get; private set; }
+        public string Compare { get; private set; }
+        public int Size { get; private set; }
+        public IReadOnlyList<PushWebhookCommit> Commits { get; private set; }
+        public PushWebhookCommit HeadCommit { get; private set; }
     }
 }

--- a/Octokit/Models/Response/ActivityPayloads/ReleaseEventPayload.cs
+++ b/Octokit/Models/Response/ActivityPayloads/ReleaseEventPayload.cs
@@ -5,8 +5,8 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class ReleaseEventPayload : ActivityPayload
     {
-        public string Action { get; protected set; }
+        public string Action { get; private set; }
 
-        public Release Release { get; protected set; }
+        public Release Release { get; private set; }
     }
 }

--- a/Octokit/Models/Response/ActivityPayloads/StarredEventPayload.cs
+++ b/Octokit/Models/Response/ActivityPayloads/StarredEventPayload.cs
@@ -5,6 +5,6 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class StarredEventPayload : ActivityPayload
     {
-        public string Action { get; protected set; }
+        public string Action { get; private set; }
     }
 }

--- a/Octokit/Models/Response/ActivityPayloads/StatusEventPayload.cs
+++ b/Octokit/Models/Response/ActivityPayloads/StatusEventPayload.cs
@@ -10,62 +10,62 @@ namespace Octokit
         /// <summary>
         /// The name of the repository.
         /// </summary>
-        public string Name { get; protected set; }
+        public string Name { get; private set; }
 
         /// <summary>
         /// The SHA of the reference.
         /// </summary>
-        public string Sha { get; protected set; }
+        public string Sha { get; private set; }
 
         /// <summary>
         /// The date the commit status was created.
         /// </summary>
-        public DateTimeOffset CreatedAt { get; protected set; }
+        public DateTimeOffset CreatedAt { get; private set; }
 
         /// <summary>
         /// The date the commit status was updated.
         /// </summary>
-        public DateTimeOffset UpdatedAt { get; protected set; }
+        public DateTimeOffset UpdatedAt { get; private set; }
 
         /// <summary>
         /// The state of the commit
         /// </summary>
-        public StringEnum<CommitState> State { get; protected set; }
+        public StringEnum<CommitState> State { get; private set; }
 
         /// <summary>
         /// URL associated with this status. GitHub.com displays this URL as a link to allow users to easily see the
         /// ‘source’ of the Status.
         /// </summary>
-        public string TargetUrl { get; protected set; }
+        public string TargetUrl { get; private set; }
 
         /// <summary>
         /// Short description of the status.
         /// </summary>
-        public string Description { get; protected set; }
+        public string Description { get; private set; }
 
         /// <summary>
         /// A string label to differentiate this status from the status of other systems.
         /// </summary>
-        public string Context { get; protected set; }
+        public string Context { get; private set; }
 
         /// <summary>
         /// The unique identifier of the status.
         /// </summary>
-        public long Id { get; protected set; }
+        public long Id { get; private set; }
 
         /// <summary>
         /// The relevant commit.
         /// </summary>
-        public GitHubCommit Commit { get; protected set; }
+        public GitHubCommit Commit { get; private set; }
 
         /// <summary>
         /// The organization associated with the event.
         /// </summary>
-        public Organization Organization { get; protected set; }
+        public Organization Organization { get; private set; }
 
         /// <summary>
         /// The branches involved.
         /// </summary>
-        public IReadOnlyList<Branch> Branches { get; protected set; }
+        public IReadOnlyList<Branch> Branches { get; private set; }
     }
 }

--- a/Octokit/Models/Response/ApiError.cs
+++ b/Octokit/Models/Response/ApiError.cs
@@ -29,17 +29,17 @@ namespace Octokit
         /// <summary>
         /// The error message
         /// </summary>
-        public string Message { get; protected set; }
+        public string Message { get; private set; }
 
         /// <summary>
         /// URL to the documentation for this error.
         /// </summary>
-        public string DocumentationUrl { get; protected set; }
+        public string DocumentationUrl { get; private set; }
 
         /// <summary>
         /// Additional details about the error
         /// </summary>
-        public IReadOnlyList<ApiErrorDetail> Errors { get; protected set; }
+        public IReadOnlyList<ApiErrorDetail> Errors { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/ApiErrorDetail.cs
+++ b/Octokit/Models/Response/ApiErrorDetail.cs
@@ -18,13 +18,13 @@ namespace Octokit
             Resource = resource;
         }
 
-        public string Message { get; protected set; }
+        public string Message { get; private set; }
 
-        public string Code { get; protected set; }
+        public string Code { get; private set; }
 
-        public string Field { get; protected set; }
+        public string Field { get; private set; }
 
-        public string Resource { get; protected set; }
+        public string Resource { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/Application.cs
+++ b/Octokit/Models/Response/Application.cs
@@ -20,12 +20,12 @@ namespace Octokit
         /// <summary>
         /// <see cref="Application"/> Name.
         /// </summary>
-        public string Name { get; protected set; }
+        public string Name { get; private set; }
 
         /// <summary>
         /// The Url of this <see cref="Application"/>.
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/Blob.cs
+++ b/Octokit/Models/Response/Blob.cs
@@ -21,27 +21,27 @@ namespace Octokit
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
         /// <summary>
         /// The content of the blob.
         /// </summary>
-        public string Content { get; protected set; }
+        public string Content { get; private set; }
 
         /// <summary>
         /// The encoding of the blob.
         /// </summary>
-        public StringEnum<EncodingType> Encoding { get; protected set; }
+        public StringEnum<EncodingType> Encoding { get; private set; }
 
         /// <summary>
         /// The SHA of the blob.
         /// </summary>
-        public string Sha { get; protected set; }
+        public string Sha { get; private set; }
 
         /// <summary>
         /// The size of the blob.
         /// </summary>
-        public int Size { get; protected set; }
+        public int Size { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/BlobReference.cs
+++ b/Octokit/Models/Response/BlobReference.cs
@@ -16,7 +16,7 @@ namespace Octokit
         /// <summary>
         /// The SHA of the blob.
         /// </summary>
-        public string Sha { get; protected set; }
+        public string Sha { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/Branch.cs
+++ b/Octokit/Models/Response/Branch.cs
@@ -19,17 +19,17 @@ namespace Octokit
         /// <summary>
         /// Name of this <see cref="Branch"/>.
         /// </summary>
-        public string Name { get; protected set; }
+        public string Name { get; private set; }
 
         /// <summary>
-        /// Whether this <see cref="Branch"/> is protected. 
+        /// Whether this <see cref="Branch"/> is protected.
         /// </summary>
-        public bool Protected { get; protected set; }
+        public bool Protected { get; private set; }
 
         /// <summary>
         /// The <see cref="GitReference"/> history for this <see cref="Branch"/>.
         /// </summary>
-        public GitReference Commit { get; protected set; }
+        public GitReference Commit { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/BranchProtection.cs
+++ b/Octokit/Models/Response/BranchProtection.cs
@@ -116,7 +116,7 @@ namespace Octokit
             Enabled = enabled;
         }
 
-        public bool Enabled { get; protected set; }
+        public bool Enabled { get; private set; }
 
         internal string DebuggerDisplay
         {
@@ -144,7 +144,7 @@ namespace Octokit
         /// <summary>
         /// Require branches to be up to date before merging
         /// </summary>
-        public bool Strict { get; protected set; }
+        public bool Strict { get; private set; }
 
         /// <summary>
         /// Require status checks to pass before merging
@@ -218,22 +218,22 @@ namespace Octokit
         /// <summary>
         /// Specify which users and teams can dismiss pull request reviews.
         /// </summary>
-        public BranchProtectionRequiredReviewsDismissalRestrictions DismissalRestrictions { get; protected set; }
+        public BranchProtectionRequiredReviewsDismissalRestrictions DismissalRestrictions { get; private set; }
 
         /// <summary>
         /// Dismiss approved reviews automatically when a new commit is pushed.
         /// </summary>
-        public bool DismissStaleReviews { get; protected set; }
+        public bool DismissStaleReviews { get; private set; }
 
         /// <summary>
         /// Blocks merge until code owners have reviewed.
         /// </summary>
-        public bool RequireCodeOwnerReviews { get; protected set; }
+        public bool RequireCodeOwnerReviews { get; private set; }
 
         /// <summary>
         /// Specify the number of reviewers required to approve pull requests. Use a number between 1 and 6.
         /// </summary>
-        public int RequiredApprovingReviewCount { get; protected set; }
+        public int RequiredApprovingReviewCount { get; private set; }
 
         internal string DebuggerDisplay
         {
@@ -294,7 +294,7 @@ namespace Octokit
             Enabled = enabled;
         }
 
-        public bool Enabled { get; protected set; }
+        public bool Enabled { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/CheckRun.cs
+++ b/Octokit/Models/Response/CheckRun.cs
@@ -34,77 +34,77 @@ namespace Octokit
         /// <summary>
         /// The Id of the check run
         /// </summary>
-        public long Id { get; protected set; }
+        public long Id { get; private set; }
 
         /// <summary>
         /// The SHA of the commit the check run is associated with
         /// </summary>
-        public string HeadSha { get; protected set; }
+        public string HeadSha { get; private set; }
 
         /// <summary>
         /// A reference for the run on the integrator's system
         /// </summary>
-        public string ExternalId { get; protected set; }
+        public string ExternalId { get; private set; }
 
         /// <summary>
         /// The GitHub API URL of the check run
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         /// <summary>
         /// The GitHub.com URL of the check run
         /// </summary>
-        public string HtmlUrl { get; protected set; }
+        public string HtmlUrl { get; private set; }
 
         /// <summary>
         /// The URL of the integrator's site that has the full details of the check.
         /// </summary>
-        public string DetailsUrl { get; protected set; }
+        public string DetailsUrl { get; private set; }
 
         /// <summary>
         /// The check run status
         /// </summary>
-        public StringEnum<CheckStatus> Status { get; protected set; }
+        public StringEnum<CheckStatus> Status { get; private set; }
 
         /// <summary>
         /// The final conclusion of the check
         /// </summary>
-        public StringEnum<CheckConclusion>? Conclusion { get; protected set; }
+        public StringEnum<CheckConclusion>? Conclusion { get; private set; }
 
         /// <summary>
         /// The time that the check run began
         /// </summary>
-        public DateTimeOffset StartedAt { get; protected set; }
+        public DateTimeOffset StartedAt { get; private set; }
 
         /// <summary>
         /// The time the check run completed
         /// </summary>
-        public DateTimeOffset? CompletedAt { get; protected set; }
+        public DateTimeOffset? CompletedAt { get; private set; }
 
         /// <summary>
         /// Descriptive details about the run
         /// </summary>
-        public CheckRunOutputResponse Output { get; protected set; }
+        public CheckRunOutputResponse Output { get; private set; }
 
         /// <summary>
         /// The name of the check
         /// </summary>
-        public string Name { get; protected set; }
+        public string Name { get; private set; }
 
         /// <summary>
         /// The check suite that is associated with this check run
         /// </summary>
-        public CheckSuite CheckSuite { get; protected set; }
+        public CheckSuite CheckSuite { get; private set; }
 
         /// <summary>
         /// The GitHub App that is associated with this check run
         /// </summary>
-        public GitHubApp App { get; protected set; }
+        public GitHubApp App { get; private set; }
 
         /// <summary>
         /// The pull requests that are associated with this check run
         /// </summary>
-        public IReadOnlyList<PullRequest> PullRequests { get; protected set; }
+        public IReadOnlyList<PullRequest> PullRequests { get; private set; }
 
         internal string DebuggerDisplay => string.Format(CultureInfo.InvariantCulture, "Id: {0}, HeadSha: {1}, Conclusion: {2}", Id, HeadSha, Conclusion);
     }

--- a/Octokit/Models/Response/CheckRunAnnotation.cs
+++ b/Octokit/Models/Response/CheckRunAnnotation.cs
@@ -52,63 +52,63 @@ namespace Octokit
         /// The path of the file the annotation refers to
         /// </summary>
         [Obsolete("This property is replaced with Path but may still be required on GitHub Enterprise 2.14")]
-        public string Filename { get; protected set; }
+        public string Filename { get; private set; }
 
         /// <summary>
         /// The path of the file the annotation refers to
         /// </summary>
-        public string Path { get; protected set; }
+        public string Path { get; private set; }
 
         /// <summary>
         /// The file's full blob URL
         /// </summary>
-        public string BlobHref { get; protected set; }
+        public string BlobHref { get; private set; }
 
         /// <summary>
         /// The start line of the annotation
         /// </summary>
-        public int StartLine { get; protected set; }
+        public int StartLine { get; private set; }
 
         /// <summary>
         /// The end line of the annotation
         /// </summary>
-        public int EndLine { get; protected set; }
+        public int EndLine { get; private set; }
 
         /// <summary>
         /// The start line of the annotation
         /// </summary>
-        public int? StartColumn { get; protected set; }
+        public int? StartColumn { get; private set; }
 
         /// <summary>
         /// The end line of the annotation
         /// </summary>
-        public int? EndColumn { get; protected set; }
+        public int? EndColumn { get; private set; }
 
         /// <summary>
         /// The warning level of the annotation. Can be one of notice, warning, or failure
         /// </summary>
         [Obsolete("This property is replaced with AnnotationLevel but may still be required on GitHub Enterprise 2.14")]
-        public StringEnum<CheckWarningLevel>? WarningLevel { get; protected set; }
+        public StringEnum<CheckWarningLevel>? WarningLevel { get; private set; }
 
         /// <summary>
         /// The level of the annotation. Can be one of notice, warning, or failure
         /// </summary>
-        public StringEnum<CheckAnnotationLevel>? AnnotationLevel { get; protected set; }
+        public StringEnum<CheckAnnotationLevel>? AnnotationLevel { get; private set; }
 
         /// <summary>
         /// A short description of the feedback for these lines of code
         /// </summary>
-        public string Message { get; protected set; }
+        public string Message { get; private set; }
 
         /// <summary>
         /// The title that represents the annotation
         /// </summary>
-        public string Title { get; protected set; }
+        public string Title { get; private set; }
 
         /// <summary>
         /// Details about this annotation
         /// </summary>
-        public string RawDetails { get; protected set; }
+        public string RawDetails { get; private set; }
 
 #pragma warning disable CS0618 // Type or member is obsolete
         internal string DebuggerDisplay => string.Format(CultureInfo.InvariantCulture, "Path: {0}, StartLine: {1}, WarningLevel: {2}", Path ?? Filename, StartLine, AnnotationLevel?.DebuggerDisplay ?? WarningLevel?.DebuggerDisplay);

--- a/Octokit/Models/Response/CheckRunOutputResponse.cs
+++ b/Octokit/Models/Response/CheckRunOutputResponse.cs
@@ -22,22 +22,22 @@ namespace Octokit
         /// <summary>
         /// The title of the check run
         /// </summary>
-        public string Title { get; protected set; }
+        public string Title { get; private set; }
 
         /// <summary>
         /// The summary of the check run
         /// </summary>
-        public string Summary { get; protected set; }
+        public string Summary { get; private set; }
 
         /// <summary>
         /// The details of the check run
         /// </summary>
-        public string Text { get; protected set; }
+        public string Text { get; private set; }
 
         /// <summary>
         /// The number of annotation entries for the check run (use <see cref="ICheckRunsClient.GetAllAnnotations(string, string, long)"/> to get annotation details)
         /// </summary>
-        public long AnnotationsCount { get; protected set; }
+        public long AnnotationsCount { get; private set; }
 
         internal string DebuggerDisplay => string.Format(CultureInfo.CurrentCulture, "Title: {0}", Title);
     }

--- a/Octokit/Models/Response/CheckRunRequestedAction.cs
+++ b/Octokit/Models/Response/CheckRunRequestedAction.cs
@@ -20,7 +20,7 @@ namespace Octokit
         /// <summary>
         /// The Identifier of the check run requested action.
         /// </summary>
-        public string Identifier { get; protected set; }
+        public string Identifier { get; private set; }
 
         internal string DebuggerDisplay => string.Format(CultureInfo.InvariantCulture, "Identifier: {0}", Identifier);
     }

--- a/Octokit/Models/Response/CheckRunsResponse.cs
+++ b/Octokit/Models/Response/CheckRunsResponse.cs
@@ -20,12 +20,12 @@ namespace Octokit
         /// <summary>
         /// The total number of check runs that match the request filter
         /// </summary>
-        public int TotalCount { get; protected set; }
+        public int TotalCount { get; private set; }
 
         /// <summary>
         /// The retrieved check runs
         /// </summary>
-        public IReadOnlyList<CheckRun> CheckRuns { get; protected set; }
+        public IReadOnlyList<CheckRun> CheckRuns { get; private set; }
 
         internal string DebuggerDisplay => string.Format(CultureInfo.CurrentCulture, "TotalCount: {0}, CheckRuns: {1}", TotalCount, CheckRuns.Count);
     }

--- a/Octokit/Models/Response/CheckSuite.cs
+++ b/Octokit/Models/Response/CheckSuite.cs
@@ -29,57 +29,57 @@ namespace Octokit
         /// <summary>
         /// The Id of the check suite
         /// </summary>
-        public long Id { get; protected set; }
+        public long Id { get; private set; }
 
         /// <summary>
         /// The branch the check suite is associated with
         /// </summary>
-        public string HeadBranch { get; protected set; }
+        public string HeadBranch { get; private set; }
 
         /// <summary>
         /// The SHA of the head commit in the push that created the check suite
         /// </summary>
-        public string HeadSha { get; protected set; }
+        public string HeadSha { get; private set; }
 
         /// <summary>
         /// The summarized status of the check runs included in the check suite
         /// </summary>
-        public StringEnum<CheckStatus> Status { get; protected set; }
+        public StringEnum<CheckStatus> Status { get; private set; }
 
         /// <summary>
         /// The summarized conclusion of the check runs included in the check suite
         /// </summary>
-        public StringEnum<CheckConclusion>? Conclusion { get; protected set; }
+        public StringEnum<CheckConclusion>? Conclusion { get; private set; }
 
         /// <summary>
         /// The GitHub API URL of the check suite
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         /// <summary>
         /// The hash of the commit prior to the push that created the check suite
         /// </summary>
-        public string Before { get; protected set; }
+        public string Before { get; private set; }
 
         /// <summary>
         /// The hash of the commit after the push that created the check suite (or HeadSha if no later commits exist)
         /// </summary>
-        public string After { get; protected set; }
+        public string After { get; private set; }
 
         /// <summary>
         /// The pull requests that are associated with the check suite
         /// </summary>
-        public IReadOnlyList<PullRequest> PullRequests { get; protected set; }
+        public IReadOnlyList<PullRequest> PullRequests { get; private set; }
 
         /// <summary>
         /// The GitHub App for the check suite
         /// </summary>
-        public GitHubApp App { get; protected set; }
+        public GitHubApp App { get; private set; }
 
         /// <summary>
         /// The repository for the check suite
         /// </summary>
-        public Repository Repository { get; protected set; }
+        public Repository Repository { get; private set; }
 
         internal string DebuggerDisplay => string.Format(CultureInfo.InvariantCulture, "Id: {0}, HeadBranch: {1}, HeadSha: {2}, Conclusion: {3}", Id, HeadBranch, HeadSha, Conclusion);
     }

--- a/Octokit/Models/Response/CheckSuitePreferencesResponse.cs
+++ b/Octokit/Models/Response/CheckSuitePreferencesResponse.cs
@@ -19,12 +19,12 @@ namespace Octokit
         /// <summary>
         /// The check suite preferences
         /// </summary>
-        public CheckSuitePreferences Preferences { get; protected set; }
+        public CheckSuitePreferences Preferences { get; private set; }
 
         /// <summary>
         /// The repository the check suite preferences are related to
         /// </summary>
-        public Repository Repository { get; protected set; }
+        public Repository Repository { get; private set; }
 
         internal string DebuggerDisplay => string.Format(CultureInfo.InvariantCulture, "Preferences: {0}, Repository: {1}", Preferences.DebuggerDisplay, Repository.DebuggerDisplay);
     }

--- a/Octokit/Models/Response/CheckSuitesResponse.cs
+++ b/Octokit/Models/Response/CheckSuitesResponse.cs
@@ -20,12 +20,12 @@ namespace Octokit
         /// <summary>
         /// The total number of check suites that match the request filter
         /// </summary>
-        public int TotalCount { get; protected set; }
+        public int TotalCount { get; private set; }
 
         /// <summary>
         /// The retrieved check suites
         /// </summary>
-        public IReadOnlyList<CheckSuite> CheckSuites { get; protected set; }
+        public IReadOnlyList<CheckSuite> CheckSuites { get; private set; }
 
         internal string DebuggerDisplay => string.Format(CultureInfo.CurrentCulture, "TotalCount: {0}, CheckSuites: {1}", TotalCount, CheckSuites.Count);
     }

--- a/Octokit/Models/Response/CollaboratorPermission.cs
+++ b/Octokit/Models/Response/CollaboratorPermission.cs
@@ -13,8 +13,8 @@ namespace Octokit
             User = user;
         }
 
-        public StringEnum<PermissionLevel> Permission { get; protected set; }
-        public User User { get; protected set; }
+        public StringEnum<PermissionLevel> Permission { get; private set; }
+        public User User { get; private set; }
 
         internal string DebuggerDisplay => $"User: {User.Id} Permission: {Permission}";
     }

--- a/Octokit/Models/Response/CombinedCommitStatus.cs
+++ b/Octokit/Models/Response/CombinedCommitStatus.cs
@@ -21,27 +21,27 @@ namespace Octokit
         /// <summary>
         /// The combined state of the commits.
         /// </summary>
-        public StringEnum<CommitState> State { get; protected set; }
+        public StringEnum<CommitState> State { get; private set; }
 
         /// <summary>
         /// The SHA of the reference.
         /// </summary>
-        public string Sha { get; protected set; }
+        public string Sha { get; private set; }
 
         /// <summary>
         /// The total number of statuses.
         /// </summary>
-        public int TotalCount { get; protected set; }
+        public int TotalCount { get; private set; }
 
         /// <summary>
         /// The statuses.
         /// </summary>
-        public IReadOnlyList<CommitStatus> Statuses { get; protected set; }
+        public IReadOnlyList<CommitStatus> Statuses { get; private set; }
 
         /// <summary>
         /// The repository of the reference.
         /// </summary>
-        public Repository Repository { get; protected set; }
+        public Repository Repository { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/Commit.cs
+++ b/Octokit/Models/Response/Commit.cs
@@ -24,18 +24,18 @@ namespace Octokit
             Verification = verification;
         }
 
-        public string Message { get; protected set; }
+        public string Message { get; private set; }
 
-        public Committer Author { get; protected set; }
+        public Committer Author { get; private set; }
 
-        public Committer Committer { get; protected set; }
+        public Committer Committer { get; private set; }
 
-        public GitReference Tree { get; protected set; }
+        public GitReference Tree { get; private set; }
 
-        public IReadOnlyList<GitReference> Parents { get; protected set; }
+        public IReadOnlyList<GitReference> Parents { get; private set; }
 
-        public int CommentCount { get; protected set; }
+        public int CommentCount { get; private set; }
 
-        public Verification Verification { get; protected set; }
+        public Verification Verification { get; private set; }
     }
 }

--- a/Octokit/Models/Response/CommitComment.cs
+++ b/Octokit/Models/Response/CommitComment.cs
@@ -29,67 +29,67 @@ namespace Octokit
         /// <summary>
         /// The issue comment Id.
         /// </summary>
-        public int Id { get; protected set; }
+        public int Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
         /// <summary>
         /// The URL for this repository comment.
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         /// <summary>
         /// The html URL for this repository comment.
         /// </summary>
-        public string HtmlUrl { get; protected set; }
+        public string HtmlUrl { get; private set; }
 
         /// <summary>
         /// Details about the repository comment.
         /// </summary>
-        public string Body { get; protected set; }
+        public string Body { get; private set; }
 
         /// <summary>
         /// Relative path of the file that was commented on.
         /// </summary>
-        public string Path { get; protected set; }
+        public string Path { get; private set; }
 
         /// <summary>
         /// Line index in the diff that was commented on.
         /// </summary>
-        public int? Position { get; protected set; }
+        public int? Position { get; private set; }
 
         /// <summary>
         /// The line number in the file that was commented on.
         /// </summary>
-        public int? Line { get; protected set; }
+        public int? Line { get; private set; }
 
         /// <summary>
-        /// The commit 
+        /// The commit
         /// </summary>
-        public string CommitId { get; protected set; }
+        public string CommitId { get; private set; }
 
         /// <summary>
         /// The user that created the repository comment.
         /// </summary>
-        public User User { get; protected set; }
+        public User User { get; private set; }
 
         /// <summary>
         /// The date the repository comment was created.
         /// </summary>
-        public DateTimeOffset CreatedAt { get; protected set; }
+        public DateTimeOffset CreatedAt { get; private set; }
 
         /// <summary>
         /// The date the repository comment was last updated.
         /// </summary>
-        public DateTimeOffset? UpdatedAt { get; protected set; }
+        public DateTimeOffset? UpdatedAt { get; private set; }
 
         /// <summary>
         /// The reaction summary for this comment.
         /// </summary>
-        public ReactionSummary Reactions { get; protected set; }
+        public ReactionSummary Reactions { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/CommitStatus.cs
+++ b/Octokit/Models/Response/CommitStatus.cs
@@ -27,53 +27,53 @@ namespace Octokit
         /// <summary>
         /// The date the commit status was created.
         /// </summary>
-        public DateTimeOffset CreatedAt { get; protected set; }
+        public DateTimeOffset CreatedAt { get; private set; }
 
         /// <summary>
         /// The date the commit status was updated.
         /// </summary>
-        public DateTimeOffset UpdatedAt { get; protected set; }
+        public DateTimeOffset UpdatedAt { get; private set; }
 
         /// <summary>
         /// The state of the commit
         /// </summary>
-        public StringEnum<CommitState> State { get; protected set; }
+        public StringEnum<CommitState> State { get; private set; }
 
         /// <summary>
         /// URL associated with this status. GitHub.com displays this URL as a link to allow users to easily see the
         /// ‘source’ of the Status.
         /// </summary>
-        public string TargetUrl { get; protected set; }
+        public string TargetUrl { get; private set; }
 
         /// <summary>
         /// Short description of the status.
         /// </summary>
-        public string Description { get; protected set; }
+        public string Description { get; private set; }
 
         /// <summary>
         /// A string label to differentiate this status from the status of other systems.
         /// </summary>
-        public string Context { get; protected set; }
+        public string Context { get; private set; }
 
         /// <summary>
         /// The unique identifier of the status.
         /// </summary>
-        public long Id { get; protected set; }
+        public long Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
         /// <summary>
         /// The URL of the status.
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         /// <summary>
         /// The user that created the status.
         /// </summary>
-        public User Creator { get; protected set; }
+        public User Creator { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/CompareResult.cs
+++ b/Octokit/Models/Response/CompareResult.cs
@@ -26,19 +26,19 @@ namespace Octokit
             Files = files;
         }
 
-        public string Url { get; protected set; }
-        public string HtmlUrl { get; protected set; }
-        public string PermalinkUrl { get; protected set; }
-        public string DiffUrl { get; protected set; }
-        public string PatchUrl { get; protected set; }
-        public GitHubCommit BaseCommit { get; protected set; }
-        public GitHubCommit MergeBaseCommit { get; protected set; }
-        public string Status { get; protected set; }
-        public int AheadBy { get; protected set; }
-        public int BehindBy { get; protected set; }
-        public int TotalCommits { get; protected set; }
-        public IReadOnlyList<GitHubCommit> Commits { get; protected set; }
-        public IReadOnlyList<GitHubCommitFile> Files { get; protected set; }
+        public string Url { get; private set; }
+        public string HtmlUrl { get; private set; }
+        public string PermalinkUrl { get; private set; }
+        public string DiffUrl { get; private set; }
+        public string PatchUrl { get; private set; }
+        public GitHubCommit BaseCommit { get; private set; }
+        public GitHubCommit MergeBaseCommit { get; private set; }
+        public string Status { get; private set; }
+        public int AheadBy { get; private set; }
+        public int BehindBy { get; private set; }
+        public int TotalCommits { get; private set; }
+        public IReadOnlyList<GitHubCommit> Commits { get; private set; }
+        public IReadOnlyList<GitHubCommitFile> Files { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/Contributor.cs
+++ b/Octokit/Models/Response/Contributor.cs
@@ -19,11 +19,11 @@ namespace Octokit
             Weeks = weeks;
         }
 
-        public Author Author { get; protected set; }
+        public Author Author { get; private set; }
 
-        public int Total { get; protected set; }
+        public int Total { get; private set; }
 
-        public IReadOnlyList<WeeklyHash> Weeks { get; protected set; }
+        public IReadOnlyList<WeeklyHash> Weeks { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/DeployKey.cs
+++ b/Octokit/Models/Response/DeployKey.cs
@@ -16,10 +16,10 @@ namespace Octokit
             Title = title;
         }
 
-        public int Id { get; protected set; }
-        public string Key { get; protected set; }
-        public string Url { get; protected set; }
-        public string Title { get; protected set; }
+        public int Id { get; private set; }
+        public string Key { get; private set; }
+        public string Url { get; private set; }
+        public string Title { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/Deployment.cs
+++ b/Octokit/Models/Response/Deployment.cs
@@ -33,67 +33,67 @@ namespace Octokit
         /// <summary>
         /// Id of this deployment.
         /// </summary>
-        public int Id { get; protected set; }
+        public int Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
-        public string Sha { get; protected set; }
+        public string Sha { get; private set; }
 
         /// <summary>
         /// The API URL for this deployment.
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         /// <summary>
         /// The <seealso cref="User"/> that created the deployment.
         /// </summary>
-        public User Creator { get; protected set; }
+        public User Creator { get; private set; }
 
         /// <summary>
         /// JSON payload with extra information about the deployment.
         /// </summary>
-        public IReadOnlyDictionary<string, string> Payload { get; protected set; }
+        public IReadOnlyDictionary<string, string> Payload { get; private set; }
 
         /// <summary>
         /// Date and time that the deployment was created.
         /// </summary>
-        public DateTimeOffset CreatedAt { get; protected set; }
+        public DateTimeOffset CreatedAt { get; private set; }
 
         /// <summary>
         /// Date and time that the deployment was updated.
         /// </summary>
-        public DateTimeOffset UpdatedAt { get; protected set; }
+        public DateTimeOffset UpdatedAt { get; private set; }
 
         /// <summary>
         /// A short description of the deployment.
         /// </summary>
-        public string Description { get; protected set; }
+        public string Description { get; private set; }
 
         /// <summary>
         /// The API URL for the <seealso cref="DeploymentStatus"/>es of this deployment.
         /// </summary>
-        public string StatusesUrl { get; protected set; }
+        public string StatusesUrl { get; private set; }
 
         /// <summary>
         /// Indicates if the environment is specific to a deployment and will no longer exist at some point in the future.
         /// </summary>
-        public bool TransientEnvironment { get; protected set; }
+        public bool TransientEnvironment { get; private set; }
 
         /// <summary>
         /// Indicates if the environment is one with which end users directly interact.
         /// </summary>
-        public bool ProductionEnvironment { get; protected set; }
+        public bool ProductionEnvironment { get; private set; }
 
         /// <summary>
         /// Specifies a task to execute (e.g., deploy or deploy:migrations)
         /// </summary>
-        public string Task { get; protected set; }
+        public string Task { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/DeploymentStatus.cs
+++ b/Octokit/Models/Response/DeploymentStatus.cs
@@ -30,66 +30,66 @@ namespace Octokit
         /// <summary>
         /// Id of this deployment status.
         /// </summary>
-        public int Id { get; protected set; }
+        public int Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
         /// <summary>
         /// The API URL for this deployment status.
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         /// <summary>
         /// The state of this deployment status.
         /// </summary>
-        public StringEnum<DeploymentState> State { get; protected set; }
+        public StringEnum<DeploymentState> State { get; private set; }
 
         /// <summary>
         /// The <seealso cref="User"/> that created this deployment status.
         /// </summary>
-        public User Creator { get; protected set; }
+        public User Creator { get; private set; }
 
         /// <summary>
         /// JSON payload with extra information about the deployment.
         /// </summary>
-        public IReadOnlyDictionary<string, string> Payload { get; protected set; }
+        public IReadOnlyDictionary<string, string> Payload { get; private set; }
 
         /// <summary>
         /// The target URL of this deployment status. This URL should contain
         /// output to keep the user updated while the task is running or serve
         /// as historical information for what happened in the deployment
         /// </summary>
-        public string TargetUrl { get; protected set; }
+        public string TargetUrl { get; private set; }
 
         /// <summary>
         /// The target URL  of this deployment status. This URL should contain
         /// output to keep the user updated while the task is running or serve as
         /// historical information for what happened in the deployment
         /// </summary>
-        public string LogUrl { get; protected set; }
+        public string LogUrl { get; private set; }
 
         /// <summary>
         /// The URL for accessing your environment.
         /// </summary>
-        public string EnvironmentUrl { get; protected set; }
+        public string EnvironmentUrl { get; private set; }
 
         /// <summary>
         /// The date and time that the status was created.
         /// </summary>
-        public DateTimeOffset CreatedAt { get; protected set; }
+        public DateTimeOffset CreatedAt { get; private set; }
 
         /// <summary>
         /// The date and time that the status was updated.
         /// </summary>
-        public DateTimeOffset UpdatedAt { get; protected set; }
+        public DateTimeOffset UpdatedAt { get; private set; }
 
         /// <summary>
         /// A short description of the status.
         /// </summary>
-        public string Description { get; protected set; }
+        public string Description { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/EmailAddress.cs
+++ b/Octokit/Models/Response/EmailAddress.cs
@@ -24,23 +24,23 @@ namespace Octokit
         /// <summary>
         /// The email address
         /// </summary>
-        public string Email { get; protected set; }
+        public string Email { get; private set; }
 
         /// <summary>
         /// True if the email is verified; otherwise false
         /// </summary>
-        public bool Verified { get; protected set; }
+        public bool Verified { get; private set; }
 
         /// <summary>
         /// True if this is the users primary email; otherwise false
         /// </summary>
-        public bool Primary { get; protected set; }
+        public bool Primary { get; private set; }
 
         /// <summary>
         /// "private" or "public" if the email address is the primary;
         /// otherwise null
         /// </summary>
-        public StringEnum<EmailVisibility>? Visibility { get; protected set; }
+        public StringEnum<EmailVisibility>? Visibility { get; private set; }
 
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode",
             Justification = "Used by DebuggerDisplayAttribute")]
@@ -61,13 +61,13 @@ namespace Octokit
     {
         /// <summary>
         /// Primary email address and is public
-        /// </summary>     
+        /// </summary>
         [Parameter(Value = "public")]
         Public,
 
         /// <summary>
         /// Primary email address and is private
-        /// </summary> 
+        /// </summary>
         [Parameter(Value = "private")]
         Private
     }

--- a/Octokit/Models/Response/Enterprise/MaintenanceModeActiveProcesses.cs
+++ b/Octokit/Models/Response/Enterprise/MaintenanceModeActiveProcesses.cs
@@ -14,9 +14,9 @@ namespace Octokit
             Number = number;
         }
 
-        public string Name { get; protected set; }
+        public string Name { get; private set; }
 
-        public int Number { get; protected set; }
+        public int Number { get; private set; }
 
         public override string ToString()
         {

--- a/Octokit/Models/Response/Enterprise/PreReceiveEnvironment.cs
+++ b/Octokit/Models/Response/Enterprise/PreReceiveEnvironment.cs
@@ -29,47 +29,47 @@ namespace Octokit
         /// <summary>
         /// Identifier for the pre-receive environment.
         /// </summary>
-        public long Id { get; protected set; }
+        public long Id { get; private set; }
 
         /// <summary>
         /// The name of the environment as displayed in the UI.
         /// </summary>
-        public string Name { get; protected set; }
+        public string Name { get; private set; }
 
         /// <summary>
         /// URL to the pre-receive environment.
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         /// <summary>
         /// URL to the tarball that will be downloaded and extracted.
         /// </summary>
-        public string ImageUrl { get; protected set; }
+        public string ImageUrl { get; private set; }
 
         /// <summary>
         /// UI URL to the pre-receive environment.
         /// </summary>
-        public string HtmlUrl { get; protected set; }
+        public string HtmlUrl { get; private set; }
 
         /// <summary>
         /// Whether this is the default environment that ships with GitHub Enterprise.
         /// </summary>
-        public bool DefaultEnvironment { get; protected set; }
+        public bool DefaultEnvironment { get; private set; }
 
         /// <summary>
         /// The time when the pre-receive environment was created.
         /// </summary>
-        public DateTimeOffset? CreatedAt { get; protected set; }
+        public DateTimeOffset? CreatedAt { get; private set; }
 
         /// <summary>
         /// The number of pre-receive hooks that use this environment.
         /// </summary>
-        public int HooksCount { get; protected set; }
+        public int HooksCount { get; private set; }
 
         /// <summary>
         /// This environment's download status.
         /// </summary>
-        public PreReceiveEnvironmentDownload Download { get; protected set; }
+        public PreReceiveEnvironmentDownload Download { get; private set; }
 
         /// <summary>
         /// Prepares an <see cref="UpdatePreReceiveEnvironment"/> for use when updating a pre-receive environment.

--- a/Octokit/Models/Response/Enterprise/PreReceiveEnvironmentDownload.cs
+++ b/Octokit/Models/Response/Enterprise/PreReceiveEnvironmentDownload.cs
@@ -24,22 +24,22 @@ namespace Octokit
         /// <summary>
         /// URL to the download status for a pre-receive environment.
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         /// <summary>
         /// The state of the most recent download.
         /// </summary>
-        public StringEnum<PreReceiveEnvironmentDownloadState> State { get; protected set; }
+        public StringEnum<PreReceiveEnvironmentDownloadState> State { get; private set; }
 
         /// <summary>
         /// On failure, this will have any error messages produced.
         /// </summary>
-        public string Message { get; protected set; }
+        public string Message { get; private set; }
 
         /// <summary>
         /// The time when the most recent download started.
         /// </summary>
-        public DateTimeOffset? DownloadedAt { get; protected set; }
+        public DateTimeOffset? DownloadedAt { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/Enterprise/PreReceiveHook.cs
+++ b/Octokit/Models/Response/Enterprise/PreReceiveHook.cs
@@ -26,37 +26,37 @@ namespace Octokit
         /// <summary>
         /// The identifier for the pre-receive hook.
         /// </summary>
-        public int Id { get; protected set; }
+        public int Id { get; private set; }
 
         /// <summary>
         /// The name of the hook.
         /// </summary>
-        public string Name { get; protected set; }
+        public string Name { get; private set; }
 
         /// <summary>
         /// The state of enforcement for this hook.
         /// </summary>
-        public StringEnum<PreReceiveHookEnforcement> Enforcement { get; protected set; }
+        public StringEnum<PreReceiveHookEnforcement> Enforcement { get; private set; }
 
         /// <summary>
         /// The script that the hook runs.
         /// </summary>
-        public string Script { get; protected set; }
+        public string Script { get; private set; }
 
         /// <summary>
         /// The GitHub repository where the script is kept.
         /// </summary>
-        public Repository ScriptRepository { get; protected set; }
+        public Repository ScriptRepository { get; private set; }
 
         /// <summary>
         /// The pre-receive environment where the script is executed.
         /// </summary>
-        public PreReceiveEnvironment Environment { get; protected set; }
+        public PreReceiveEnvironment Environment { get; private set; }
 
         /// <summary>
         /// Whether enforcement can be overridden at the org or repo level.
         /// </summary>
-        public bool AllowDownstreamConfiguration { get; protected set; }
+        public bool AllowDownstreamConfiguration { get; private set; }
 
         public UpdatePreReceiveHook ToUpdate()
         {

--- a/Octokit/Models/Response/EventInfo.cs
+++ b/Octokit/Models/Response/EventInfo.cs
@@ -27,47 +27,47 @@ namespace Octokit
         /// <summary>
         /// The id of the issue/pull request event.
         /// </summary>
-        public long Id { get; protected set; }
+        public long Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
         /// <summary>
         /// The URL for this event.
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         /// <summary>
         /// Always the User that generated the event.
         /// </summary>
-        public User Actor { get; protected set; }
+        public User Actor { get; private set; }
 
         /// <summary>
         /// The user that was assigned, if the event was 'Assigned'.
         /// </summary>
-        public User Assignee { get; protected set; }
+        public User Assignee { get; private set; }
 
         /// <summary>
         /// The label that was assigned, if the event was 'Labeled'
         /// </summary>
-        public Label Label { get; protected set; }
+        public Label Label { get; private set; }
 
         /// <summary>
         /// Identifies the actual type of Event that occurred.
         /// </summary>
-        public StringEnum<EventInfoState> Event { get; protected set; }
+        public StringEnum<EventInfoState> Event { get; private set; }
 
         /// <summary>
         /// The String SHA of a commit that referenced this Issue.
         /// </summary>
-        public string CommitId { get; protected set; }
+        public string CommitId { get; private set; }
 
         /// <summary>
         /// Date the event occurred for the issue/pull request.
         /// </summary>
-        public DateTimeOffset CreatedAt { get; protected set; }
+        public DateTimeOffset CreatedAt { get; private set; }
 
         internal string DebuggerDisplay
         {
@@ -111,7 +111,7 @@ namespace Octokit
         BaseRefChanged,
 
         /// <summary>
-        /// The issue was closed by the actor. When the commit_id is present, it identifies the commit that 
+        /// The issue was closed by the actor. When the commit_id is present, it identifies the commit that
         /// closed the issue using “closes / fixes #NN” syntax.
         /// </summary>
         [Parameter(Value = "closed")]
@@ -195,7 +195,7 @@ namespace Octokit
         HeadRefRestored,
 
         /// <summary>
-        /// The pull request’s branch was force pushed to. 
+        /// The pull request’s branch was force pushed to.
         /// </summary>
         [Parameter(Value = "head_ref_force_pushed")]
         HeadRefForcePushed,
@@ -256,7 +256,7 @@ namespace Octokit
         ReadyForReview,
 
         /// <summary>
-        /// The issue was referenced from a commit message. The commit_id attribute is the commit SHA1 of where 
+        /// The issue was referenced from a commit message. The commit_id attribute is the commit SHA1 of where
         /// that happened.
         /// </summary>
         [Parameter(Value = "referenced")]
@@ -309,7 +309,7 @@ namespace Octokit
         /// </summary>
         [Parameter(Value = "subscribed")]
         Subscribed,
-        
+
         /// <summary>
         /// An issue was transferred.
         /// </summary>
@@ -321,7 +321,7 @@ namespace Octokit
         /// </summary>
         [Parameter(Value = "unassigned")]
         Unassigned,
-        
+
         /// <summary>
         /// A label was removed from the issue.
         /// </summary>
@@ -339,7 +339,7 @@ namespace Octokit
         /// </summary>
         [Parameter(Value = "unmarked_as_duplicate")]
         UnmarkedAsDuplicate,
-        
+
         /// <summary>
         /// An issue was unpinned.
         /// </summary>

--- a/Octokit/Models/Response/Feed.cs
+++ b/Octokit/Models/Response/Feed.cs
@@ -26,38 +26,38 @@ namespace Octokit
         /// <summary>
         /// The GitHub global public timeline
         /// </summary>
-        public string TimelineUrl { get; protected set; }
+        public string TimelineUrl { get; private set; }
 
         /// <summary>
         /// The public timeline for any user, using URI template
         /// </summary>
-        public string UserUrl { get; protected set; }
+        public string UserUrl { get; private set; }
 
         /// <summary>
         /// The public timeline for the authenticated user
         /// </summary>
-        public string CurrentUserPublicUrl { get; protected set; }
+        public string CurrentUserPublicUrl { get; private set; }
 
         /// <summary>
         /// The private timeline for the authenticated user
         /// </summary>
-        public string CurrentUserUrl { get; protected set; }
+        public string CurrentUserUrl { get; private set; }
 
         /// <summary>
         /// The private timeline for activity created by the authenticated user
         /// </summary>
-        public string CurrentUserActorUrl { get; protected set; }
+        public string CurrentUserActorUrl { get; private set; }
 
         /// <summary>
         /// The private timeline for the authenticated user for a given organization, using URI template
         /// </summary>
-        public string CurrentUserOrganizationUrl { get; protected set; }
+        public string CurrentUserOrganizationUrl { get; private set; }
 
         /// <summary>
         /// List of feed urls including feed url and feed type, e.g. application/atom+xml
         /// </summary>
         [Parameter(Key = "_links")]
-        public FeedLinks Links { get; protected set; }
+        public FeedLinks Links { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/FeedLink.cs
+++ b/Octokit/Models/Response/FeedLink.cs
@@ -24,32 +24,32 @@ namespace Octokit
         /// <summary>
         /// The GitHub global public timeline
         /// </summary>
-        public FeedLink Timeline { get; protected set; }
+        public FeedLink Timeline { get; private set; }
 
         /// <summary>
         /// The public timeline for any user, using URI template
         /// </summary>
-        public FeedLink User { get; protected set; }
+        public FeedLink User { get; private set; }
 
         /// <summary>
         /// The public timeline for the authenticated user
         /// </summary>
-        public FeedLink CurrentUserPublic { get; protected set; }
+        public FeedLink CurrentUserPublic { get; private set; }
 
         /// <summary>
         /// The private timeline for the authenticated user
         /// </summary>
-        public FeedLink CurrentUser { get; protected set; }
+        public FeedLink CurrentUser { get; private set; }
 
         /// <summary>
         /// The private timeline for activity created by the authenticated user
         /// </summary>
-        public FeedLink CurrentUserActor { get; protected set; }
+        public FeedLink CurrentUserActor { get; private set; }
 
         /// <summary>
         /// The private timeline for the authenticated user for a given organization, using URI template
         /// </summary>
-        public FeedLink CurrentUserOrganization { get; protected set; }
+        public FeedLink CurrentUserOrganization { get; private set; }
 
         internal string DebuggerDisplay
         {
@@ -74,13 +74,13 @@ namespace Octokit
         /// <summary>
         /// Link to feed
         /// </summary>
-        public string Href { get; protected set; }
+        public string Href { get; private set; }
 
         /// <summary>
         /// Feed type, e.g. application/atom+xml
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods")]
-        public string Type { get; protected set; }
+        public string Type { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/Gist.cs
+++ b/Octokit/Models/Response/Gist.cs
@@ -33,7 +33,7 @@ namespace Octokit
         /// <summary>
         /// The API URL for this <see cref="Gist"/>.
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         /// <summary>
         /// The Id of this <see cref="Gist"/>.
@@ -41,22 +41,22 @@ namespace Octokit
         /// <remarks>
         /// Given a gist url of https://gist.github.com/UserName/1234 the Id would be '1234'.
         /// </remarks>
-        public string Id { get; protected set; }
+        public string Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
         /// <summary>
         /// A description of the <see cref="Gist"/>.
         /// </summary>
-        public string Description { get; protected set; }
+        public string Description { get; private set; }
 
         /// <summary>
         /// Indicates if the <see cref="Gist"/> is private or public.
         /// </summary>
-        public bool Public { get; protected set; }
+        public bool Public { get; private set; }
 
         /// <summary>
         /// The <see cref="User"/> who owns this <see cref="Gist"/>.
@@ -64,57 +64,57 @@ namespace Octokit
         /// <remarks>
         /// Given a gist url of https://gist.github.com/UserName/1234 the Owner would be 'UserName'.
         /// </remarks>
-        public User Owner { get; protected set; }
+        public User Owner { get; private set; }
 
         /// <summary>
         /// A <see cref="IDictionary{TKey,TValue}"/> containing all <see cref="GistFile"/>s in this <see cref="Gist"/>.
         /// </summary>
-        public IReadOnlyDictionary<string, GistFile> Files { get; protected set; }
+        public IReadOnlyDictionary<string, GistFile> Files { get; private set; }
 
         /// <summary>
         /// The number of comments on this <see cref="Gist"/>.
         /// </summary>
-        public int Comments { get; protected set; }
+        public int Comments { get; private set; }
 
         /// <summary>
         /// A url to retrieve the comments for this <see cref="Gist"/>.
         /// </summary>
-        public string CommentsUrl { get; protected set; }
+        public string CommentsUrl { get; private set; }
 
         /// <summary>
         /// URL to view the gist on gist.github.com.
         /// </summary>
-        public string HtmlUrl { get; protected set; }
+        public string HtmlUrl { get; private set; }
 
         /// <summary>
         /// The git url to pull from to retrieve the contents for this <see cref="Gist"/>.
         /// </summary>
-        public string GitPullUrl { get; protected set; }
+        public string GitPullUrl { get; private set; }
 
         /// <summary>
         /// The git url to push to when changing this <see cref="Gist"/>.
         /// </summary>
-        public string GitPushUrl { get; protected set; }
+        public string GitPushUrl { get; private set; }
 
         /// <summary>
         /// The <see cref="DateTimeOffset"/> for when this <see cref="Gist"/> was created.
         /// </summary>
-        public DateTimeOffset CreatedAt { get; protected set; }
+        public DateTimeOffset CreatedAt { get; private set; }
 
         /// <summary>
         /// The <see cref="DateTimeOffset"/> for when this <see cref="Gist"/> was last updated.
         /// </summary>
-        public DateTimeOffset UpdatedAt { get; protected set; }
+        public DateTimeOffset UpdatedAt { get; private set; }
 
         /// <summary>
         /// A <see cref="IList{T}"/> of all <see cref="GistFork"/> that exist for this <see cref="Gist"/>.
         /// </summary>
-        public IReadOnlyList<GistFork> Forks { get; protected set; }
+        public IReadOnlyList<GistFork> Forks { get; private set; }
 
         /// <summary>
         /// A <see cref="IList{T}"/> of all <see cref="GistHistory"/> containing the full history for this <see cref="Gist"/>.
         /// </summary>
-        public IReadOnlyList<GistHistory> History { get; protected set; }
+        public IReadOnlyList<GistHistory> History { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/GistChangeStatus.cs
+++ b/Octokit/Models/Response/GistChangeStatus.cs
@@ -21,17 +21,17 @@ namespace Octokit
         /// <summary>
         /// The number of deletions that occurred as part of this change.
         /// </summary>
-        public int Deletions { get; protected set; }
+        public int Deletions { get; private set; }
 
         /// <summary>
         /// The number of additions that occurred as part of this change.
         /// </summary>
-        public int Additions { get; protected set; }
+        public int Additions { get; private set; }
 
         /// <summary>
         /// The total number of changes.
         /// </summary>
-        public int Total { get; protected set; }
+        public int Total { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/GistComment.cs
+++ b/Octokit/Models/Response/GistComment.cs
@@ -23,37 +23,37 @@ namespace Octokit
         /// <summary>
         /// The gist comment id.
         /// </summary>
-        public int Id { get; protected set; }
+        public int Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
         /// <summary>
         /// The URL for this gist comment.
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         /// <summary>
         /// The body of this gist comment.
         /// </summary>t
-        public string Body { get; protected set; }
+        public string Body { get; private set; }
 
         /// <summary>
         /// The user that created this gist comment.
         /// </summary>
-        public User User { get; protected set; }
+        public User User { get; private set; }
 
         /// <summary>
         /// The date this comment was created.
         /// </summary>
-        public DateTimeOffset CreatedAt { get; protected set; }
+        public DateTimeOffset CreatedAt { get; private set; }
 
         /// <summary>
         /// The date this comment was last updated.
         /// </summary>
-        public DateTimeOffset? UpdatedAt { get; protected set; }
+        public DateTimeOffset? UpdatedAt { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/GistFile.cs
+++ b/Octokit/Models/Response/GistFile.cs
@@ -23,34 +23,34 @@ namespace Octokit
         /// <summary>
         /// The size in bytes of the file.
         /// </summary>
-        public int Size { get; protected set; }
+        public int Size { get; private set; }
 
         /// <summary>
         /// The name of the file
         /// </summary>
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
-        public string Filename { get; protected set; }
+        public string Filename { get; private set; }
 
         /// <summary>
         /// The mime type of the file
         /// </summary>
         [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods")]
-        public string Type { get; protected set; }
+        public string Type { get; private set; }
 
         /// <summary>
         /// The programming language of the file, if any.
         /// </summary>
-        public string Language { get; protected set; }
+        public string Language { get; private set; }
 
         /// <summary>
         /// The text content of the file.
         /// </summary>
-        public string Content { get; protected set; }
+        public string Content { get; private set; }
 
         /// <summary>
         /// The url to download the file.
         /// </summary>
-        public string RawUrl { get; protected set; }
+        public string RawUrl { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/GistFork.cs
+++ b/Octokit/Models/Response/GistFork.cs
@@ -20,22 +20,22 @@ namespace Octokit
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
         /// <summary>
         /// The <see cref="User"/> that created this <see cref="GistFork"/>
         /// </summary>
-        public User User { get; protected set; }
+        public User User { get; private set; }
 
         /// <summary>
         /// The API URL for this <see cref="GistFork"/>.
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         /// <summary>
         /// The <see cref="DateTimeOffset"/> for when this <see cref="Gist"/> was created.
         /// </summary>
-        public DateTimeOffset CreatedAt { get; protected set; }
+        public DateTimeOffset CreatedAt { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/GistHistory.cs
+++ b/Octokit/Models/Response/GistHistory.cs
@@ -24,27 +24,27 @@ namespace Octokit
         /// <summary>
         /// The url that can be used by the API to retrieve this version of the <see cref="Gist"/>.
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         /// <summary>
         /// A git sha representing the version.
         /// </summary>
-        public string Version { get; protected set; }
+        public string Version { get; private set; }
 
         /// <summary>
         /// The <see cref="User"/> who create this version.
         /// </summary>
-        public User User { get; protected set; }
+        public User User { get; private set; }
 
         /// <summary>
         /// A <see cref="GistHistory"/> that represents the level of change for this <see cref="GistHistory"/>.
         /// </summary>
-        public GistChangeStatus ChangeStatus { get; protected set; }
+        public GistChangeStatus ChangeStatus { get; private set; }
 
         /// <summary>
         /// The <see cref="DateTimeOffset"/> the version was created.
         /// </summary>
-        public DateTimeOffset CommittedAt { get; protected set; }
+        public DateTimeOffset CommittedAt { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/GitHubApp.cs
+++ b/Octokit/Models/Response/GitHubApp.cs
@@ -28,47 +28,47 @@ namespace Octokit
         /// <summary>
         /// The Id of the GitHub App.
         /// </summary>
-        public long Id { get; protected set; }
+        public long Id { get; private set; }
 
         /// <summary>
         /// The url-friendly version of the GitHub App name.
         /// </summary>
-        public string Slug { get; protected set; }
+        public string Slug { get; private set; }
 
         /// <summary>
         /// The Name of the GitHub App.
         /// </summary>
-        public string Name { get; protected set; }
+        public string Name { get; private set; }
 
         /// <summary>
         /// The Owner of the GitHub App.
         /// </summary>
-        public User Owner { get; protected set; }
+        public User Owner { get; private set; }
 
         /// <summary>
         /// The Description of the GitHub App.
         /// </summary>
-        public string Description { get; protected set; }
+        public string Description { get; private set; }
 
         /// <summary>
         /// The URL to the GitHub App's external website.
         /// </summary>
-        public string ExternalUrl { get; protected set; }
+        public string ExternalUrl { get; private set; }
 
         /// <summary>
         /// The URL to view the GitHub App on GitHub.
         /// </summary>
-        public string HtmlUrl { get; protected set; }
+        public string HtmlUrl { get; private set; }
 
         /// <summary>
         /// Date the GitHub App was created.
         /// </summary>
-        public DateTimeOffset CreatedAt { get; protected set; }
+        public DateTimeOffset CreatedAt { get; private set; }
 
         /// <summary>
         /// Date the GitHub App was last updated.
         /// </summary>
-        public DateTimeOffset UpdatedAt { get; protected set; }
+        public DateTimeOffset UpdatedAt { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/GitHubCommit.cs
+++ b/Octokit/Models/Response/GitHubCommit.cs
@@ -29,25 +29,25 @@ namespace Octokit
         /// address used in the commit with the email addresses registered with the GitHub account.
         /// If no account corresponds to the commit email, then this property is null.
         /// </summary>
-        public Author Author { get; protected set; }
+        public Author Author { get; private set; }
 
-        public string CommentsUrl { get; protected set; }
+        public string CommentsUrl { get; private set; }
 
-        public Commit Commit { get; protected set; }
+        public Commit Commit { get; private set; }
 
         /// <summary>
         /// Gets the GitHub account information for the commit committer. It attempts to match the email
         /// address used in the commit with the email addresses registered with the GitHub account.
         /// If no account corresponds to the commit email, then this property is null.
         /// </summary>
-        public Author Committer { get; protected set; }
+        public Author Committer { get; private set; }
 
-        public string HtmlUrl { get; protected set; }
+        public string HtmlUrl { get; private set; }
 
-        public GitHubCommitStats Stats { get; protected set; }
+        public GitHubCommitStats Stats { get; private set; }
 
-        public IReadOnlyList<GitReference> Parents { get; protected set; }
+        public IReadOnlyList<GitReference> Parents { get; private set; }
 
-        public IReadOnlyList<GitHubCommitFile> Files { get; protected set; }
+        public IReadOnlyList<GitHubCommitFile> Files { get; private set; }
     }
 }

--- a/Octokit/Models/Response/GitHubCommitFile.cs
+++ b/Octokit/Models/Response/GitHubCommitFile.cs
@@ -33,58 +33,58 @@ namespace Octokit
         /// The name of the file
         /// </summary>
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
-        public string Filename { get; protected set; }
+        public string Filename { get; private set; }
 
         /// <summary>
         /// Number of additions performed on the file.
         /// </summary>
-        public int Additions { get; protected set; }
+        public int Additions { get; private set; }
 
         /// <summary>
         /// Number of deletions performed on the file.
         /// </summary>
-        public int Deletions { get; protected set; }
+        public int Deletions { get; private set; }
 
         /// <summary>
         /// Number of changes performed on the file.
         /// </summary>
-        public int Changes { get; protected set; }
+        public int Changes { get; private set; }
 
         /// <summary>
         /// File status, like modified, added, deleted.
         /// </summary>
-        public string Status { get; protected set; }
+        public string Status { get; private set; }
 
         /// <summary>
         /// The url to the file blob.
         /// </summary>
-        public string BlobUrl { get; protected set; }
+        public string BlobUrl { get; private set; }
 
         /// <summary>
         /// The url to file contents API.
         /// </summary>
-        public string ContentsUrl { get; protected set; }
+        public string ContentsUrl { get; private set; }
 
         /// <summary>
         /// The raw url to download the file.
         /// </summary>
-        public string RawUrl { get; protected set; }
+        public string RawUrl { get; private set; }
 
         /// <summary>
         /// The SHA of the file.
         /// </summary>
-        public string Sha { get; protected set; }
+        public string Sha { get; private set; }
 
         /// <summary>
         /// The patch associated with the commit
         /// </summary>
-        public string Patch { get; protected set; }
+        public string Patch { get; private set; }
 
         /// <summary>
         /// The previous filename for a renamed file.
         /// </summary>
         [Parameter(Key = "previous_filename")]
-        public string PreviousFileName { get; protected set; }
+        public string PreviousFileName { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/GitHubCommitStats.cs
+++ b/Octokit/Models/Response/GitHubCommitStats.cs
@@ -21,17 +21,17 @@ namespace Octokit
         /// <summary>
         /// The number of additions made within the commit
         /// </summary>
-        public int Additions { get; protected set; }
+        public int Additions { get; private set; }
 
         /// <summary>
         /// The number of deletions made within the commit
         /// </summary>
-        public int Deletions { get; protected set; }
+        public int Deletions { get; private set; }
 
         /// <summary>
         /// The total number of modifications within the commit
         /// </summary>
-        public int Total { get; protected set; }
+        public int Total { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/GitIgnoreTemplate.cs
+++ b/Octokit/Models/Response/GitIgnoreTemplate.cs
@@ -19,8 +19,8 @@ namespace Octokit
         {
         }
 
-        public string Name { get; protected set; }
-        public string Source { get; protected set; }
+        public string Name { get; private set; }
+        public string Source { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/GitTag.cs
+++ b/Octokit/Models/Response/GitTag.cs
@@ -18,14 +18,14 @@ namespace Octokit
         }
 
 
-        public string Tag { get; protected set; }
+        public string Tag { get; private set; }
 
-        public string Message { get; protected set; }
+        public string Message { get; private set; }
 
-        public Committer Tagger { get; protected set; }
+        public Committer Tagger { get; private set; }
 
-        public TagObject Object { get; protected set; }
+        public TagObject Object { get; private set; }
 
-        public Verification Verification { get; protected set; }
+        public Verification Verification { get; private set; }
     }
 }

--- a/Octokit/Models/Response/GpgKey.cs
+++ b/Octokit/Models/Response/GpgKey.cs
@@ -28,19 +28,19 @@ namespace Octokit
             ExpiresAt = expiresAt;
         }
 
-        public int Id { get; protected set; }
-        public int? PrimaryKeyId { get; protected set; }
-        public string KeyId { get; protected set; }
-        public string PublicKey { get; protected set; }
-        public IReadOnlyList<EmailAddress> Emails { get; protected set; }
-        public IReadOnlyList<GpgKey> Subkeys { get; protected set; }
-        public bool CanSign { get; protected set; }
+        public int Id { get; private set; }
+        public int? PrimaryKeyId { get; private set; }
+        public string KeyId { get; private set; }
+        public string PublicKey { get; private set; }
+        public IReadOnlyList<EmailAddress> Emails { get; private set; }
+        public IReadOnlyList<GpgKey> Subkeys { get; private set; }
+        public bool CanSign { get; private set; }
         [Parameter(Key = "can_encrypt_comms")]
-        public bool CanEncryptCommunications { get; protected set; }
-        public bool CanEncryptStorage { get; protected set; }
-        public bool CanCertify { get; protected set; }
-        public DateTimeOffset CreatedAt { get; protected set; }
-        public DateTimeOffset? ExpiresAt { get; protected set; }
+        public bool CanEncryptCommunications { get; private set; }
+        public bool CanEncryptStorage { get; private set; }
+        public bool CanCertify { get; private set; }
+        public DateTimeOffset CreatedAt { get; private set; }
+        public DateTimeOffset? ExpiresAt { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/Installation.cs
+++ b/Octokit/Models/Response/Installation.cs
@@ -32,27 +32,27 @@ namespace Octokit
         /// <summary>
         /// The user who owns the Installation.
         /// </summary>
-        public User Account { get; protected set; }
+        public User Account { get; private set; }
 
         /// <summary>
         /// The URL to view the Installation on GitHub.
         /// </summary>
-        public string HtmlUrl { get; protected set; }
+        public string HtmlUrl { get; private set; }
 
         /// <summary>
         /// The Id of the associated GitHub App.
         /// </summary>
-        public long AppId { get; protected set; }
+        public long AppId { get; private set; }
 
         /// <summary>
         /// The Id of the User/Organization the Installation is installed in
         /// </summary>
-        public long TargetId { get; protected set; }
+        public long TargetId { get; private set; }
 
         /// <summary>
         /// The type of the target (User or Organization)
         /// </summary>
-        public StringEnum<AccountType> TargetType { get; protected set; }
+        public StringEnum<AccountType> TargetType { get; private set; }
 
         /// <summary>
         /// The Permissions granted to the Installation
@@ -67,12 +67,12 @@ namespace Octokit
         /// <summary>
         /// The single file the GitHub App can manage (when Permissions.SingleFile is set to read or write)
         /// </summary>
-        public string SingleFileName { get; protected set; }
+        public string SingleFileName { get; private set; }
 
         /// <summary>
         /// The choice of repositories the installation is on. Can be either "selected" or "all".
         /// </summary>
-        public StringEnum<InstallationRepositorySelection> RepositorySelection { get; protected set; }
+        public StringEnum<InstallationRepositorySelection> RepositorySelection { get; private set; }
 
         internal new string DebuggerDisplay
         {

--- a/Octokit/Models/Response/InstallationPermissions.cs
+++ b/Octokit/Models/Response/InstallationPermissions.cs
@@ -31,85 +31,85 @@ namespace Octokit
         /// Repository metadata
         /// Search repositories, list collaborators, and access repository metadata.
         /// </summary>
-        public StringEnum<InstallationPermissionLevel>? Metadata { get; protected set; }
+        public StringEnum<InstallationPermissionLevel>? Metadata { get; private set; }
 
         /// <summary>
         /// Repository administration
         /// Repository creation, deletion, settings, teams, and collaborators.
         /// </summary>
-        public StringEnum<InstallationPermissionLevel>? Administration { get; protected set; }
+        public StringEnum<InstallationPermissionLevel>? Administration { get; private set; }
 
         /// <summary>
         /// Commit statuses
         /// Commit statuses.
         /// </summary>
-        public StringEnum<InstallationPermissionLevel>? Statuses { get; protected set; }
+        public StringEnum<InstallationPermissionLevel>? Statuses { get; private set; }
 
         /// <summary>
         /// Deployments
         /// Deployments and deployment statuses.
         /// </summary>
-        public StringEnum<InstallationPermissionLevel>? Deployments { get; protected set; }
+        public StringEnum<InstallationPermissionLevel>? Deployments { get; private set; }
 
         /// <summary>
         /// Issues
         /// Issues and related comments, assignees, labels, and milestones.
         /// </summary>
-        public StringEnum<InstallationPermissionLevel>? Issues { get; protected set; }
+        public StringEnum<InstallationPermissionLevel>? Issues { get; private set; }
 
         /// <summary>
         /// Pages
         /// Retrieve Pages statuses, configuration, and builds, as well as create new builds.
         /// </summary>
-        public StringEnum<InstallationPermissionLevel>? Pages { get; protected set; }
+        public StringEnum<InstallationPermissionLevel>? Pages { get; private set; }
 
         /// <summary>
         /// Pull requests
         /// Pull requests and related comments, assignees, labels, milestones, and merges.
         /// </summary>
-        public StringEnum<InstallationPermissionLevel>? PullRequests { get; protected set; }
+        public StringEnum<InstallationPermissionLevel>? PullRequests { get; private set; }
 
         /// <summary>
         /// Repository contents
         /// Repository contents, commits, branches, downloads, releases, and merges.
         /// </summary>
-        public StringEnum<InstallationPermissionLevel>? Contents { get; protected set; }
+        public StringEnum<InstallationPermissionLevel>? Contents { get; private set; }
 
         /// <summary>
         /// Single file
         /// Manage just a single file.
         /// </summary>
-        public StringEnum<InstallationPermissionLevel>? SingleFile { get; protected set; }
+        public StringEnum<InstallationPermissionLevel>? SingleFile { get; private set; }
 
         /// <summary>
         /// Repository projects
         /// Manage repository projects, columns, and cards.
         /// </summary>
-        public StringEnum<InstallationPermissionLevel>? RepositoryProjects { get; protected set; }
+        public StringEnum<InstallationPermissionLevel>? RepositoryProjects { get; private set; }
 
         /// <summary>
         /// Checks
         /// Detailed information about CI checks
         /// </summary>
-        public StringEnum<InstallationPermissionLevel>? Checks { get; protected set; }
+        public StringEnum<InstallationPermissionLevel>? Checks { get; private set; }
 
         /// <summary>
         /// Organization members (only applicable when installed for an Organization )
         /// Organization members and teams.
         /// </summary>
-        public StringEnum<InstallationPermissionLevel>? Members { get; protected set; }
+        public StringEnum<InstallationPermissionLevel>? Members { get; private set; }
 
         /// <summary>
         /// Organization projects (only applicable when installed for an Organization )
         /// Manage organization projects, columns, and cards.
         /// </summary>
-        public StringEnum<InstallationPermissionLevel>? OrganizationProjects { get; protected set; }
+        public StringEnum<InstallationPermissionLevel>? OrganizationProjects { get; private set; }
 
         /// <summary>
         /// Team discussions (only applicable when installed for an Organization )
         /// Team discussions.
         /// </summary>
-        public StringEnum<InstallationPermissionLevel>? TeamDiscussions { get; protected set; }
+        public StringEnum<InstallationPermissionLevel>? TeamDiscussions { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/InstallationsResponse.cs
+++ b/Octokit/Models/Response/InstallationsResponse.cs
@@ -20,12 +20,12 @@ namespace Octokit
         /// <summary>
         /// The total number of check suites that match the request filter
         /// </summary>
-        public int TotalCount { get; protected set; }
+        public int TotalCount { get; private set; }
 
         /// <summary>
         /// The retrieved check suites
         /// </summary>
-        public IReadOnlyList<Installation> Installations { get; protected set; }
+        public IReadOnlyList<Installation> Installations { get; private set; }
 
         internal string DebuggerDisplay => string.Format(CultureInfo.CurrentCulture, "TotalCount: {0}, Installations: {1}", TotalCount, Installations.Count);
     }

--- a/Octokit/Models/Response/Issue.cs
+++ b/Octokit/Models/Response/Issue.cs
@@ -44,124 +44,124 @@ namespace Octokit
         /// <summary>
         /// The internal Id for this issue (not the issue number)
         /// </summary>
-        public int Id { get; protected set; }
+        public int Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
         /// <summary>
         /// The URL for this issue.
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         /// <summary>
         /// The URL for the HTML view of this issue.
         /// </summary>
-        public string HtmlUrl { get; protected set; }
+        public string HtmlUrl { get; private set; }
 
         /// <summary>
         /// The Comments URL of this issue.
         /// </summary>
-        public string CommentsUrl { get; protected set; }
+        public string CommentsUrl { get; private set; }
 
         /// <summary>
         /// The Events URL of this issue.
         /// </summary>
-        public string EventsUrl { get; protected set; }
+        public string EventsUrl { get; private set; }
 
         /// <summary>
         /// The issue number.
         /// </summary>
-        public int Number { get; protected set; }
+        public int Number { get; private set; }
 
         /// <summary>
         /// Whether the issue is open or closed.
         /// </summary>
-        public StringEnum<ItemState> State { get; protected set; }
+        public StringEnum<ItemState> State { get; private set; }
 
         /// <summary>
         /// Title of the issue
         /// </summary>
-        public string Title { get; protected set; }
+        public string Title { get; private set; }
 
         /// <summary>
         /// Details about the issue.
         /// </summary>
-        public string Body { get; protected set; }
+        public string Body { get; private set; }
 
         /// <summary>
         /// Details about the user who has closed this issue.
         /// </summary>
-        public User ClosedBy { get; protected set; }
+        public User ClosedBy { get; private set; }
 
         /// <summary>
         /// The user that created the issue.
         /// </summary>
-        public User User { get; protected set; }
+        public User User { get; private set; }
 
         /// <summary>
         /// The set of labels applied to the issue
         /// </summary>
-        public IReadOnlyList<Label> Labels { get; protected set; }
+        public IReadOnlyList<Label> Labels { get; private set; }
 
         /// <summary>
         /// The user this issue is assigned to.
         /// </summary>
-        public User Assignee { get; protected set; }
+        public User Assignee { get; private set; }
 
         /// <summary>
         ///The multiple users this issue is assigned to.
         /// </summary>
-        public IReadOnlyList<User> Assignees { get; protected set; }
+        public IReadOnlyList<User> Assignees { get; private set; }
 
         /// <summary>
         /// The milestone, if any, that this issue is assigned to.
         /// </summary>
-        public Milestone Milestone { get; protected set; }
+        public Milestone Milestone { get; private set; }
 
         /// <summary>
         /// The number of comments on the issue.
         /// </summary>
-        public int Comments { get; protected set; }
+        public int Comments { get; private set; }
 
-        public PullRequest PullRequest { get; protected set; }
+        public PullRequest PullRequest { get; private set; }
 
         /// <summary>
         /// The date the issue was closed if closed.
         /// </summary>
-        public DateTimeOffset? ClosedAt { get; protected set; }
+        public DateTimeOffset? ClosedAt { get; private set; }
 
         /// <summary>
         /// The date the issue was created.
         /// </summary>
-        public DateTimeOffset CreatedAt { get; protected set; }
+        public DateTimeOffset CreatedAt { get; private set; }
 
         /// <summary>
         /// The date the issue was last updated.
         /// </summary>
-        public DateTimeOffset? UpdatedAt { get; protected set; }
+        public DateTimeOffset? UpdatedAt { get; private set; }
 
         /// <summary>
         /// If the issue is locked or not.
         /// </summary>
-        public bool Locked { get; protected set; }
+        public bool Locked { get; private set; }
 
         /// <summary>
         /// The repository the issue comes from.
         /// </summary>
-        public Repository Repository { get; protected set; }
+        public Repository Repository { get; private set; }
 
         /// <summary>
         /// The reaction summary for this issue.
         /// </summary>
-        public ReactionSummary Reactions { get; protected set; }
+        public ReactionSummary Reactions { get; private set; }
 
         /// <summary>
         /// Reason that the conversation was locked.
         /// </summary>
-        public StringEnum<LockReason>? ActiveLockReason { get; protected set; }
+        public StringEnum<LockReason>? ActiveLockReason { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/IssueComment.cs
+++ b/Octokit/Models/Response/IssueComment.cs
@@ -27,52 +27,52 @@ namespace Octokit
         /// <summary>
         /// The issue comment Id.
         /// </summary>
-        public int Id { get; protected set; }
+        public int Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
         /// <summary>
         /// The URL for this issue comment.
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         /// <summary>
         /// The html URL for this issue comment.
         /// </summary>
-        public string HtmlUrl { get; protected set; }
+        public string HtmlUrl { get; private set; }
 
         /// <summary>
         /// Details about the issue comment.
         /// </summary>
-        public string Body { get; protected set; }
+        public string Body { get; private set; }
 
         /// <summary>
         /// The date the issue comment was created.
         /// </summary>
-        public DateTimeOffset CreatedAt { get; protected set; }
+        public DateTimeOffset CreatedAt { get; private set; }
 
         /// <summary>
         /// The date the issue comment was last updated.
         /// </summary>
-        public DateTimeOffset? UpdatedAt { get; protected set; }
+        public DateTimeOffset? UpdatedAt { get; private set; }
 
         /// <summary>
         /// The user that created the issue comment.
         /// </summary>
-        public User User { get; protected set; }
+        public User User { get; private set; }
 
         /// <summary>
         /// The comment author association with repository.
         /// </summary>
-        public StringEnum<AuthorAssociation> AuthorAssociation { get; protected set; }
+        public StringEnum<AuthorAssociation> AuthorAssociation { get; private set; }
 
         /// <summary>
         /// The reaction summary for this comment.
         /// </summary>
-        public ReactionSummary Reactions { get; protected set; }
+        public ReactionSummary Reactions { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/IssueEvent.cs
+++ b/Octokit/Models/Response/IssueEvent.cs
@@ -29,69 +29,69 @@ namespace Octokit
         /// <summary>
         /// The id of the issue/pull request event.
         /// </summary>
-        public long Id { get; protected set; }
+        public long Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
         /// <summary>
         /// The URL for this issue/pull request event.
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         /// <summary>
         /// Always the User that generated the event.
         /// </summary>
-        public User Actor { get; protected set; }
+        public User Actor { get; private set; }
 
         /// <summary>
         /// The user that was assigned, if the event was 'Assigned'.
         /// </summary>
-        public User Assignee { get; protected set; }
+        public User Assignee { get; private set; }
 
         /// <summary>
         /// The label that was assigned, if the event was 'Labeled'
         /// </summary>
-        public Label Label { get; protected set; }
+        public Label Label { get; private set; }
 
         /// <summary>
         /// Identifies the actual type of Event that occurred.
         /// </summary>
-        public StringEnum<EventInfoState> Event { get; protected set; }
+        public StringEnum<EventInfoState> Event { get; private set; }
 
         /// <summary>
         /// The String SHA of a commit that referenced this Issue.
         /// </summary>
-        public string CommitId { get; protected set; }
+        public string CommitId { get; private set; }
 
         /// <summary>
         /// The commit URL of a commit that referenced this issue.
         /// </summary>
-        public string CommitUrl { get; protected set; }
+        public string CommitUrl { get; private set; }
 
         /// <summary>
         /// Date the event occurred for the issue/pull request.
         /// </summary>
-        public DateTimeOffset CreatedAt { get; protected set; }
+        public DateTimeOffset CreatedAt { get; private set; }
 
         /// <summary>
         /// The issue associated to this event.
         /// </summary>
-        public Issue Issue { get; protected set; }
+        public Issue Issue { get; private set; }
 
         /// <summary>
         /// An object containing rename details
         /// Only provided for renamed events
         /// </summary>
-        public RenameInfo Rename { get; protected set; }
+        public RenameInfo Rename { get; private set; }
 
         /// <summary>
         /// Information about the project card that triggered the event.
         /// The project_card attribute is not returned if someone deletes the project board, or if you do not have permission to view it.
         /// </summary>
-        public IssueEventProjectCard ProjectCard { get; protected set; }
+        public IssueEventProjectCard ProjectCard { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/IssueEventProjectCard.cs
+++ b/Octokit/Models/Response/IssueEventProjectCard.cs
@@ -21,34 +21,34 @@ namespace Octokit
         /// <summary>
         /// The identification number of the project card.
         /// </summary>
-        public long Id { get; protected set; }
+        public long Id { get; private set; }
 
         /// <summary>
         /// The API URL of the project card, if the card still exists.
         /// Not included for removed_from_project events.
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         /// <summary>
         /// The identification number of the project.
         /// </summary>
-        public long ProjectId { get; protected set; }
+        public long ProjectId { get; private set; }
 
         /// <summary>
         /// The API URL of the project.
         /// </summary>
-        public string ProjectUrl { get; protected set; }
+        public string ProjectUrl { get; private set; }
 
         /// <summary>
         /// The name of the column that the card is listed in.
         /// </summary>
-        public string ColumnName { get; protected set; }
+        public string ColumnName { get; private set; }
 
         /// <summary>
         /// The name of the column that the card was listed in prior to column_name
         /// Only returned for moved_columns_in_project events.
         /// </summary>
-        public string PreviousColumnName { get; protected set; }
+        public string PreviousColumnName { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/Label.cs
+++ b/Octokit/Models/Response/Label.cs
@@ -22,37 +22,37 @@ namespace Octokit
         /// <summary>
         /// Id of the label
         /// </summary>
-        public long Id { get; protected set; }
+        public long Id { get; private set; }
 
         /// <summary>
         /// Url of the label
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         /// <summary>
         /// Name of the label
         /// </summary>
-        public string Name { get; protected set; }
+        public string Name { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
         /// <summary>
         /// Color of the label
         /// </summary>
-        public string Color { get; protected set; }
+        public string Color { get; private set; }
 
         /// <summary>
         /// Description of the label
         /// </summary>
-        public string Description { get; protected set; }
+        public string Description { get; private set; }
 
         /// <summary>
         /// Is default label
         /// </summary>
-        public bool Default { get; protected set; }
+        public bool Default { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/License.cs
+++ b/Octokit/Models/Response/License.cs
@@ -42,42 +42,42 @@ namespace Octokit
         /// <summary>
         /// Url to the license on https://choosealicense.com
         /// </summary>
-        public string HtmlUrl { get; protected set; }
+        public string HtmlUrl { get; private set; }
 
         /// <summary>
         /// A description of the license.
         /// </summary>
-        public string Description { get; protected set; }
+        public string Description { get; private set; }
 
         /// <summary>
         /// A group or family that the license belongs to such as the GPL family of licenses.
         /// </summary>
-        public string Category { get; protected set; }
+        public string Category { get; private set; }
 
         /// <summary>
         /// Notes on how to properly apply the license.
         /// </summary>
-        public string Implementation { get; protected set; }
+        public string Implementation { get; private set; }
 
         /// <summary>
         /// Set of codes for what is required under the terms of the license. For example, "include-copyright"
         /// </summary>
-        public IReadOnlyList<string> Required { get; protected set; }
+        public IReadOnlyList<string> Required { get; private set; }
 
         /// <summary>
         /// Set of codes for what is permitted under the terms of the license. For example, "commercial-use"
         /// </summary>
-        public IReadOnlyList<string> Permitted { get; protected set; }
+        public IReadOnlyList<string> Permitted { get; private set; }
 
         /// <summary>
         /// Set of codes for what is forbidden under the terms of the license. For example, "no-liability"
         /// </summary>
-        public IReadOnlyList<string> Forbidden { get; protected set; }
+        public IReadOnlyList<string> Forbidden { get; private set; }
 
         /// <summary>
         /// The text of the license
         /// </summary>
-        public string Body { get; protected set; }
+        public string Body { get; private set; }
 
         internal override string DebuggerDisplay
         {

--- a/Octokit/Models/Response/LicenseMetadata.cs
+++ b/Octokit/Models/Response/LicenseMetadata.cs
@@ -21,7 +21,7 @@ namespace Octokit
         }
 
         /// <summary>
-        /// The 
+        /// Keyword for the given license (i.e. mit, gpl, cc)
         /// </summary>
         public string Key { get; protected set; }
 

--- a/Octokit/Models/Response/Merge.cs
+++ b/Octokit/Models/Response/Merge.cs
@@ -24,12 +24,12 @@ namespace Octokit
             HtmlUrl = htmlUrl;
         }
 
-        public Author Author { get; protected set; }
-        public Author Committer { get; protected set; }
-        public Commit Commit { get; protected set; }
-        public IReadOnlyList<GitReference> Parents { get; protected set; }
-        public string CommentsUrl { get; protected set; }
-        public int CommentCount { get; protected set; }
-        public string HtmlUrl { get; protected set; }
+        public Author Author { get; private set; }
+        public Author Committer { get; private set; }
+        public Commit Commit { get; private set; }
+        public IReadOnlyList<GitReference> Parents { get; private set; }
+        public string CommentsUrl { get; private set; }
+        public int CommentCount { get; private set; }
+        public string HtmlUrl { get; private set; }
     }
 }

--- a/Octokit/Models/Response/Migration.cs
+++ b/Octokit/Models/Response/Migration.cs
@@ -53,7 +53,7 @@ namespace Octokit
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
         /// <summary>
         /// Guid of migration.

--- a/Octokit/Models/Response/Milestone.cs
+++ b/Octokit/Models/Response/Milestone.cs
@@ -36,77 +36,77 @@ namespace Octokit
         /// <summary>
         /// The URL for this milestone.
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         /// <summary>
         /// The Html page for this milestone.
         /// </summary>
-        public string HtmlUrl { get; protected set; }
+        public string HtmlUrl { get; private set; }
 
         /// <summary>
         /// The ID for this milestone.
         /// </summary>
-        public long Id { get; protected set; }
+        public long Id { get; private set; }
 
         /// <summary>
         /// The milestone number.
         /// </summary>
-        public int Number { get; protected set; }
+        public int Number { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
         /// <summary>
         /// Whether the milestone is open or closed.
         /// </summary>
-        public StringEnum<ItemState> State { get; protected set; }
+        public StringEnum<ItemState> State { get; private set; }
 
         /// <summary>
         /// Title of the milestone.
         /// </summary>
-        public string Title { get; protected set; }
+        public string Title { get; private set; }
 
         /// <summary>
         /// Optional description for the milestone.
         /// </summary>
-        public string Description { get; protected set; }
+        public string Description { get; private set; }
 
         /// <summary>
         /// The user that created this milestone.
         /// </summary>
-        public User Creator { get; protected set; }
+        public User Creator { get; private set; }
 
         /// <summary>
         /// The number of open issues in this milestone.
         /// </summary>
-        public int OpenIssues { get; protected set; }
+        public int OpenIssues { get; private set; }
 
         /// <summary>
         /// The number of closed issues in this milestone.
         /// </summary>
-        public int ClosedIssues { get; protected set; }
+        public int ClosedIssues { get; private set; }
 
         /// <summary>
         /// The date this milestone was created.
         /// </summary>
-        public DateTimeOffset CreatedAt { get; protected set; }
+        public DateTimeOffset CreatedAt { get; private set; }
 
         /// <summary>
         /// The date, if any, when this milestone is due.
         /// </summary>
-        public DateTimeOffset? DueOn { get; protected set; }
+        public DateTimeOffset? DueOn { get; private set; }
 
         /// <summary>
         /// The date, if any, when this milestone was closed.
         /// </summary>
-        public DateTimeOffset? ClosedAt { get; protected set; }
+        public DateTimeOffset? ClosedAt { get; private set; }
 
         /// <summary>
         /// The date, if any, when this milestone was updated.
         /// </summary>
-        public DateTimeOffset? UpdatedAt { get; protected set; }
+        public DateTimeOffset? UpdatedAt { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/Notification.cs
+++ b/Octokit/Models/Response/Notification.cs
@@ -20,21 +20,21 @@ namespace Octokit
             Url = url;
         }
 
-        public string Id { get; protected set; } // NB: API currently returns this as string which is Weird
+        public string Id { get; private set; } // NB: API currently returns this as string which is Weird
 
-        public Repository Repository { get; protected set; }
+        public Repository Repository { get; private set; }
 
-        public NotificationInfo Subject { get; protected set; }
+        public NotificationInfo Subject { get; private set; }
 
-        public string Reason { get; protected set; }
+        public string Reason { get; private set; }
 
-        public bool Unread { get; protected set; }
+        public bool Unread { get; private set; }
 
-        public string UpdatedAt { get; protected set; }
+        public string UpdatedAt { get; private set; }
 
-        public string LastReadAt { get; protected set; }
+        public string LastReadAt { get; private set; }
 
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/NotificationInfo.cs
+++ b/Octokit/Models/Response/NotificationInfo.cs
@@ -17,15 +17,15 @@ namespace Octokit
             Type = type;
         }
 
-        public string Title { get; protected set; }
+        public string Title { get; private set; }
 
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
-        public string LatestCommentUrl { get; protected set; }
+        public string LatestCommentUrl { get; private set; }
 
         [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods",
             Justification = "Matches the property name used by the API")]
-        public string Type { get; protected set; }
+        public string Type { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/Organization.cs
+++ b/Octokit/Models/Response/Organization.cs
@@ -28,21 +28,21 @@ namespace Octokit
         }
 
         /// <summary>
-        /// The billing address for an organization. This is only returned when updating 
+        /// The billing address for an organization. This is only returned when updating
         /// an organization.
         /// </summary>
-        public string BillingAddress { get; protected set; }
-        public string ReposUrl { get; protected set; }
-        public string EventsUrl { get; protected set; }
-        public string HooksUrl { get; protected set; }
-        public string IssuesUrl { get; protected set; }
-        public string MembersUrl { get; protected set; }
-        public string PublicMembersUrl { get; protected set; }
-        public string Description { get; protected set; }
-        public bool IsVerified { get; protected set; }
-        public bool HasOrganizationProjects { get; protected set; }
-        public bool HasRepositoryProjects { get; protected set; }
-        public DateTimeOffset UpdatedAt { get; protected set; }
+        public string BillingAddress { get; private set; }
+        public string ReposUrl { get; private set; }
+        public string EventsUrl { get; private set; }
+        public string HooksUrl { get; private set; }
+        public string IssuesUrl { get; private set; }
+        public string MembersUrl { get; private set; }
+        public string PublicMembersUrl { get; private set; }
+        public string Description { get; private set; }
+        public bool IsVerified { get; private set; }
+        public bool HasOrganizationProjects { get; private set; }
+        public bool HasRepositoryProjects { get; private set; }
+        public DateTimeOffset UpdatedAt { get; private set; }
 
 
         internal string DebuggerDisplay

--- a/Octokit/Models/Response/OrganizationMembership.cs
+++ b/Octokit/Models/Response/OrganizationMembership.cs
@@ -20,12 +20,12 @@ namespace Octokit
             User = user;
         }
 
-        public string Url { get; protected set; }
-        public StringEnum<MembershipState> State { get; protected set; }
-        public StringEnum<MembershipRole> Role { get; protected set; }
-        public string OrganizationUrl { get; protected set; }
-        public Organization Organization { get; protected set; }
-        public User User { get; protected set; }
+        public string Url { get; private set; }
+        public StringEnum<MembershipState> State { get; private set; }
+        public StringEnum<MembershipRole> Role { get; private set; }
+        public string OrganizationUrl { get; private set; }
+        public Organization Organization { get; private set; }
+        public User User { get; private set; }
 
         internal string DebuggerDisplay => $"{nameof(OrganizationMembership)}: User: {User.Login}; Organization: {Organization.Login}; State: {State}; Role: {Role}";
     }

--- a/Octokit/Models/Response/OrganizationMembershipInvitation.cs
+++ b/Octokit/Models/Response/OrganizationMembershipInvitation.cs
@@ -23,18 +23,18 @@ namespace Octokit
             Inviter = inviter;
         }
 
-        public int Id { get; protected set; }
+        public int Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
-        public string Login { get; protected set; }
-        public string Email { get; protected set; }
-        public StringEnum<OrganizationMembershipRole> Role { get; protected set; }
-        public DateTimeOffset CreatedAt { get; protected set; }
-        public User Inviter { get; protected set; }
+        public string Login { get; private set; }
+        public string Email { get; private set; }
+        public StringEnum<OrganizationMembershipRole> Role { get; private set; }
+        public DateTimeOffset CreatedAt { get; private set; }
+        public User Inviter { get; private set; }
 
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode",
             Justification = "Used by DebuggerDisplayAttribute")]

--- a/Octokit/Models/Response/Page.cs
+++ b/Octokit/Models/Response/Page.cs
@@ -60,28 +60,28 @@ namespace Octokit
         /// <summary>
         /// The pages's API URL.
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         /// <summary>
         /// Absolute URL to the rendered site.
         /// </summary>
-        public string HtmlUrl { get; protected set; }
+        public string HtmlUrl { get; private set; }
 
         /// <summary>
         /// Build status of the pages site.
         /// </summary>
-        public StringEnum<PagesBuildStatus> Status { get; protected set; }
+        public StringEnum<PagesBuildStatus> Status { get; private set; }
 
         /// <summary>
         /// CName of the pages site. Will be null if no CName was provided by the user.
         /// </summary>
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "CName")]
-        public string CName { get; protected set; }
+        public string CName { get; private set; }
 
         /// <summary>
         /// Is a custom 404 page provided.
         /// </summary>
-        public bool Custom404 { get; protected set; }
+        public bool Custom404 { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/PagesBuild.cs
+++ b/Octokit/Models/Response/PagesBuild.cs
@@ -27,29 +27,29 @@ namespace Octokit
         /// <summary>
         /// The pages's API URL.
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
         /// <summary>
         /// The status of the build.
         /// </summary>
-        public StringEnum<PagesBuildStatus> Status { get; protected set; }
+        public StringEnum<PagesBuildStatus> Status { get; private set; }
         /// <summary>
         /// Error details - if there was one.
         /// </summary>
-        public ApiError Error { get; protected set; }
+        public ApiError Error { get; private set; }
         /// <summary>
         /// The user whose commit initiated the build.
         /// </summary>
-        public User Pusher { get; protected set; }
+        public User Pusher { get; private set; }
         /// <summary>
         /// Commit SHA.
         /// </summary>
-        public Commit Commit { get; protected set; }
+        public Commit Commit { get; private set; }
         /// <summary>
         /// Duration of the build
         /// </summary>
-        public TimeSpan Duration { get; protected set; }
-        public DateTime CreatedAt { get; protected set; }
-        public DateTime UpdatedAt { get; protected set; }
+        public TimeSpan Duration { get; private set; }
+        public DateTime CreatedAt { get; private set; }
+        public DateTime UpdatedAt { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/Participation.cs
+++ b/Octokit/Models/Response/Participation.cs
@@ -26,12 +26,12 @@ namespace Octokit
         /// <summary>
         /// Returns the commit counts made each week, for the last 52 weeks
         /// </summary>
-        public IReadOnlyList<int> All { get; protected set; }
+        public IReadOnlyList<int> All { get; private set; }
 
         /// <summary>
         /// Returns the commit counts made by the owner each week, for the last 52 weeks
         /// </summary>
-        public IReadOnlyList<int> Owner { get; protected set; }
+        public IReadOnlyList<int> Owner { get; private set; }
 
         /// <summary>
         /// The total number of commits made by the owner in the last 52 weeks.

--- a/Octokit/Models/Response/Project.cs
+++ b/Octokit/Models/Response/Project.cs
@@ -28,62 +28,62 @@ namespace Octokit
         /// <summary>
         /// The URL for this projects repository.
         /// </summary>
-        public string OwnerUrl { get; protected set; }
+        public string OwnerUrl { get; private set; }
 
         /// <summary>
         /// The HTML URL for this project.
         /// </summary>
-        public string HtmlUrl { get; protected set; }
+        public string HtmlUrl { get; private set; }
 
         /// <summary>
         /// The URL for this project.
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         /// <summary>
         /// The Id for this project.
         /// </summary>
-        public int Id { get; protected set; }
+        public int Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
         /// <summary>
         /// The name for this project.
         /// </summary>
-        public string Name { get; protected set; }
+        public string Name { get; private set; }
 
         /// <summary>
         /// The body for this project.
         /// </summary>
-        public string Body { get; protected set; }
+        public string Body { get; private set; }
 
         /// <summary>
         /// The number for this project.
         /// </summary>
-        public int Number { get; protected set; }
+        public int Number { get; private set; }
 
         /// <summary>
         /// The current state of this project.
         /// </summary>
-        public StringEnum<ItemState> State { get; protected set; }
+        public StringEnum<ItemState> State { get; private set; }
 
         /// <summary>
         /// The user associated with this project.
         /// </summary>
-        public User Creator { get; protected set; }
+        public User Creator { get; private set; }
 
         /// <summary>
         /// When this project was created.
         /// </summary>
-        public DateTimeOffset CreatedAt { get; protected set; }
+        public DateTimeOffset CreatedAt { get; private set; }
 
         /// <summary>
         /// When this project was last updated.
         /// </summary>
-        public DateTimeOffset UpdatedAt { get; protected set; }
+        public DateTimeOffset UpdatedAt { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/ProjectCard.cs
+++ b/Octokit/Models/Response/ProjectCard.cs
@@ -25,47 +25,47 @@ namespace Octokit
         /// <summary>
         /// The URL for this cards column.
         /// </summary>
-        public string ColumnUrl { get; protected set; }
+        public string ColumnUrl { get; private set; }
 
         /// <summary>
         /// The URL for this cards content.
         /// </summary>
-        public string ContentUrl { get; protected set; }
+        public string ContentUrl { get; private set; }
 
         /// <summary>
         /// The Id for this card.
         /// </summary>
-        public int Id { get; protected set; }
+        public int Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
         /// <summary>
         /// The note for this card.
         /// </summary>
-        public string Note { get; protected set; }
+        public string Note { get; private set; }
 
         /// <summary>
         /// The user associated with this card.
         /// </summary>
-        public User Creator { get; protected set; }
+        public User Creator { get; private set; }
 
         /// <summary>
         /// When this card was created.
         /// </summary>
-        public DateTimeOffset CreatedAt { get; protected set; }
+        public DateTimeOffset CreatedAt { get; private set; }
 
         /// <summary>
         /// When this card was last updated.
         /// </summary>
-        public DateTimeOffset UpdatedAt { get; protected set; }
+        public DateTimeOffset UpdatedAt { get; private set; }
 
         /// <summary>
         /// Whether this card is archived.
         /// </summary>
-        public bool Archived { get; protected set; }
+        public bool Archived { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/ProjectColumn.cs
+++ b/Octokit/Models/Response/ProjectColumn.cs
@@ -22,32 +22,32 @@ namespace Octokit
         /// <summary>
         /// The Id for this column.
         /// </summary>
-        public int Id { get; protected set; }
+        public int Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
         /// <summary>
         /// The name for this column.
         /// </summary>
-        public string Name { get; protected set; }
+        public string Name { get; private set; }
 
         /// <summary>
         /// The URL for this columns project.
         /// </summary>
-        public string ProjectUrl { get; protected set; }
+        public string ProjectUrl { get; private set; }
 
         /// <summary>
         /// When this column was created.
         /// </summary>
-        public DateTimeOffset CreatedAt { get; protected set; }
+        public DateTimeOffset CreatedAt { get; private set; }
 
         /// <summary>
         /// When this column was last updated.
         /// </summary>
-        public DateTimeOffset UpdatedAt { get; protected set; }
+        public DateTimeOffset UpdatedAt { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/PublicKey.cs
+++ b/Octokit/Models/Response/PublicKey.cs
@@ -16,19 +16,19 @@ namespace Octokit
             Title = title;
         }
 
-        public int Id { get; protected set; }
+        public int Id { get; private set; }
 
-        public string Key { get; protected set; }
-
-        /// <remarks>
-        /// Only visible for the current user, or with the correct OAuth scope
-        /// </remarks>
-        public string Url { get; protected set; }
+        public string Key { get; private set; }
 
         /// <remarks>
         /// Only visible for the current user, or with the correct OAuth scope
         /// </remarks>
-        public string Title { get; protected set; }
+        public string Url { get; private set; }
+
+        /// <remarks>
+        /// Only visible for the current user, or with the correct OAuth scope
+        /// </remarks>
+        public string Title { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/PullRequest.cs
+++ b/Octokit/Models/Response/PullRequest.cs
@@ -61,117 +61,117 @@ namespace Octokit
         /// <summary>
         /// The internal Id for this pull request (not the pull request number)
         /// </summary>
-        public long Id { get; protected set; }
+        public long Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
         /// <summary>
         /// The URL for this pull request.
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         /// <summary>
         /// The URL for the pull request page.
         /// </summary>
-        public string HtmlUrl { get; protected set; }
+        public string HtmlUrl { get; private set; }
 
         /// <summary>
         /// The URL for the pull request's diff (.diff) file.
         /// </summary>
-        public string DiffUrl { get; protected set; }
+        public string DiffUrl { get; private set; }
 
         /// <summary>
         /// The URL for the pull request's patch (.patch) file.
         /// </summary>
-        public string PatchUrl { get; protected set; }
+        public string PatchUrl { get; private set; }
 
         /// <summary>
         /// The URL for the specific pull request issue.
         /// </summary>
-        public string IssueUrl { get; protected set; }
+        public string IssueUrl { get; private set; }
 
         /// <summary>
         /// The URL for the pull request statuses.
         /// </summary>
-        public string StatusesUrl { get; protected set; }
+        public string StatusesUrl { get; private set; }
 
         /// <summary>
         /// The pull request number.
         /// </summary>
-        public int Number { get; protected set; }
+        public int Number { get; private set; }
 
         /// <summary>
         /// Whether the pull request is open or closed. The default is <see cref="ItemState.Open"/>.
         /// </summary>
-        public StringEnum<ItemState> State { get; protected set; }
+        public StringEnum<ItemState> State { get; private set; }
 
         /// <summary>
         /// Title of the pull request.
         /// </summary>
-        public string Title { get; protected set; }
+        public string Title { get; private set; }
 
         /// <summary>
         /// The body (content) contained within the pull request.
         /// </summary>
-        public string Body { get; protected set; }
+        public string Body { get; private set; }
 
         /// <summary>
         /// When the pull request was created.
         /// </summary>
-        public DateTimeOffset CreatedAt { get; protected set; }
+        public DateTimeOffset CreatedAt { get; private set; }
 
         /// <summary>
         /// When the pull request was last updated.
         /// </summary>
-        public DateTimeOffset UpdatedAt { get; protected set; }
+        public DateTimeOffset UpdatedAt { get; private set; }
 
         /// <summary>
         /// When the pull request was closed.
         /// </summary>
-        public DateTimeOffset? ClosedAt { get; protected set; }
+        public DateTimeOffset? ClosedAt { get; private set; }
 
         /// <summary>
         /// When the pull request was merged.
         /// </summary>
-        public DateTimeOffset? MergedAt { get; protected set; }
+        public DateTimeOffset? MergedAt { get; private set; }
 
         /// <summary>
         /// The HEAD reference for the pull request.
         /// </summary>
-        public GitReference Head { get; protected set; }
+        public GitReference Head { get; private set; }
 
         /// <summary>
         /// The BASE reference for the pull request.
         /// </summary>
-        public GitReference Base { get; protected set; }
+        public GitReference Base { get; private set; }
 
         /// <summary>
         /// The user who created the pull request.
         /// </summary>
-        public User User { get; protected set; }
+        public User User { get; private set; }
 
         /// <summary>
         /// The user who is assigned the pull request.
         /// </summary>
-        public User Assignee { get; protected set; }
+        public User Assignee { get; private set; }
 
         /// <summary>
         ///The multiple users this pull request is assigned to.
         /// </summary>
-        public IReadOnlyList<User> Assignees { get; protected set; }
+        public IReadOnlyList<User> Assignees { get; private set; }
 
         /// <summary>
         /// The milestone, if any, that this pull request is assigned to.
         /// </summary>
-        public Milestone Milestone { get; protected set; }
+        public Milestone Milestone { get; private set; }
 
         /// <summary>
         /// Whether or not the pull request is in a draft state, and cannot be merged.
         /// </summary>
-        public bool Draft { get; protected set; }
+        public bool Draft { get; private set; }
 
         /// <summary>
         /// Whether or not the pull request has been merged.
@@ -184,17 +184,17 @@ namespace Octokit
         /// <summary>
         /// Whether or not the pull request can be merged.
         /// </summary>
-        public bool? Mergeable { get; protected set; }
+        public bool? Mergeable { get; private set; }
 
         /// <summary>
         /// Provides extra information regarding the mergeability of the pull request.
         /// </summary>
-        public StringEnum<MergeableState>? MergeableState { get; protected set; }
+        public StringEnum<MergeableState>? MergeableState { get; private set; }
 
         /// <summary>
         /// The user who merged the pull request.
         /// </summary>
-        public User MergedBy { get; protected set; }
+        public User MergedBy { get; private set; }
 
         /// <summary>
         /// The value of this field changes depending on the state of the pull request.
@@ -203,59 +203,59 @@ namespace Octokit
         /// Merged via squashing - the hash of the squashed commit added to the base branch.
         /// Merged via rebase - the hash of the commit that the base branch was updated to.
         /// </summary>
-        public string MergeCommitSha { get; protected set; }
+        public string MergeCommitSha { get; private set; }
 
         /// <summary>
         /// Total number of comments contained in the pull request.
         /// </summary>
-        public int Comments { get; protected set; }
+        public int Comments { get; private set; }
 
         /// <summary>
         /// Total number of commits contained in the pull request.
         /// </summary>
-        public int Commits { get; protected set; }
+        public int Commits { get; private set; }
 
         /// <summary>
         /// Total number of additions contained in the pull request.
         /// </summary>
-        public int Additions { get; protected set; }
+        public int Additions { get; private set; }
 
         /// <summary>
         /// Total number of deletions contained in the pull request.
         /// </summary>
-        public int Deletions { get; protected set; }
+        public int Deletions { get; private set; }
 
         /// <summary>
         /// Total number of files changed in the pull request.
         /// </summary>
-        public int ChangedFiles { get; protected set; }
+        public int ChangedFiles { get; private set; }
 
         /// <summary>
         /// If the issue is locked or not
         /// </summary>
-        public bool Locked { get; protected set; }
+        public bool Locked { get; private set; }
 
         /// <summary>
         /// Whether maintainers of the base repository can push to the HEAD branch
         /// </summary>
-        public bool? MaintainerCanModify { get; protected set; }
+        public bool? MaintainerCanModify { get; private set; }
 
         /// <summary>
         /// Users requested for review
         /// </summary>
-        public IReadOnlyList<User> RequestedReviewers { get; protected set; }
+        public IReadOnlyList<User> RequestedReviewers { get; private set; }
 
         /// <summary>
         /// Teams requested for review
         /// </summary>
-        public IReadOnlyList<Team> RequestedTeams { get; protected set; }
+        public IReadOnlyList<Team> RequestedTeams { get; private set; }
 
-        public IReadOnlyList<Label> Labels { get; protected set; }
+        public IReadOnlyList<Label> Labels { get; private set; }
 
         /// <summary>
         /// Reason that the conversation was locked
         /// </summary>
-        public StringEnum<LockReason>? ActiveLockReason { get; protected set; }
+        public StringEnum<LockReason>? ActiveLockReason { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/PullRequestCommit.cs
+++ b/Octokit/Models/Response/PullRequestCommit.cs
@@ -29,23 +29,23 @@ namespace Octokit
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
-        public User Author { get; protected set; }
+        public User Author { get; private set; }
 
-        public string CommentsUrl { get; protected set; }
+        public string CommentsUrl { get; private set; }
 
-        public Commit Commit { get; protected set; }
+        public Commit Commit { get; private set; }
 
-        public User Committer { get; protected set; }
+        public User Committer { get; private set; }
 
-        public string HtmlUrl { get; protected set; }
+        public string HtmlUrl { get; private set; }
 
-        public IReadOnlyList<GitReference> Parents { get; protected set; }
+        public IReadOnlyList<GitReference> Parents { get; private set; }
 
-        public string Sha { get; protected set; }
+        public string Sha { get; private set; }
 
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/PullRequestFile.cs
+++ b/Octokit/Models/Response/PullRequestFile.cs
@@ -24,19 +24,19 @@ namespace Octokit
             PreviousFileName = previousFileName;
         }
 
-        public string Sha { get; protected set; }
+        public string Sha { get; private set; }
         [Parameter(Key = "filename")]
-        public string FileName { get; protected set; }
-        public string Status { get; protected set; }
-        public int Additions { get; protected set; }
-        public int Deletions { get; protected set; }
-        public int Changes { get; protected set; }
-        public string BlobUrl { get; protected set; }
-        public string RawUrl { get; protected set; }
-        public string ContentsUrl { get; protected set; }
-        public string Patch { get; protected set; }
+        public string FileName { get; private set; }
+        public string Status { get; private set; }
+        public int Additions { get; private set; }
+        public int Deletions { get; private set; }
+        public int Changes { get; private set; }
+        public string BlobUrl { get; private set; }
+        public string RawUrl { get; private set; }
+        public string ContentsUrl { get; private set; }
+        public string Patch { get; private set; }
         [Parameter(Key = "previous_filename")]
-        public string PreviousFileName { get; protected set; }
+        public string PreviousFileName { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/PullRequestMerge.cs
+++ b/Octokit/Models/Response/PullRequestMerge.cs
@@ -28,17 +28,17 @@ namespace Octokit
         /// <summary>
         /// The sha reference of the commit.
         /// </summary>
-        public string Sha { get; protected set; }
+        public string Sha { get; private set; }
 
         /// <summary>
         /// True if merged successfully, otherwise false.
         /// </summary>
-        public bool Merged { get; protected set; }
+        public bool Merged { get; private set; }
 
         /// <summary>
         /// The message that will be used for the merge commit.
         /// </summary>
-        public string Message { get; protected set; }
+        public string Message { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/PullRequestReview.cs
+++ b/Octokit/Models/Response/PullRequestReview.cs
@@ -32,52 +32,52 @@ namespace Octokit
         /// <summary>
         /// The review Id.
         /// </summary>
-        public long Id { get; protected set; }
+        public long Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
         /// <summary>
         /// The state of the review
         /// </summary>
-        public StringEnum<PullRequestReviewState> State { get; protected set; }
+        public StringEnum<PullRequestReviewState> State { get; private set; }
 
         /// <summary>
         /// The commit Id the review is associated with.
         /// </summary>
-        public string CommitId { get; protected set; }
+        public string CommitId { get; private set; }
 
         /// <summary>
         /// The user that created the review.
         /// </summary>
-        public User User { get; protected set; }
+        public User User { get; private set; }
 
         /// <summary>
         /// The text of the review.
         /// </summary>
-        public string Body { get; protected set; }
+        public string Body { get; private set; }
 
         /// <summary>
         /// The URL for this review on Github.com
         /// </summary>
-        public string HtmlUrl { get; protected set; }
+        public string HtmlUrl { get; private set; }
 
         /// <summary>
         /// The URL for the pull request via the API.
         /// </summary>
-        public string PullRequestUrl { get; protected set; }
+        public string PullRequestUrl { get; private set; }
 
         /// <summary>
         /// The comment author association with repository.
         /// </summary>
-        public StringEnum<AuthorAssociation> AuthorAssociation { get; protected set; }
+        public StringEnum<AuthorAssociation> AuthorAssociation { get; private set; }
 
         /// <summary>
         /// The time the review was submitted
         /// </summary>
-        public DateTimeOffset SubmittedAt { get; protected set; }
+        public DateTimeOffset SubmittedAt { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/PullRequestReviewComment.cs
+++ b/Octokit/Models/Response/PullRequestReviewComment.cs
@@ -41,97 +41,97 @@ namespace Octokit
         /// <summary>
         /// URL of the comment via the API.
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         /// <summary>
         /// The comment Id.
         /// </summary>
-        public int Id { get; protected set; }
+        public int Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
         /// <summary>
         /// The diff hunk the comment is about.
         /// </summary>
-        public string DiffHunk { get; protected set; }
+        public string DiffHunk { get; private set; }
 
         /// <summary>
         /// The relative path of the file the comment is about.
         /// </summary>
-        public string Path { get; protected set; }
+        public string Path { get; private set; }
 
         /// <summary>
         /// The line index in the diff.
         /// </summary>
-        public int? Position { get; protected set; }
+        public int? Position { get; private set; }
 
         /// <summary>
         /// The comment original position.
         /// </summary>
-        public int? OriginalPosition { get; protected set; }
+        public int? OriginalPosition { get; private set; }
 
         /// <summary>
         /// The commit Id the comment is associated with.
         /// </summary>
-        public string CommitId { get; protected set; }
+        public string CommitId { get; private set; }
 
         /// <summary>
         /// The original commit Id the comment is associated with.
         /// </summary>
-        public string OriginalCommitId { get; protected set; }
+        public string OriginalCommitId { get; private set; }
 
         /// <summary>
         /// The user that created the comment.
         /// </summary>
-        public User User { get; protected set; }
+        public User User { get; private set; }
 
         /// <summary>
         /// The text of the comment.
         /// </summary>
-        public string Body { get; protected set; }
+        public string Body { get; private set; }
 
         /// <summary>
         /// The date the comment was created.
         /// </summary>
-        public DateTimeOffset CreatedAt { get; protected set; }
+        public DateTimeOffset CreatedAt { get; private set; }
 
         /// <summary>
         /// The date the comment was last updated.
         /// </summary>
-        public DateTimeOffset UpdatedAt { get; protected set; }
+        public DateTimeOffset UpdatedAt { get; private set; }
 
         /// <summary>
         /// The URL for this comment on Github.com
         /// </summary>
-        public string HtmlUrl { get; protected set; }
+        public string HtmlUrl { get; private set; }
 
         /// <summary>
         /// The URL for the pull request via the API.
         /// </summary>
-        public string PullRequestUrl { get; protected set; }
+        public string PullRequestUrl { get; private set; }
 
         /// <summary>
         /// The reaction summary for this comment.
         /// </summary>
-        public ReactionSummary Reactions { get; protected set; }
+        public ReactionSummary Reactions { get; private set; }
 
         /// <summary>
         /// The Id of the comment this comment replys to.
         /// </summary>
-        public int? InReplyToId { get; protected set; }
+        public int? InReplyToId { get; private set; }
 
         /// <summary>
         /// The Id of the pull request this comment belongs to.
         /// </summary>
-        public int? PullRequestReviewId { get; protected set; }
+        public int? PullRequestReviewId { get; private set; }
 
         /// <summary>
         /// The comment author association with repository.
         /// </summary>
-        public StringEnum<AuthorAssociation> AuthorAssociation { get; protected set; }
+        public StringEnum<AuthorAssociation> AuthorAssociation { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/Reaction.cs
+++ b/Octokit/Models/Response/Reaction.cs
@@ -47,23 +47,23 @@ namespace Octokit
         /// <summary>
         /// The Id for this reaction.
         /// </summary>
-        public int Id { get; protected set; }
+        public int Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
         /// <summary>
         /// Information about the user.
         /// </summary>
-        public User User { get; protected set; }
+        public User User { get; private set; }
 
         /// <summary>
         /// The reaction type for this commit comment.
         /// </summary>
         [Parameter(Key = "content")]
-        public StringEnum<ReactionType> Content { get; protected set; }
+        public StringEnum<ReactionType> Content { get; private set; }
 
         internal string DebuggerDisplay
         {
@@ -74,4 +74,3 @@ namespace Octokit
         }
     }
 }
-

--- a/Octokit/Models/Response/ReactionSummary.cs
+++ b/Octokit/Models/Response/ReactionSummary.cs
@@ -21,16 +21,16 @@ namespace Octokit
             Url = url;
         }
 
-        public int TotalCount { get; protected set; }
+        public int TotalCount { get; private set; }
         [Parameter(Key = "+1")]
-        public int Plus1 { get; protected set; }
+        public int Plus1 { get; private set; }
         [Parameter(Key = "-1")]
-        public int Minus1 { get; protected set; }
-        public int Laugh { get; protected set; }
-        public int Confused { get; protected set; }
-        public int Heart { get; protected set; }
-        public int Hooray { get; protected set; }
-        public string Url { get; protected set; }
+        public int Minus1 { get; private set; }
+        public int Laugh { get; private set; }
+        public int Confused { get; private set; }
+        public int Heart { get; private set; }
+        public int Hooray { get; private set; }
+        public string Url { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/ReadmeResponse.cs
+++ b/Octokit/Models/Response/ReadmeResponse.cs
@@ -13,10 +13,10 @@ namespace Octokit
             Encoding = encoding;
         }
 
-        public string Content { get; protected set; }
-        public string Name { get; protected set; }
-        public string HtmlUrl { get; protected set; }
-        public string Url { get; protected set; }
-        public string Encoding { get; protected set; }
+        public string Content { get; private set; }
+        public string Name { get; private set; }
+        public string HtmlUrl { get; private set; }
+        public string Url { get; private set; }
+        public string Encoding { get; private set; }
     }
 }

--- a/Octokit/Models/Response/Reference.cs
+++ b/Octokit/Models/Response/Reference.cs
@@ -16,16 +16,16 @@ namespace Octokit
             Object = @object;
         }
 
-        public string Ref { get; protected set; }
+        public string Ref { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
-        public TagObject Object { get; protected set; }
+        public TagObject Object { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/Release.cs
+++ b/Octokit/Models/Response/Release.cs
@@ -39,44 +39,44 @@ namespace Octokit
             UploadUrl = uploadUrl;
         }
 
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
-        public string HtmlUrl { get; protected set; }
+        public string HtmlUrl { get; private set; }
 
-        public string AssetsUrl { get; protected set; }
+        public string AssetsUrl { get; private set; }
 
-        public string UploadUrl { get; protected set; }
+        public string UploadUrl { get; private set; }
 
-        public int Id { get; protected set; }
+        public int Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
-        public string TagName { get; protected set; }
+        public string TagName { get; private set; }
 
-        public string TargetCommitish { get; protected set; }
+        public string TargetCommitish { get; private set; }
 
-        public string Name { get; protected set; }
+        public string Name { get; private set; }
 
-        public string Body { get; protected set; }
+        public string Body { get; private set; }
 
-        public bool Draft { get; protected set; }
+        public bool Draft { get; private set; }
 
-        public bool Prerelease { get; protected set; }
+        public bool Prerelease { get; private set; }
 
-        public DateTimeOffset CreatedAt { get; protected set; }
+        public DateTimeOffset CreatedAt { get; private set; }
 
-        public DateTimeOffset? PublishedAt { get; protected set; }
+        public DateTimeOffset? PublishedAt { get; private set; }
 
-        public Author Author { get; protected set; }
+        public Author Author { get; private set; }
 
-        public string TarballUrl { get; protected set; }
+        public string TarballUrl { get; private set; }
 
-        public string ZipballUrl { get; protected set; }
+        public string ZipballUrl { get; private set; }
 
-        public IReadOnlyList<ReleaseAsset> Assets { get; protected set; }
+        public IReadOnlyList<ReleaseAsset> Assets { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/ReleaseAsset.cs
+++ b/Octokit/Models/Response/ReleaseAsset.cs
@@ -26,34 +26,34 @@ namespace Octokit
             Uploader = uploader;
         }
 
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
-        public int Id { get; protected set; }
+        public int Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
-        public string Name { get; protected set; }
+        public string Name { get; private set; }
 
-        public string Label { get; protected set; }
+        public string Label { get; private set; }
 
-        public string State { get; protected set; }
+        public string State { get; private set; }
 
-        public string ContentType { get; protected set; }
+        public string ContentType { get; private set; }
 
-        public int Size { get; protected set; }
+        public int Size { get; private set; }
 
-        public int DownloadCount { get; protected set; }
+        public int DownloadCount { get; private set; }
 
-        public DateTimeOffset CreatedAt { get; protected set; }
+        public DateTimeOffset CreatedAt { get; private set; }
 
-        public DateTimeOffset UpdatedAt { get; protected set; }
+        public DateTimeOffset UpdatedAt { get; private set; }
 
-        public string BrowserDownloadUrl { get; protected set; }
+        public string BrowserDownloadUrl { get; private set; }
 
-        public Author Uploader { get; protected set; }
+        public Author Uploader { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/RenameInfo.cs
+++ b/Octokit/Models/Response/RenameInfo.cs
@@ -14,8 +14,8 @@ namespace Octokit
             To = to;
         }
 
-        public string From { get; protected set; }
-        public string To { get; protected set; }
+        public string From { get; private set; }
+        public string To { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/RepositoriesResponse.cs
+++ b/Octokit/Models/Response/RepositoriesResponse.cs
@@ -20,12 +20,12 @@ namespace Octokit
         /// <summary>
         /// The total number of check suites that match the request filter
         /// </summary>
-        public int TotalCount { get; protected set; }
+        public int TotalCount { get; private set; }
 
         /// <summary>
         /// The retrieved check suites
         /// </summary>
-        public IReadOnlyList<Repository> Repositories { get; protected set; }
+        public IReadOnlyList<Repository> Repositories { get; private set; }
 
         internal string DebuggerDisplay => string.Format(CultureInfo.CurrentCulture, "TotalCount: {0}, Repositories: {1}", TotalCount, Repositories.Count);
     }

--- a/Octokit/Models/Response/Repository.cs
+++ b/Octokit/Models/Response/Repository.cs
@@ -67,97 +67,97 @@ namespace Octokit
             AllowAutoMerge = allowAutoMerge;
         }
 
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
-        public string HtmlUrl { get; protected set; }
+        public string HtmlUrl { get; private set; }
 
-        public string CloneUrl { get; protected set; }
+        public string CloneUrl { get; private set; }
 
-        public string GitUrl { get; protected set; }
+        public string GitUrl { get; private set; }
 
-        public string SshUrl { get; protected set; }
+        public string SshUrl { get; private set; }
 
-        public string SvnUrl { get; protected set; }
+        public string SvnUrl { get; private set; }
 
-        public string MirrorUrl { get; protected set; }
+        public string MirrorUrl { get; private set; }
 
-        public long Id { get; protected set; }
+        public long Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
-        public User Owner { get; protected set; }
+        public User Owner { get; private set; }
 
-        public string Name { get; protected set; }
+        public string Name { get; private set; }
 
-        public string FullName { get; protected set; }
+        public string FullName { get; private set; }
 
-        public bool IsTemplate { get; protected set; }
+        public bool IsTemplate { get; private set; }
 
-        public string Description { get; protected set; }
+        public string Description { get; private set; }
 
-        public string Homepage { get; protected set; }
+        public string Homepage { get; private set; }
 
-        public string Language { get; protected set; }
+        public string Language { get; private set; }
 
-        public bool Private { get; protected set; }
+        public bool Private { get; private set; }
 
-        public bool Fork { get; protected set; }
+        public bool Fork { get; private set; }
 
-        public int ForksCount { get; protected set; }
+        public int ForksCount { get; private set; }
 
-        public int StargazersCount { get; protected set; }
+        public int StargazersCount { get; private set; }
 
         [Obsolete("WatchersCount returns the same data as StargazersCount. You are likely looking to use SubscribersCount. Update your code to use SubscribersCount, as this field will stop containing data in the future")]
-        public int WatchersCount { get; protected set; }
+        public int WatchersCount { get; private set; }
 
-        public string DefaultBranch { get; protected set; }
+        public string DefaultBranch { get; private set; }
 
-        public int OpenIssuesCount { get; protected set; }
+        public int OpenIssuesCount { get; private set; }
 
-        public DateTimeOffset? PushedAt { get; protected set; }
+        public DateTimeOffset? PushedAt { get; private set; }
 
-        public DateTimeOffset CreatedAt { get; protected set; }
+        public DateTimeOffset CreatedAt { get; private set; }
 
-        public DateTimeOffset UpdatedAt { get; protected set; }
+        public DateTimeOffset UpdatedAt { get; private set; }
 
-        public RepositoryPermissions Permissions { get; protected set; }
+        public RepositoryPermissions Permissions { get; private set; }
 
-        public Repository Parent { get; protected set; }
+        public Repository Parent { get; private set; }
 
-        public Repository Source { get; protected set; }
+        public Repository Source { get; private set; }
 
-        public LicenseMetadata License { get; protected set; }
+        public LicenseMetadata License { get; private set; }
 
-        public bool HasIssues { get; protected set; }
+        public bool HasIssues { get; private set; }
 
-        public bool HasWiki { get; protected set; }
+        public bool HasWiki { get; private set; }
 
-        public bool HasDownloads { get; protected set; }
+        public bool HasDownloads { get; private set; }
 
-        public bool? AllowRebaseMerge { get; protected set; }
+        public bool? AllowRebaseMerge { get; private set; }
 
-        public bool? AllowSquashMerge { get; protected set; }
+        public bool? AllowSquashMerge { get; private set; }
 
-        public bool? AllowMergeCommit { get; protected set; }
+        public bool? AllowMergeCommit { get; private set; }
 
-        public bool HasPages { get; protected set; }
+        public bool HasPages { get; private set; }
 
-        public int SubscribersCount { get; protected set; }
+        public int SubscribersCount { get; private set; }
 
-        public long Size { get; protected set; }
+        public long Size { get; private set; }
 
-        public bool Archived { get; protected set; }
+        public bool Archived { get; private set; }
 
-        public IReadOnlyList<string> Topics { get; protected set; }
+        public IReadOnlyList<string> Topics { get; private set; }
 
-        public bool? DeleteBranchOnMerge { get; protected set; }
+        public bool? DeleteBranchOnMerge { get; private set; }
 
-        public RepositoryVisibility? Visibility { get; protected set; }
+        public RepositoryVisibility? Visibility { get; private set; }
 
-        public bool? AllowAutoMerge { get; protected set; }
+        public bool? AllowAutoMerge { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/RepositoryContent.cs
+++ b/Octokit/Models/Response/RepositoryContent.cs
@@ -24,7 +24,7 @@ namespace Octokit
         /// <summary>
         /// The encoding of the content if this is a file. Typically "base64". Otherwise it's null.
         /// </summary>
-        public string Encoding { get; protected set; }
+        public string Encoding { get; private set; }
 
         /// <summary>
         /// The Base64 encoded content if this is a file. Otherwise it's null.
@@ -48,11 +48,11 @@ namespace Octokit
         /// <summary>
         /// Path to the target file in the repository if this is a symlink. Otherwise it's null.
         /// </summary>
-        public string Target { get; protected set; }
+        public string Target { get; private set; }
 
         /// <summary>
         /// The location of the submodule repository if this is a submodule. Otherwise it's null.
         /// </summary>
-        public string SubmoduleGitUrl { get; protected set; }
+        public string SubmoduleGitUrl { get; private set; }
     }
 }

--- a/Octokit/Models/Response/RepositoryContentChangeSet.cs
+++ b/Octokit/Models/Response/RepositoryContentChangeSet.cs
@@ -21,12 +21,12 @@ namespace Octokit
         /// <summary>
         /// The content of the response.
         /// </summary>
-        public RepositoryContentInfo Content { get; protected set; }
+        public RepositoryContentInfo Content { get; private set; }
 
         /// <summary>
         /// The commit information for the content change.
         /// </summary>
-        public Commit Commit { get; protected set; }
+        public Commit Commit { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/RepositoryContentLicense.cs
+++ b/Octokit/Models/Response/RepositoryContentLicense.cs
@@ -21,7 +21,7 @@ namespace Octokit
         /// <summary>
         /// License information
         /// </summary>
-        public LicenseMetadata License { get; protected set; }
+        public LicenseMetadata License { get; private set; }
 
         internal new string DebuggerDisplay
         {

--- a/Octokit/Models/Response/RepositoryContributor.cs
+++ b/Octokit/Models/Response/RepositoryContributor.cs
@@ -16,6 +16,6 @@ namespace Octokit
             Contributions = contributions;
         }
 
-        public int Contributions { get; protected set; }
+        public int Contributions { get; private set; }
     }
 }

--- a/Octokit/Models/Response/RepositoryInvitation.cs
+++ b/Octokit/Models/Response/RepositoryInvitation.cs
@@ -35,26 +35,26 @@ namespace Octokit
             HtmlUrl = htmlUrl;
         }
 
-        public int Id { get; protected set; }
+        public int Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
-        public Repository Repository { get; protected set; }
+        public Repository Repository { get; private set; }
 
-        public User Invitee { get; protected set; }
+        public User Invitee { get; private set; }
 
-        public User Inviter { get; protected set; }
+        public User Inviter { get; private set; }
 
-        public StringEnum<InvitationPermissionType> Permissions { get; protected set; }
+        public StringEnum<InvitationPermissionType> Permissions { get; private set; }
 
-        public DateTimeOffset CreatedAt { get; protected set; }
+        public DateTimeOffset CreatedAt { get; private set; }
 
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
-        public string HtmlUrl { get; protected set; }
+        public string HtmlUrl { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/RepositoryLanguage.cs
+++ b/Octokit/Models/Response/RepositoryLanguage.cs
@@ -15,9 +15,9 @@ namespace Octokit
             NumberOfBytes = numberOfBytes;
         }
 
-        public string Name { get; protected set; }
+        public string Name { get; private set; }
 
-        public long NumberOfBytes { get; protected set; }
+        public long NumberOfBytes { get; private set; }
 
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal string DebuggerDisplay

--- a/Octokit/Models/Response/RepositoryStar.cs
+++ b/Octokit/Models/Response/RepositoryStar.cs
@@ -21,12 +21,12 @@ namespace Octokit
         /// <summary>
         /// The date the star was created.
         /// </summary>
-        public DateTimeOffset StarredAt { get; protected set; }
+        public DateTimeOffset StarredAt { get; private set; }
 
         /// <summary>
         /// The repository associated with the star.
         /// </summary>
-        public Repository Repo { get; protected set; }
+        public Repository Repo { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/RepositoryTag.cs
+++ b/Octokit/Models/Response/RepositoryTag.cs
@@ -21,20 +21,20 @@ namespace Octokit
             TarballUrl = tarballUrl;
         }
 
-        public string Name { get; protected set; }
+        public string Name { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
-        public GitReference Commit { get; protected set; }
+        public GitReference Commit { get; private set; }
 
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Zipball")]
-        public string ZipballUrl { get; protected set; }
+        public string ZipballUrl { get; private set; }
 
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Tarball")]
-        public string TarballUrl { get; protected set; }
+        public string TarballUrl { get; private set; }
 
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal string DebuggerDisplay

--- a/Octokit/Models/Response/RepositoryTopics.cs
+++ b/Octokit/Models/Response/RepositoryTopics.cs
@@ -18,7 +18,7 @@ namespace Octokit
             Names = new ReadOnlyCollection<string>(initialItems);
         }
 
-        public IReadOnlyList<string> Names { get; protected set; }
+        public IReadOnlyList<string> Names { get; private set; }
 
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal string DebuggerDisplay

--- a/Octokit/Models/Response/RepositoryTrafficClone.cs
+++ b/Octokit/Models/Response/RepositoryTrafficClone.cs
@@ -20,12 +20,12 @@ namespace Octokit
             Clones = clones;
         }
 
-        public int Count { get; protected set; }
+        public int Count { get; private set; }
 
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", Justification = "It's a property from the api.")]
-        public int Uniques { get; protected set; }
+        public int Uniques { get; private set; }
 
-        public IReadOnlyList<RepositoryTrafficClone> Clones { get; protected set; }
+        public IReadOnlyList<RepositoryTrafficClone> Clones { get; private set; }
 
         internal string DebuggerDisplay
         {
@@ -46,12 +46,12 @@ namespace Octokit
             Uniques = uniques;
         }
 
-        public DateTimeOffset Timestamp { get; protected set; }
+        public DateTimeOffset Timestamp { get; private set; }
 
-        public int Count { get; protected set; }
+        public int Count { get; private set; }
 
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", Justification = "It's a property from the api.")]
-        public int Uniques { get; protected set; }
+        public int Uniques { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/RepositoryTrafficPath.cs
+++ b/Octokit/Models/Response/RepositoryTrafficPath.cs
@@ -18,14 +18,14 @@ namespace Octokit
             Uniques = uniques;
         }
 
-        public string Path { get; protected set; }
+        public string Path { get; private set; }
 
-        public string Title { get; protected set; }
+        public string Title { get; private set; }
 
-        public int Count { get; protected set; }
+        public int Count { get; private set; }
 
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", Justification = "It's a property from the api.")]
-        public int Uniques { get; protected set; }
+        public int Uniques { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/RepositoryTrafficReferrer.cs
+++ b/Octokit/Models/Response/RepositoryTrafficReferrer.cs
@@ -17,12 +17,12 @@ namespace Octokit
             Uniques = uniques;
         }
 
-        public string Referrer { get; protected set; }
+        public string Referrer { get; private set; }
 
-        public int Count { get; protected set; }
+        public int Count { get; private set; }
 
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", Justification = "It's a property from the api.")]
-        public int Uniques { get; protected set; }
+        public int Uniques { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/RepositoryTrafficView.cs
+++ b/Octokit/Models/Response/RepositoryTrafficView.cs
@@ -19,12 +19,12 @@ namespace Octokit
             Views = views;
         }
 
-        public int Count { get; protected set; }
+        public int Count { get; private set; }
 
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", Justification = "It's a property from the api.")]
-        public int Uniques { get; protected set; }
+        public int Uniques { get; private set; }
 
-        public IReadOnlyList<RepositoryTrafficView> Views { get; protected set; }
+        public IReadOnlyList<RepositoryTrafficView> Views { get; private set; }
 
         internal string DebuggerDisplay
         {
@@ -45,12 +45,12 @@ namespace Octokit
             Uniques = uniques;
         }
 
-        public DateTimeOffset Timestamp { get; protected set; }
+        public DateTimeOffset Timestamp { get; private set; }
 
-        public int Count { get; protected set; }
+        public int Count { get; private set; }
 
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", Justification = "It's a property from the api.")]
-        public int Uniques { get; protected set; }
+        public int Uniques { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/RequestedReviews.cs
+++ b/Octokit/Models/Response/RequestedReviews.cs
@@ -22,8 +22,8 @@ namespace Octokit
             Users = users;
             Teams = teams;
         }
-        public IReadOnlyList<User> Users { get; protected set; }
-        public IReadOnlyList<Team> Teams { get; protected set; }
+        public IReadOnlyList<User> Users { get; private set; }
+        public IReadOnlyList<Team> Teams { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/SearchCode.cs
+++ b/Octokit/Models/Response/SearchCode.cs
@@ -22,37 +22,37 @@ namespace Octokit
         /// <summary>
         /// file name
         /// </summary>
-        public string Name { get; protected set; }
+        public string Name { get; private set; }
 
         /// <summary>
         /// path to file
         /// </summary>
-        public string Path { get; protected set; }
+        public string Path { get; private set; }
 
         /// <summary>
         /// Sha for file
         /// </summary>
-        public string Sha { get; protected set; }
+        public string Sha { get; private set; }
 
         /// <summary>
         /// api-url to file
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         /// <summary>
         /// git-url to file
         /// </summary>
-        public string GitUrl { get; protected set; }
+        public string GitUrl { get; private set; }
 
         /// <summary>
         /// html-url to file
         /// </summary>
-        public string HtmlUrl { get; protected set; }
+        public string HtmlUrl { get; private set; }
 
         /// <summary>
         /// Repo where this file belongs to
         /// </summary>
-        public Repository Repository { get; protected set; }
+        public Repository Repository { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/SourceInfo.cs
+++ b/Octokit/Models/Response/SourceInfo.cs
@@ -16,10 +16,10 @@ namespace Octokit
             Url = url;
         }
 
-        public User Actor { get; protected set; }
-        public int Id { get; protected set; }
-        public Issue Issue { get; protected set; }
-        public string Url { get; protected set; }
+        public User Actor { get; private set; }
+        public int Id { get; private set; }
+        public Issue Issue { get; private set; }
+        public string Url { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/Subscription.cs
+++ b/Octokit/Models/Response/Subscription.cs
@@ -22,32 +22,32 @@ namespace Octokit
         /// <summary>
         /// Determines if notifications should be received from this repository.
         /// </summary>
-        public bool Subscribed { get; protected set; }
+        public bool Subscribed { get; private set; }
 
         /// <summary>
         /// Determines if all notifications should be blocked from this repository.
         /// </summary>
-        public bool Ignored { get; protected set; }
+        public bool Ignored { get; private set; }
 
         /// <summary>
         /// Url of the label
         /// </summary>
-        public string Reason { get; protected set; }
+        public string Reason { get; private set; }
 
         /// <summary>
         /// The <see cref="DateTimeOffset"/> for when this <see cref="Subscription"/> was created.
         /// </summary>
-        public DateTimeOffset CreatedAt { get; protected set; }
+        public DateTimeOffset CreatedAt { get; private set; }
 
         /// <summary>
         /// The API URL for this <see cref="Subscription"/>.
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         /// <summary>
         /// The API URL for this <see cref="Repository"/>.
         /// </summary>
-        public string RepositoryUrl { get; protected set; }
+        public string RepositoryUrl { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/TagObject.cs
+++ b/Octokit/Models/Response/TagObject.cs
@@ -17,7 +17,7 @@ namespace Octokit
 
         [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods",
             Justification = "Name defined by web api and required for deserialization")]
-        public StringEnum<TaggedType> Type { get; protected set; }
+        public StringEnum<TaggedType> Type { get; private set; }
     }
 
     /// <summary>

--- a/Octokit/Models/Response/Team.cs
+++ b/Octokit/Models/Response/Team.cs
@@ -33,73 +33,73 @@ namespace Octokit
         /// <summary>
         /// url for this team
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         /// <summary>
         /// The HTML URL for this team.
         /// </summary>
-        public string HtmlUrl { get; protected set; }
+        public string HtmlUrl { get; private set; }
 
         /// <summary>
         /// team id
         /// </summary>
-        public int Id { get; protected set; }
+        public int Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
         /// <summary>
         /// team slug
         /// </summary>
-        public string Slug { get; protected set; }
+        public string Slug { get; private set; }
 
         /// <summary>
         /// team name
         /// </summary>
-        public string Name { get; protected set; }
+        public string Name { get; private set; }
 
         /// <summary>
         /// team description
         /// </summary>
-        public string Description { get; protected set; }
+        public string Description { get; private set; }
 
         /// <summary>
         /// team privacy
         /// </summary>
-        public StringEnum<TeamPrivacy> Privacy { get; protected set; }
+        public StringEnum<TeamPrivacy> Privacy { get; private set; }
 
         /// <summary>
         /// permission attached to this team
         /// </summary>
-        public StringEnum<PermissionLevel> Permission { get; protected set; }
+        public StringEnum<PermissionLevel> Permission { get; private set; }
 
         /// <summary>
         /// how many members in this team
         /// </summary>
-        public int MembersCount { get; protected set; }
+        public int MembersCount { get; private set; }
 
         /// <summary>
         /// how many repo this team has access to
         /// </summary>
-        public int ReposCount { get; protected set; }
+        public int ReposCount { get; private set; }
 
         /// <summary>
         /// who this team belongs to
         /// </summary>
-        public Organization Organization { get; protected set; }
+        public Organization Organization { get; private set; }
 
         /// <summary>
         /// The parent team
         /// </summary>
-        public Team Parent { get; protected set; }
+        public Team Parent { get; private set; }
 
         /// <summary>
         /// LDAP Binding (GitHub Enterprise only)
         /// </summary>
         [Parameter(Key = "ldap_dn")]
-        public string LdapDistinguishedName { get; protected set; }
+        public string LdapDistinguishedName { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/TeamMembershipDetails.cs
+++ b/Octokit/Models/Response/TeamMembershipDetails.cs
@@ -15,9 +15,9 @@ namespace Octokit
             State = state;
         }
 
-        public StringEnum<TeamRole> Role { get; protected set; }
+        public StringEnum<TeamRole> Role { get; private set; }
 
-        public StringEnum<MembershipState> State { get; protected set; }
+        public StringEnum<MembershipState> State { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/ThreadSubscription.cs
+++ b/Octokit/Models/Response/ThreadSubscription.cs
@@ -22,32 +22,32 @@ namespace Octokit
         /// <summary>
         /// Determines if notifications should be received from this repository.
         /// </summary>
-        public bool Subscribed { get; protected set; }
+        public bool Subscribed { get; private set; }
 
         /// <summary>
         /// Determines if all notifications should be blocked from this repository.
         /// </summary>
-        public bool Ignored { get; protected set; }
+        public bool Ignored { get; private set; }
 
         /// <summary>
         /// Url of the label
         /// </summary>
-        public string Reason { get; protected set; }
+        public string Reason { get; private set; }
 
         /// <summary>
         /// The <see cref="DateTimeOffset"/> for when this <see cref="Subscription"/> was created.
         /// </summary>
-        public DateTimeOffset CreatedAt { get; protected set; }
+        public DateTimeOffset CreatedAt { get; private set; }
 
         /// <summary>
         /// The API URL for this <see cref="Subscription"/>.
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         /// <summary>
         /// The API URL for this thread.
         /// </summary>
-        public string ThreadUrl { get; protected set; }
+        public string ThreadUrl { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/TimelineEventInfo.cs
+++ b/Octokit/Models/Response/TimelineEventInfo.cs
@@ -26,39 +26,39 @@ namespace Octokit
             ProjectCard = projectCard;
         }
 
-        public long Id { get; protected set; }
+        public long Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id
         /// </summary>
-        public string NodeId { get; protected set; }
+        public string NodeId { get; private set; }
 
-        public string Url { get; protected set; }
-        public User Actor { get; protected set; }
-        public string CommitId { get; protected set; }
-        public StringEnum<EventInfoState> Event { get; protected set; }
-        public DateTimeOffset CreatedAt { get; protected set; }
-        public Label Label { get; protected set; }
-        public User Assignee { get; protected set; }
-        public Milestone Milestone { get; protected set; }
+        public string Url { get; private set; }
+        public User Actor { get; private set; }
+        public string CommitId { get; private set; }
+        public StringEnum<EventInfoState> Event { get; private set; }
+        public DateTimeOffset CreatedAt { get; private set; }
+        public Label Label { get; private set; }
+        public User Assignee { get; private set; }
+        public Milestone Milestone { get; private set; }
 
         /// <summary>
         /// The source of reference from another issue
         /// Only provided for cross-referenced events
         /// </summary>
-        public SourceInfo Source { get; protected set; }
+        public SourceInfo Source { get; private set; }
 
         /// <summary>
         /// An object containing rename details
         /// Only provided for renamed events
         /// </summary>
-        public RenameInfo Rename { get; protected set; }
+        public RenameInfo Rename { get; private set; }
 
         /// <summary>
         /// The name of the column that the card was listed in prior to column_name.
         /// Only returned for moved_columns_in_project events
         /// </summary>
-        public IssueEventProjectCard ProjectCard { get; protected set; }
+        public IssueEventProjectCard ProjectCard { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/TreeItem.cs
+++ b/Octokit/Models/Response/TreeItem.cs
@@ -23,33 +23,33 @@ namespace Octokit
         /// <summary>
         /// The path for this Tree Item.
         /// </summary>
-        public string Path { get; protected set; }
+        public string Path { get; private set; }
 
         /// <summary>
         /// The mode of this Tree Item.
         /// </summary>
-        public string Mode { get; protected set; }
+        public string Mode { get; private set; }
 
         /// <summary>
         /// The type of this Tree Item.
         /// </summary>
         [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods")]
-        public StringEnum<TreeType> Type { get; protected set; }
+        public StringEnum<TreeType> Type { get; private set; }
 
         /// <summary>
         /// The size of this Tree Item.
         /// </summary>
-        public int Size { get; protected set; }
+        public int Size { get; private set; }
 
         /// <summary>
         /// The SHA of this Tree Item.
         /// </summary>
-        public string Sha { get; protected set; }
+        public string Sha { get; private set; }
 
         /// <summary>
         /// The URL of this Tree Item.
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/TreeResponse.cs
+++ b/Octokit/Models/Response/TreeResponse.cs
@@ -20,22 +20,22 @@ namespace Octokit
         /// <summary>
         /// The SHA for this Tree response.
         /// </summary>
-        public string Sha { get; protected set; }
+        public string Sha { get; private set; }
 
         /// <summary>
         /// The URL for this Tree response.
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         /// <summary>
         /// The list of Tree Items for this Tree response.
         /// </summary>
-        public IReadOnlyList<TreeItem> Tree { get; protected set; }
+        public IReadOnlyList<TreeItem> Tree { get; private set; }
 
         /// <summary>
         /// Whether the response was truncated due to GitHub API limits.
         /// </summary>
-        public bool Truncated { get; protected set; }
+        public bool Truncated { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/User.cs
+++ b/Octokit/Models/Response/User.cs
@@ -24,17 +24,17 @@ namespace Octokit
             UpdatedAt = updatedAt;
         }
 
-        public RepositoryPermissions Permissions { get; protected set; }
+        public RepositoryPermissions Permissions { get; private set; }
 
         /// <summary>
         /// Whether or not the user is an administrator of the site
         /// </summary>
-        public bool SiteAdmin { get; protected set; }
+        public bool SiteAdmin { get; private set; }
 
         /// <summary>
         /// When the user was suspended, if at all (GitHub Enterprise)
         /// </summary>
-        public DateTimeOffset? SuspendedAt { get; protected set; }
+        public DateTimeOffset? SuspendedAt { get; private set; }
 
         /// <summary>
         /// Whether or not the user is currently suspended
@@ -45,12 +45,12 @@ namespace Octokit
         /// LDAP Binding (GitHub Enterprise only)
         /// </summary>
         [Parameter(Key = "ldap_dn")]
-        public string LdapDistinguishedName { get; protected set; }
+        public string LdapDistinguishedName { get; private set; }
 
         /// <summary>
         /// Date the user account was updated.
         /// </summary>
-        public DateTimeOffset UpdatedAt { get; protected set; }
+        public DateTimeOffset UpdatedAt { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/UserRenameResponse.cs
+++ b/Octokit/Models/Response/UserRenameResponse.cs
@@ -20,12 +20,12 @@ namespace Octokit
         /// <summary>
         /// Message indicating if the Rename request was queued
         /// </summary>
-        public string Message { get; protected set; }
+        public string Message { get; private set; }
 
         /// <summary>
         /// Url to the user that will be renamed
         /// </summary>
-        public string Url { get; protected set; }
+        public string Url { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/UserStar.cs
+++ b/Octokit/Models/Response/UserStar.cs
@@ -21,12 +21,12 @@ namespace Octokit
         /// <summary>
         /// The date the star was created.
         /// </summary>
-        public DateTimeOffset StarredAt { get; protected set; }
+        public DateTimeOffset StarredAt { get; private set; }
 
         /// <summary>
         /// The user associated with the star.
         /// </summary>
-        public User User { get; protected set; }
+        public User User { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/Verification.cs
+++ b/Octokit/Models/Response/Verification.cs
@@ -23,23 +23,23 @@ namespace Octokit
         /// <summary>
         /// Does GitHub consider the signature in this commit to be verified?
         /// </summary>
-        public bool Verified { get; protected set; }
+        public bool Verified { get; private set; }
 
         /// <summary>
         /// The reason for verified value.
         /// </summary>
         [Parameter(Key = "reason")]
-        public StringEnum<VerificationReason> Reason { get; protected set; }
+        public StringEnum<VerificationReason> Reason { get; private set; }
 
         /// <summary>
         /// The signature that was extracted from the commit.
         /// </summary>
-        public string Signature { get; protected set; }
+        public string Signature { get; private set; }
 
         /// <summary>
         /// The value that was signed.
         /// </summary>
-        public string Payload { get; protected set; }
+        public string Payload { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/WeeklyCommitActivity.cs
+++ b/Octokit/Models/Response/WeeklyCommitActivity.cs
@@ -24,17 +24,17 @@ namespace Octokit
         /// <summary>
         /// The days array is a group of commits per day, starting on Sunday.
         /// </summary>
-        public IReadOnlyList<int> Days { get; protected set; }
+        public IReadOnlyList<int> Days { get; private set; }
 
         /// <summary>
         /// Totally number of commits made this week.
         /// </summary>
-        public int Total { get; protected set; }
+        public int Total { get; private set; }
 
         /// <summary>
         /// The week of commits
         /// </summary>
-        public long Week { get; protected set; }
+        public long Week { get; private set; }
 
         public DateTimeOffset WeekTimestamp => DateTimeOffset.FromUnixTimeSeconds(Week);
 

--- a/Octokit/Models/Response/WeeklyHash.cs
+++ b/Octokit/Models/Response/WeeklyHash.cs
@@ -23,16 +23,16 @@ namespace Octokit
         }
 
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "W")]
-        public long W { get; protected set; }
+        public long W { get; private set; }
 
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "A")]
-        public int A { get; protected set; }
+        public int A { get; private set; }
 
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "D")]
-        public int D { get; protected set; }
+        public int D { get; private set; }
 
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "C")]
-        public int C { get; protected set; }
+        public int C { get; private set; }
 
         public DateTimeOffset Week
         {


### PR DESCRIPTION
From the [issue](https://github.com/octokit/octokit.net/issues/2472):

> As we start making our way toward generating models based on the OpenAPI definitions from the GitHub REST API we need to do some pre-work to help us know what the result of the generated code might look like. This begins with standardization, establishing patterns, and approaches to building our models.

> One area where we need to do this is with our [response models](https://github.com/octokit/octokit.net/tree/main/Octokit/Models/Response). Given that most of them have constructors now we should be able to move to a standardized way of writing these models.

Notes about the changes in this PR:
- The existing serialization and hydration tests cover this changeset
- Common and request models will be modified in a separate PR if needed
- Some object's properties could not be changed due to inheritance (listed below)

The following models remain unchanged due to inheritance constraints (where the `protected` accessor is required).  We can evaluate these relationships either prior or post generation (depending on of we approach the generation byte for byte or if it's a complete rewrite):
- Account
- Author
- Authorization
- CommitContent
- GitReference
- InstallationId
- LicenseMetadata
- SerchResults