### PR TITLE
Remove `/en` slug in docs.github.com links (and stop VSCode from formatting on save)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,20 +48,20 @@ jobs:
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
-        
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+
+        # Details on CodeQL's query packs refer to : https://docs.github.com/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
-        
+
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+    # 📚 See https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
+    #   If the Autobuild fails above, remove it and uncomment the following three lines.
     #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
     # - run: |

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "editor.formatOnSave": false,
   "files.exclude": {
     "**/bin": true,
     "**/obj": true,

--- a/Octokit.Reactive/Clients/Enterprise/IObservableEnterpriseClient.cs
+++ b/Octokit.Reactive/Clients/Enterprise/IObservableEnterpriseClient.cs
@@ -68,7 +68,7 @@
         /// A client for GitHub's Enterprise Pre-receive Hooks API
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#pre-receive-hooks">Enterprise Pre-receive Hooks API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#pre-receive-hooks">Enterprise Pre-receive Hooks API documentation</a> for more information.
         ///</remarks>
         IObservableEnterprisePreReceiveHooksClient PreReceiveHook { get; }
     }

--- a/Octokit.Reactive/Clients/Enterprise/IObservableEnterprisePreReceiveHooksClient.cs
+++ b/Octokit.Reactive/Clients/Enterprise/IObservableEnterprisePreReceiveHooksClient.cs
@@ -7,7 +7,7 @@ namespace Octokit.Reactive
     /// A client for GitHub's Enterprise Pre-receive Hooks API
     /// </summary>
     /// <remarks>
-    /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#pre-receive-hooks">Enterprise Pre-receive Hooks API documentation</a> for more information.
+    /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#pre-receive-hooks">Enterprise Pre-receive Hooks API documentation</a> for more information.
     ///</remarks>
     public interface IObservableEnterprisePreReceiveHooksClient
     {
@@ -15,7 +15,7 @@ namespace Octokit.Reactive
         /// Gets all <see cref="PreReceiveHook"/>s.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#list-pre-receive-hooks">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#list-pre-receive-hooks">API documentation</a> for more information.
         /// </remarks>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         IObservable<PreReceiveHook> GetAll();
@@ -24,7 +24,7 @@ namespace Octokit.Reactive
         /// Gets all <see cref="PreReceiveHook"/>s.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#list-pre-receive-hooks">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#list-pre-receive-hooks">API documentation</a> for more information.
         /// </remarks>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
@@ -34,7 +34,7 @@ namespace Octokit.Reactive
         /// Gets a single <see cref="PreReceiveHook"/>.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#get-a-pre-receive-hook">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#get-a-pre-receive-hook">API documentation</a> for more information.
         /// </remarks>
         /// <param name="hookId">The id of the pre-receive hook</param>
         /// <exception cref="NotFoundException">Thrown when the specified <paramref name="hookId"/> does not exist.</exception>
@@ -45,7 +45,7 @@ namespace Octokit.Reactive
         /// Creates a new <see cref="PreReceiveHook"/>.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#create-a-pre-receive-hook">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#create-a-pre-receive-hook">API documentation</a> for more information.
         /// </remarks>
         /// <param name="newPreReceiveHook">A description of the pre-receive hook to create</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
@@ -55,7 +55,7 @@ namespace Octokit.Reactive
         /// Edits an existing <see cref="PreReceiveHook"/>.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#update-a-pre-receive-hook">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#update-a-pre-receive-hook">API documentation</a> for more information.
         /// </remarks>
         /// <param name="hookId">The id of the pre-receive hook</param>
         /// <param name="updatePreReceiveHook">A description of the pre-receive hook to edit</param>
@@ -67,7 +67,7 @@ namespace Octokit.Reactive
         /// Deletes an existing <see cref="PreReceiveHook"/>.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#delete-a-pre-receive-hook">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#delete-a-pre-receive-hook">API documentation</a> for more information.
         /// </remarks>
         /// <param name="hookId">The id of the pre-receive hook</param>
         /// <exception cref="NotFoundException">Thrown when the specified <paramref name="hookId"/> does not exist.</exception>

--- a/Octokit.Reactive/Clients/Enterprise/ObservableEnterpriseClient.cs
+++ b/Octokit.Reactive/Clients/Enterprise/ObservableEnterpriseClient.cs
@@ -82,7 +82,7 @@
         /// A client for GitHub's Enterprise Pre-receive Hooks API
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#pre-receive-hooks">Enterprise Pre-receive Hooks API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#pre-receive-hooks">Enterprise Pre-receive Hooks API documentation</a> for more information.
         ///</remarks>
         public IObservableEnterprisePreReceiveHooksClient PreReceiveHook { get; private set; }
     }

--- a/Octokit.Reactive/Clients/Enterprise/ObservableEnterprisePreReceiveHooksClient.cs
+++ b/Octokit.Reactive/Clients/Enterprise/ObservableEnterprisePreReceiveHooksClient.cs
@@ -9,7 +9,7 @@ namespace Octokit.Reactive
     /// A client for GitHub's Enterprise Pre-receive Hooks API
     /// </summary>
     /// <remarks>
-    /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#pre-receive-hooks">Enterprise Pre-receive Hooks API documentation</a> for more information.
+    /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#pre-receive-hooks">Enterprise Pre-receive Hooks API documentation</a> for more information.
     ///</remarks>
     public class ObservableEnterprisePreReceiveHooksClient : IObservableEnterprisePreReceiveHooksClient
     {
@@ -28,7 +28,7 @@ namespace Octokit.Reactive
         /// Gets all <see cref="PreReceiveHook"/>s.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#list-pre-receive-hooks">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#list-pre-receive-hooks">API documentation</a> for more information.
         /// </remarks>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         public IObservable<PreReceiveHook> GetAll()
@@ -40,7 +40,7 @@ namespace Octokit.Reactive
         /// Gets all <see cref="PreReceiveHook"/>s.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#list-pre-receive-hooks">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#list-pre-receive-hooks">API documentation</a> for more information.
         /// </remarks>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
@@ -55,7 +55,7 @@ namespace Octokit.Reactive
         /// Gets a single <see cref="PreReceiveHook"/>.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#get-a-pre-receive-hook">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#get-a-pre-receive-hook">API documentation</a> for more information.
         /// </remarks>
         /// <param name="hookId">The id of the pre-receive hook</param>
         /// <exception cref="NotFoundException">Thrown when the specified <paramref name="hookId"/> does not exist.</exception>
@@ -69,7 +69,7 @@ namespace Octokit.Reactive
         /// Creates a new <see cref="PreReceiveHook"/>.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#create-a-pre-receive-hook">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#create-a-pre-receive-hook">API documentation</a> for more information.
         /// </remarks>
         /// <param name="newPreReceiveHook">A description of the pre-receive hook to create</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
@@ -84,7 +84,7 @@ namespace Octokit.Reactive
         /// Edits an existing <see cref="PreReceiveHook"/>.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#update-a-pre-receive-hook">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#update-a-pre-receive-hook">API documentation</a> for more information.
         /// </remarks>
         /// <param name="hookId">The id of the pre-receive hook</param>
         /// <param name="updatePreReceiveHook">A description of the pre-receive hook to edit</param>
@@ -101,7 +101,7 @@ namespace Octokit.Reactive
         /// Deletes an existing <see cref="PreReceiveHook"/>.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#delete-a-pre-receive-hook">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#delete-a-pre-receive-hook">API documentation</a> for more information.
         /// </remarks>
         /// <param name="hookId">The id of the pre-receive hook</param>
         /// <exception cref="NotFoundException">Thrown when the specified <paramref name="hookId"/> does not exist.</exception>

--- a/Octokit.Reactive/Clients/IObservableCommitCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableCommitCommentReactionsClient.cs
@@ -38,7 +38,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment id</param>        
+        /// <param name="number">The comment id</param>
         /// <returns></returns>
         IObservable<Reaction> GetAll(string owner, string name, int number);
 
@@ -58,7 +58,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
-        /// <param name="number">The comment id</param>        
+        /// <param name="number">The comment id</param>
         /// <returns></returns>
         IObservable<Reaction> GetAll(long repositoryId, int number);
 
@@ -75,7 +75,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Deletes a reaction for a specified Commit Comment
         /// </summary>
-        /// <remarks>https://docs.github.com/en/rest/reactions#delete-a-commit-comment-reaction</remarks>
+        /// <remarks>https://docs.github.com/rest/reactions#delete-a-commit-comment-reaction</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="commentId">The comment id</param>
@@ -86,7 +86,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Deletes a reaction for a specified Commit Comment
         /// </summary>
-        /// <remarks>https://docs.github.com/en/rest/reactions#delete-a-commit-comment-reaction</remarks>
+        /// <remarks>https://docs.github.com/rest/reactions#delete-a-commit-comment-reaction</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="commentId">The comment id</param>
         /// <param name="reactionId">The reaction id</param>

--- a/Octokit.Reactive/Clients/IObservableIssueCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssueCommentReactionsClient.cs
@@ -36,7 +36,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment id</param>        
+        /// <param name="number">The comment id</param>
         IObservable<Reaction> GetAll(string owner, string name, int number);
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
-        /// <param name="options">Options for changing the API response</param>        
+        /// <param name="options">Options for changing the API response</param>
         IObservable<Reaction> GetAll(string owner, string name, int number, ApiOptions options);
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The comment id</param>        
+        /// <param name="number">The comment id</param>
         IObservable<Reaction> GetAll(long repositoryId, int number);
 
         /// <summary>
@@ -63,13 +63,13 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>
-        /// <param name="options">Options for changing the API response</param>        
+        /// <param name="options">Options for changing the API response</param>
         IObservable<Reaction> GetAll(long repositoryId, int number, ApiOptions options);
 
         /// <summary>
         /// Deletes a reaction for a specified Issue Comment
         /// </summary>
-        /// <remarks>https://docs.github.com/en/rest/reactions#delete-an-issue-comment-reaction</remarks>
+        /// <remarks>https://docs.github.com/rest/reactions#delete-an-issue-comment-reaction</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="commentId">The comment id</param>
@@ -80,7 +80,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Deletes a reaction for a specified Commit Comment
         /// </summary>
-        /// <remarks>https://docs.github.com/en/rest/reactions#delete-an-issue-comment-reaction</remarks>
+        /// <remarks>https://docs.github.com/rest/reactions#delete-an-issue-comment-reaction</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="commentId">The comment id</param>
         /// <param name="reactionId">The reaction id</param>

--- a/Octokit.Reactive/Clients/IObservableIssueReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssueReactionsClient.cs
@@ -17,7 +17,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue id</param>        
+        /// <param name="number">The issue id</param>
         IObservable<Reaction> GetAll(string owner, string name, int number);
 
         /// <summary>
@@ -27,7 +27,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>
-        /// <param name="options">Options for changing the API response</param>        
+        /// <param name="options">Options for changing the API response</param>
         IObservable<Reaction> GetAll(string owner, string name, int number, ApiOptions options);
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue id</param>        
+        /// <param name="number">The issue id</param>
         IObservable<Reaction> GetAll(long repositoryId, int number);
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue id</param>
-        /// <param name="options">Options for changing the API response</param>        
+        /// <param name="options">Options for changing the API response</param>
         IObservable<Reaction> GetAll(long repositoryId, int number, ApiOptions options);
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Deletes a reaction for a specified Issue
         /// </summary>
-        /// <remarks>https://docs.github.com/en/rest/reactions#delete-an-issue-reaction</remarks>
+        /// <remarks>https://docs.github.com/rest/reactions#delete-an-issue-reaction</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
@@ -80,7 +80,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Deletes a reaction for a specified Issue
         /// </summary>
-        /// <remarks>https://docs.github.com/en/rest/reactions#delete-an-issue-reaction</remarks>
+        /// <remarks>https://docs.github.com/rest/reactions#delete-an-issue-reaction</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="reactionId">The reaction id</param>

--- a/Octokit.Reactive/Clients/IObservableOrganizationMembersClient.cs
+++ b/Octokit.Reactive/Clients/IObservableOrganizationMembersClient.cs
@@ -253,7 +253,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>
         /// This method requires authentication.
-        /// See the <a href="http://developer.github.com/v3/orgs/members/#publicize-a-users-membership">API documentation</a> 
+        /// See the <a href="http://developer.github.com/v3/orgs/members/#publicize-a-users-membership">API documentation</a>
         /// for more information.
         /// </remarks>
         /// <param name="org">The login for the organization</param>
@@ -289,7 +289,7 @@ namespace Octokit.Reactive
         IObservable<OrganizationMembership> GetOrganizationMembership(string org, string user);
 
         /// <summary>
-        /// Add a user to the organization or update the user's role withing the organization. 
+        /// Add a user to the organization or update the user's role withing the organization.
         /// </summary>
         /// <remarks>
         /// This method requires authentication.
@@ -345,7 +345,7 @@ namespace Octokit.Reactive
         /// List failed organization invitations.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/orgs/members#list-failed-organization-invitations">API Documentation</a>
+        /// See the <a href="https://docs.github.com/rest/orgs/members#list-failed-organization-invitations">API Documentation</a>
         /// for more information.
         /// </remarks>
         /// <param name="org">The login for the organization</param>
@@ -356,7 +356,7 @@ namespace Octokit.Reactive
         /// List failed organization invitations.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/orgs/members#list-failed-organization-invitations">API Documentation</a>
+        /// See the <a href="https://docs.github.com/rest/orgs/members#list-failed-organization-invitations">API Documentation</a>
         /// for more information.
         /// </remarks>
         /// <param name="org">The login for the organization</param>

--- a/Octokit.Reactive/Clients/IObservablePullRequestReviewCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservablePullRequestReviewCommentReactionsClient.cs
@@ -17,7 +17,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment id</param>        
+        /// <param name="number">The comment id</param>
         IObservable<Reaction> GetAll(string owner, string name, int number);
 
         /// <summary>
@@ -27,7 +27,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
-        /// <param name="options">Options for changing the API response</param>        
+        /// <param name="options">Options for changing the API response</param>
         IObservable<Reaction> GetAll(string owner, string name, int number, ApiOptions options);
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The comment id</param>        
+        /// <param name="number">The comment id</param>
         IObservable<Reaction> GetAll(long repositoryId, int number);
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>
-        /// <param name="options">Options for changing the API response</param>        
+        /// <param name="options">Options for changing the API response</param>
         IObservable<Reaction> GetAll(long repositoryId, int number, ApiOptions options);
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Deletes a reaction for a specified Pull Request comment
         /// </summary>
-        /// <remarks>https://docs.github.com/en/rest/reactions#delete-a-pull-request-comment-reaction</remarks>
+        /// <remarks>https://docs.github.com/rest/reactions#delete-a-pull-request-comment-reaction</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="commentId">The comment id</param>
@@ -80,7 +80,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Deletes a reaction for a specified Pull Request comment
         /// </summary>
-        /// <remarks>https://docs.github.com/en/rest/reactions#delete-a-pull-request-comment-reaction</remarks>
+        /// <remarks>https://docs.github.com/rest/reactions#delete-a-pull-request-comment-reaction</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="commentId">The comment id</param>
         /// <param name="reactionId">The reaction id</param>

--- a/Octokit.Reactive/Clients/IObservableReleasesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableReleasesClient.cs
@@ -17,7 +17,7 @@ namespace Octokit.Reactive
         /// Generates a <see cref="GeneratedReleaseNotes"/>s for the specified repository with auto generated notes.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/releases/releases#generate-release-notes-content-for-a-release">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/rest/releases/releases#generate-release-notes-content-for-a-release">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
@@ -29,7 +29,7 @@ namespace Octokit.Reactive
         /// Generates a <see cref="GeneratedReleaseNotes"/>s for the specified repository with auto generated notes.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/releases/releases#generate-release-notes-content-for-a-release">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/rest/releases/releases#generate-release-notes-content-for-a-release">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="data">The request for generating release notes</param>

--- a/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
@@ -76,7 +76,7 @@ namespace Octokit.Reactive
         /// Checks if vulnerability alerts are enabled for the specified repository.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/reference/repos#check-if-vulnerability-alerts-are-enabled-for-a-repository">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/rest/reference/repos#check-if-vulnerability-alerts-are-enabled-for-a-repository">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The current owner of the repository</param>
         /// <param name="name">The name of the repository</param>
@@ -209,7 +209,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/statuses/">Commit Status API documentation</a> for more
-        /// details. Also check out the <a href="https://github.com/blog/1227-commit-status-api">blog post</a> 
+        /// details. Also check out the <a href="https://github.com/blog/1227-commit-status-api">blog post</a>
         /// that announced this feature.
         /// </remarks>
         IObservableCommitStatusClient Status { get; }
@@ -249,7 +249,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// A client for GitHub's Repository Forks API.
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/">Forks API documentation</a> for more information.</remarks>        
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/">Forks API documentation</a> for more information.</remarks>
         IObservableRepositoryForksClient Forks { get; }
 
         /// <summary>
@@ -583,7 +583,7 @@ namespace Octokit.Reactive
         /// Gets all topics for the specified owner and repository name.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
+        /// See the <a href="https://docs.github.com/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
@@ -595,7 +595,7 @@ namespace Octokit.Reactive
         /// Gets all topics for the specified owner and repository name.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
+        /// See the <a href="https://docs.github.com/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
@@ -606,7 +606,7 @@ namespace Octokit.Reactive
         /// Gets all topics for the specified repository ID.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
+        /// See the <a href="https://docs.github.com/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
@@ -617,7 +617,7 @@ namespace Octokit.Reactive
         /// Gets all topics for the specified repository ID.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
+        /// See the <a href="https://docs.github.com/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <returns>All topics associated with the repository.</returns>
@@ -627,7 +627,7 @@ namespace Octokit.Reactive
         /// Replaces all topics for the specified repository.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/reference/repos#replace-all-repository-topics">API documentation</a> for more details
+        /// See the <a href="https://docs.github.com/rest/reference/repos#replace-all-repository-topics">API documentation</a> for more details
         ///
         /// This is a replacement operation; it is not additive. To clear repository topics, for example, you could specify an empty list of topics here.
         /// </remarks>
@@ -640,7 +640,7 @@ namespace Octokit.Reactive
         /// Replaces all topics for the specified repository.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/reference/repos#replace-all-repository-topics">API documentation</a> for more details
+        /// See the <a href="https://docs.github.com/rest/reference/repos#replace-all-repository-topics">API documentation</a> for more details
         ///
         /// This is a replacement operation; it is not additive. To clear repository topics, for example, you could specify an empty list of topics here.
         /// </remarks>

--- a/Octokit.Reactive/Clients/ObservableCommitCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableCommitCommentReactionsClient.cs
@@ -63,7 +63,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment id</param>        
+        /// <param name="number">The comment id</param>
         /// <returns></returns>
         public IObservable<Reaction> GetAll(string owner, string name, int number)
         {
@@ -77,7 +77,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
-        /// <param name="options">Options for changing the API response</param> 
+        /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
         public IObservable<Reaction> GetAll(string owner, string name, int number, ApiOptions options)
         {
@@ -93,7 +93,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
-        /// <param name="number">The comment id</param>        
+        /// <param name="number">The comment id</param>
         /// <returns></returns>
         public IObservable<Reaction> GetAll(long repositoryId, int number)
         {
@@ -118,7 +118,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Deletes a reaction for a specified Commit Comment
         /// </summary>
-        /// <remarks>https://docs.github.com/en/rest/reactions#delete-a-commit-comment-reaction</remarks>
+        /// <remarks>https://docs.github.com/rest/reactions#delete-a-commit-comment-reaction</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="commentId">The comment id</param>
@@ -136,7 +136,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Deletes a reaction for a specified Commit Comment
         /// </summary>
-        /// <remarks>https://docs.github.com/en/rest/reactions#delete-a-commit-comment-reaction</remarks>
+        /// <remarks>https://docs.github.com/rest/reactions#delete-a-commit-comment-reaction</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="commentId">The comment id</param>
         /// <param name="reactionid">The reaction id</param>

--- a/Octokit.Reactive/Clients/ObservableIssueCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueCommentReactionsClient.cs
@@ -61,7 +61,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment id</param>        
+        /// <param name="number">The comment id</param>
         public IObservable<Reaction> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -77,7 +77,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
-        /// <param name="options">Options for changing the API response</param>        
+        /// <param name="options">Options for changing the API response</param>
         public IObservable<Reaction> GetAll(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -92,7 +92,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The comment id</param>        
+        /// <param name="number">The comment id</param>
         public IObservable<Reaction> GetAll(long repositoryId, int number)
         {
             return GetAll(repositoryId, number, ApiOptions.None);
@@ -104,7 +104,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>
-        /// <param name="options">Options for changing the API response</param>        
+        /// <param name="options">Options for changing the API response</param>
         public IObservable<Reaction> GetAll(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -115,7 +115,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Deletes a reaction for a specified Issue Comment
         /// </summary>
-        /// <remarks>https://docs.github.com/en/rest/reactions#delete-an-issue-comment-reaction</remarks>
+        /// <remarks>https://docs.github.com/rest/reactions#delete-an-issue-comment-reaction</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="commentId">The comment id</param>
@@ -133,7 +133,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Deletes a reaction for a specified Commit Comment
         /// </summary>
-        /// <remarks>https://docs.github.com/en/rest/reactions#delete-an-issue-comment-reaction</remarks>
+        /// <remarks>https://docs.github.com/rest/reactions#delete-an-issue-comment-reaction</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="commentId">The comment id</param>
         /// <param name="reactionId">The reaction id</param>

--- a/Octokit.Reactive/Clients/ObservableIssueReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueReactionsClient.cs
@@ -30,7 +30,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue id</param>        
+        /// <param name="number">The issue id</param>
         public IObservable<Reaction> GetAll(string owner, string name, int number)
         {
             return GetAll(owner, name, number, ApiOptions.None);
@@ -43,7 +43,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>
-        /// <param name="options">Options for changing the API response</param>        
+        /// <param name="options">Options for changing the API response</param>
         public IObservable<Reaction> GetAll(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -58,7 +58,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue id</param>        
+        /// <param name="number">The issue id</param>
         public IObservable<Reaction> GetAll(long repositoryId, int number)
         {
             return GetAll(repositoryId, number, ApiOptions.None);
@@ -70,7 +70,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue id</param>
-        /// <param name="options">Options for changing the API response</param>        
+        /// <param name="options">Options for changing the API response</param>
         public IObservable<Reaction> GetAll(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -112,7 +112,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Deletes a reaction for a specified Issue
         /// </summary>
-        /// <remarks>https://docs.github.com/en/rest/reactions#delete-an-issue-reaction</remarks>
+        /// <remarks>https://docs.github.com/rest/reactions#delete-an-issue-reaction</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
@@ -130,7 +130,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Deletes a reaction for a specified Issue
         /// </summary>
-        /// <remarks>https://docs.github.com/en/rest/reactions#delete-an-issue-reaction</remarks>
+        /// <remarks>https://docs.github.com/rest/reactions#delete-an-issue-reaction</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="reactionId">The reaction id</param>

--- a/Octokit.Reactive/Clients/ObservableOrganizationMembersClient.cs
+++ b/Octokit.Reactive/Clients/ObservableOrganizationMembersClient.cs
@@ -343,7 +343,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>
         /// This method requires authentication.
-        /// See the <a href="http://developer.github.com/v3/orgs/members/#publicize-a-users-membership">API documentation</a> 
+        /// See the <a href="http://developer.github.com/v3/orgs/members/#publicize-a-users-membership">API documentation</a>
         /// for more information.
         /// </remarks>
         /// <param name="org">The login for the organization</param>
@@ -397,7 +397,7 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
-        /// Add a user to the organization or update the user's role withing the organization. 
+        /// Add a user to the organization or update the user's role withing the organization.
         /// </summary>
         /// <remarks>
         /// This method requires authentication.
@@ -477,7 +477,7 @@ namespace Octokit.Reactive
         /// List failed organization invitations.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/orgs/members#list-failed-organization-invitations">API Documentation</a>
+        /// See the <a href="https://docs.github.com/rest/orgs/members#list-failed-organization-invitations">API Documentation</a>
         /// for more information.
         /// </remarks>
         /// <param name="org">The login for the organization</param>
@@ -493,7 +493,7 @@ namespace Octokit.Reactive
         /// List failed organization invitations.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/orgs/members#list-failed-organization-invitations">API Documentation</a>
+        /// See the <a href="https://docs.github.com/rest/orgs/members#list-failed-organization-invitations">API Documentation</a>
         /// for more information.
         /// </remarks>
         /// <param name="org">The login for the organization</param>

--- a/Octokit.Reactive/Clients/ObservablePullRequestReviewCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePullRequestReviewCommentReactionsClient.cs
@@ -30,7 +30,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment id</param>        
+        /// <param name="number">The comment id</param>
         public IObservable<Reaction> GetAll(string owner, string name, int number)
         {
             return GetAll(owner, name, number, ApiOptions.None);
@@ -50,7 +50,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The comment id</param>        
+        /// <param name="number">The comment id</param>
         public IObservable<Reaction> GetAll(long repositoryId, int number)
         {
             return GetAll(repositoryId, number, ApiOptions.None);
@@ -62,7 +62,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>
-        /// <param name="options">Options for changing the API response</param>        
+        /// <param name="options">Options for changing the API response</param>
         public IObservable<Reaction> GetAll(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -104,7 +104,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Deletes a reaction for a specified Pull Request comment
         /// </summary>
-        /// <remarks>https://docs.github.com/en/rest/reactions#delete-a-pull-request-comment-reaction</remarks>
+        /// <remarks>https://docs.github.com/rest/reactions#delete-a-pull-request-comment-reaction</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="commentId">The comment id</param>
@@ -122,7 +122,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Deletes a reaction for a specified Pull Request comment
         /// </summary>
-        /// <remarks>https://docs.github.com/en/rest/reactions#delete-a-pull-request-comment-reaction</remarks>
+        /// <remarks>https://docs.github.com/rest/reactions#delete-a-pull-request-comment-reaction</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="commentId">The comment id</param>
         /// <param name="reactionId">The reaction id</param>

--- a/Octokit.Reactive/Clients/ObservableReleasesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableReleasesClient.cs
@@ -29,7 +29,7 @@ namespace Octokit.Reactive
         /// Generates a <see cref="GeneratedReleaseNotes"/>s for the specified repository with auto generated notes.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/releases/releases#generate-release-notes-content-for-a-release">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/rest/releases/releases#generate-release-notes-content-for-a-release">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
@@ -48,7 +48,7 @@ namespace Octokit.Reactive
         /// Generates a <see cref="GeneratedReleaseNotes"/>s for the specified repository with auto generated notes.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/releases/releases#generate-release-notes-content-for-a-release">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/rest/releases/releases#generate-release-notes-content-for-a-release">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="data">The request for generating release notes</param>

--- a/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
@@ -155,7 +155,7 @@ namespace Octokit.Reactive
         /// Checks if vulnerability alerts are enabled for the specified repository.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/reference/repos#check-if-vulnerability-alerts-are-enabled-for-a-repository">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/rest/reference/repos#check-if-vulnerability-alerts-are-enabled-for-a-repository">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The current owner of the repository</param>
         /// <param name="name">The name of the repository</param>
@@ -889,7 +889,7 @@ namespace Octokit.Reactive
         /// Gets all topics for the specified owner and repository name.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
+        /// See the <a href="https://docs.github.com/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
@@ -904,7 +904,7 @@ namespace Octokit.Reactive
         /// Gets all topics for the specified owner and repository name.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
+        /// See the <a href="https://docs.github.com/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
@@ -918,7 +918,7 @@ namespace Octokit.Reactive
         /// Gets all topics for the specified repository ID.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
+        /// See the <a href="https://docs.github.com/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
@@ -932,7 +932,7 @@ namespace Octokit.Reactive
         /// Gets all topics for the specified repository ID.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
+        /// See the <a href="https://docs.github.com/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <returns>All topics associated with the repository.</returns>
@@ -945,7 +945,7 @@ namespace Octokit.Reactive
         /// Replaces all topics for the specified repository.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/reference/repos#replace-all-repository-topics">API documentation</a> for more details
+        /// See the <a href="https://docs.github.com/rest/reference/repos#replace-all-repository-topics">API documentation</a> for more details
         ///
         /// This is a replacement operation; it is not additive. To clear repository topics, for example, you could specify an empty list of topics here.
         /// </remarks>
@@ -961,7 +961,7 @@ namespace Octokit.Reactive
         /// Replaces all topics for the specified repository.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/reference/repos#replace-all-repository-topics">API documentation</a> for more details
+        /// See the <a href="https://docs.github.com/rest/reference/repos#replace-all-repository-topics">API documentation</a> for more details
         ///
         /// This is a replacement operation; it is not additive. To clear repository topics, for example, you could specify an empty list of topics here.
         /// </remarks>

--- a/Octokit/Clients/CommitCommentReactionsClient.cs
+++ b/Octokit/Clients/CommitCommentReactionsClient.cs
@@ -116,7 +116,7 @@ namespace Octokit
         /// <summary>
         /// Deletes a reaction for a specified Commit Comment
         /// </summary>
-        /// <remarks>https://docs.github.com/en/rest/reactions#delete-a-commit-comment-reaction</remarks>
+        /// <remarks>https://docs.github.com/rest/reactions#delete-a-commit-comment-reaction</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="commentId">The comment id</param>
@@ -134,7 +134,7 @@ namespace Octokit
         /// <summary>
         /// Deletes a reaction for a specified Commit Comment
         /// </summary>
-        /// <remarks>https://docs.github.com/en/rest/reactions#delete-a-commit-comment-reaction</remarks>
+        /// <remarks>https://docs.github.com/rest/reactions#delete-a-commit-comment-reaction</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="commentId">The comment id</param>
         /// <param name="reactionId">The reaction id</param>

--- a/Octokit/Clients/Enterprise/EnterpriseClient.cs
+++ b/Octokit/Clients/Enterprise/EnterpriseClient.cs
@@ -84,7 +84,7 @@
         /// A client for GitHub's Enterprise Pre-receive Hooks API
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#pre-receive-hooks">Enterprise Pre-receive Hooks API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#pre-receive-hooks">Enterprise Pre-receive Hooks API documentation</a> for more information.
         ///</remarks>
         public IEnterprisePreReceiveHooksClient PreReceiveHook { get; private set; }
     }

--- a/Octokit/Clients/Enterprise/EnterprisePreReceiveHooksClient.cs
+++ b/Octokit/Clients/Enterprise/EnterprisePreReceiveHooksClient.cs
@@ -7,7 +7,7 @@ namespace Octokit
     /// A client for GitHub's Enterprise Pre-receive Hooks API
     /// </summary>
     /// <remarks>
-    /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#pre-receive-hooks">Enterprise Pre-receive Hooks API documentation</a> for more information.
+    /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#pre-receive-hooks">Enterprise Pre-receive Hooks API documentation</a> for more information.
     ///</remarks>
     public class EnterprisePreReceiveHooksClient : ApiClient, IEnterprisePreReceiveHooksClient
     {
@@ -23,7 +23,7 @@ namespace Octokit
         /// Gets all <see cref="PreReceiveHook"/>s.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#list-pre-receive-hooks">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#list-pre-receive-hooks">API documentation</a> for more information.
         /// </remarks>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         [ManualRoute("GET", "/admin/pre-receive-hooks")]
@@ -36,7 +36,7 @@ namespace Octokit
         /// Gets all <see cref="PreReceiveHook"/>s.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#list-pre-receive-hooks">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#list-pre-receive-hooks">API documentation</a> for more information.
         /// </remarks>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
@@ -51,7 +51,7 @@ namespace Octokit
         /// Gets a single <see cref="PreReceiveHook"/>.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#get-a-pre-receive-hook">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#get-a-pre-receive-hook">API documentation</a> for more information.
         /// </remarks>
         /// <param name="hookId">The id of the pre-receive hook</param>
         /// <exception cref="NotFoundException">Thrown when the specified <paramref name="hookId"/> does not exist.</exception>
@@ -67,7 +67,7 @@ namespace Octokit
         /// Creates a new <see cref="PreReceiveHook"/>.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#create-a-pre-receive-hook">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#create-a-pre-receive-hook">API documentation</a> for more information.
         /// </remarks>
         /// <param name="newPreReceiveHook">A description of the pre-receive hook to create</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
@@ -84,7 +84,7 @@ namespace Octokit
         /// Edits an existing <see cref="PreReceiveHook"/>.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#update-a-pre-receive-hook">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#update-a-pre-receive-hook">API documentation</a> for more information.
         /// </remarks>
         /// <param name="hookId">The id of the pre-receive hook</param>
         /// <param name="updatePreReceiveHook">A description of the pre-receive hook to edit</param>
@@ -103,7 +103,7 @@ namespace Octokit
         /// Deletes an existing <see cref="PreReceiveHook"/>.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#delete-a-pre-receive-hook">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#delete-a-pre-receive-hook">API documentation</a> for more information.
         /// </remarks>
         /// <param name="hookId">The id of the pre-receive hook</param>
         /// <exception cref="NotFoundException">Thrown when the specified <paramref name="hookId"/> does not exist.</exception>

--- a/Octokit/Clients/Enterprise/IEnterpriseClient.cs
+++ b/Octokit/Clients/Enterprise/IEnterpriseClient.cs
@@ -68,7 +68,7 @@
         /// A client for GitHub's Enterprise Pre-receive Hooks API
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/enterprise-server@3.3/rest/reference/enterprise-admin#pre-receive-hooks">Enterprise Pre-receive Hooks API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/enterprise-server@3.3/rest/reference/enterprise-admin#pre-receive-hooks">Enterprise Pre-receive Hooks API documentation</a> for more information.
         ///</remarks>
         IEnterprisePreReceiveHooksClient PreReceiveHook { get; }
     }

--- a/Octokit/Clients/Enterprise/IEnterprisePreReceiveHooksClient.cs
+++ b/Octokit/Clients/Enterprise/IEnterprisePreReceiveHooksClient.cs
@@ -7,7 +7,7 @@ namespace Octokit
     /// A client for GitHub's Enterprise Pre-receive Hooks API
     /// </summary>
     /// <remarks>
-    /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#pre-receive-hooks">Enterprise Pre-receive Hooks API documentation</a> for more information.
+    /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#pre-receive-hooks">Enterprise Pre-receive Hooks API documentation</a> for more information.
     ///</remarks>
     public interface IEnterprisePreReceiveHooksClient
     {
@@ -15,7 +15,7 @@ namespace Octokit
         /// Gets all <see cref="PreReceiveHook"/>s.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#list-pre-receive-hooks">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#list-pre-receive-hooks">API documentation</a> for more information.
         /// </remarks>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         Task<IReadOnlyList<PreReceiveHook>> GetAll();
@@ -24,7 +24,7 @@ namespace Octokit
         /// Gets all <see cref="PreReceiveHook"/>s.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#list-pre-receive-hooks">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#list-pre-receive-hooks">API documentation</a> for more information.
         /// </remarks>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
@@ -34,7 +34,7 @@ namespace Octokit
         /// Gets a single <see cref="PreReceiveHook"/>.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#get-a-pre-receive-hook">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#get-a-pre-receive-hook">API documentation</a> for more information.
         /// </remarks>
         /// <param name="hookId">The id of the pre-receive hook</param>
         /// <exception cref="NotFoundException">Thrown when the specified <paramref name="hookId"/> does not exist.</exception>
@@ -45,7 +45,7 @@ namespace Octokit
         /// Creates a new <see cref="PreReceiveHook"/>.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#create-a-pre-receive-hook">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#create-a-pre-receive-hook">API documentation</a> for more information.
         /// </remarks>
         /// <param name="newPreReceiveHook">A description of the pre-receive hook to create</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
@@ -55,7 +55,7 @@ namespace Octokit
         /// Edits an existing <see cref="PreReceiveHook"/>.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#update-a-pre-receive-hook">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#update-a-pre-receive-hook">API documentation</a> for more information.
         /// </remarks>
         /// <param name="hookId">The id of the pre-receive hook</param>
         /// <param name="updatePreReceiveHook">A description of the pre-receive hook to edit</param>
@@ -67,7 +67,7 @@ namespace Octokit
         /// Deletes an existing <see cref="PreReceiveHook"/>.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/enterprise-server/rest/reference/enterprise-admin#delete-a-pre-receive-hook">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/enterprise-server/rest/reference/enterprise-admin#delete-a-pre-receive-hook">API documentation</a> for more information.
         /// </remarks>
         /// <param name="hookId">The id of the pre-receive hook</param>
         /// <exception cref="NotFoundException">Thrown when the specified <paramref name="hookId"/> does not exist.</exception>

--- a/Octokit/Clients/ICommitCommentReactionsClient.cs
+++ b/Octokit/Clients/ICommitCommentReactionsClient.cs
@@ -38,7 +38,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment id</param>        
+        /// <param name="number">The comment id</param>
         /// <returns></returns>
         Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number);
 
@@ -58,7 +58,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
-        /// <param name="number">The comment id</param>        
+        /// <param name="number">The comment id</param>
         /// <returns></returns>
         Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number);
 
@@ -68,14 +68,14 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="number">The comment id</param>
-        /// <param name="options">Options for changing the API response</param> 
+        /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
         Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number, ApiOptions options);
 
         /// <summary>
         /// Deletes a reaction for a specified Commit Comment
         /// </summary>
-        /// <remarks>https://docs.github.com/en/rest/reactions#delete-a-commit-comment-reaction</remarks>
+        /// <remarks>https://docs.github.com/rest/reactions#delete-a-commit-comment-reaction</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="commentId">The comment id</param>
@@ -86,7 +86,7 @@ namespace Octokit
         /// <summary>
         /// Deletes a reaction for a specified Commit Comment
         /// </summary>
-        /// <remarks>https://docs.github.com/en/rest/reactions#delete-a-commit-comment-reaction</remarks>
+        /// <remarks>https://docs.github.com/rest/reactions#delete-a-commit-comment-reaction</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="commentId">The comment id</param>
         /// <param name="reactionId">The reaction id</param>

--- a/Octokit/Clients/IIssueCommentReactionsClient.cs
+++ b/Octokit/Clients/IIssueCommentReactionsClient.cs
@@ -36,7 +36,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment id</param>        
+        /// <param name="number">The comment id</param>
         Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number);
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
-        /// <param name="options">Options for changing the API response</param>        
+        /// <param name="options">Options for changing the API response</param>
         Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number, ApiOptions options);
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The comment id</param>        
+        /// <param name="number">The comment id</param>
         Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number);
 
         /// <summary>
@@ -63,13 +63,13 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>
-        /// <param name="options">Options for changing the API response</param>        
+        /// <param name="options">Options for changing the API response</param>
         Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number, ApiOptions options);
 
         /// <summary>
         /// Deletes a reaction for a specified Commit Comment
         /// </summary>
-        /// <remarks>https://docs.github.com/en/rest/reactions#delete-a-commit-comment-reaction</remarks>
+        /// <remarks>https://docs.github.com/rest/reactions#delete-a-commit-comment-reaction</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="commentId">The comment id</param>
@@ -80,7 +80,7 @@ namespace Octokit
         /// <summary>
         /// Deletes a reaction for a specified Commit Comment
         /// </summary>
-        /// <remarks>https://docs.github.com/en/rest/reactions#delete-a-commit-comment-reaction</remarks>
+        /// <remarks>https://docs.github.com/rest/reactions#delete-a-commit-comment-reaction</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="commentId">The comment id</param>
         /// <param name="reactionId">The reaction id</param>

--- a/Octokit/Clients/IIssueReactionsClient.cs
+++ b/Octokit/Clients/IIssueReactionsClient.cs
@@ -17,7 +17,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue id</param>        
+        /// <param name="number">The issue id</param>
         Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number);
 
         /// <summary>
@@ -27,7 +27,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>
-        /// <param name="options">Options for changing the API response</param>        
+        /// <param name="options">Options for changing the API response</param>
         Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number, ApiOptions options);
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue id</param>        
+        /// <param name="number">The issue id</param>
         Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number);
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue id</param>
-        /// <param name="options">Options for changing the API response</param>        
+        /// <param name="options">Options for changing the API response</param>
         Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number, ApiOptions options);
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace Octokit
         /// <summary>
         /// Deletes a reaction for a specified Issue
         /// </summary>
-        /// <remarks>https://docs.github.com/en/rest/reactions#delete-an-issue-reaction</remarks>
+        /// <remarks>https://docs.github.com/rest/reactions#delete-an-issue-reaction</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
@@ -80,7 +80,7 @@ namespace Octokit
         /// <summary>
         /// Deletes a reaction for a specified Issue
         /// </summary>
-        /// <remarks>https://docs.github.com/en/rest/reactions#delete-an-issue-reaction</remarks>
+        /// <remarks>https://docs.github.com/rest/reactions#delete-an-issue-reaction</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="reactionId">The reaction id</param>

--- a/Octokit/Clients/IOrganizationMembersClient.cs
+++ b/Octokit/Clients/IOrganizationMembersClient.cs
@@ -259,7 +259,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>
         /// This method requires authentication.
-        /// See the <a href="http://developer.github.com/v3/orgs/members/#publicize-a-users-membership">API documentation</a> 
+        /// See the <a href="http://developer.github.com/v3/orgs/members/#publicize-a-users-membership">API documentation</a>
         /// for more information.
         /// </remarks>
         /// <param name="org">The login for the organization</param>
@@ -295,7 +295,7 @@ namespace Octokit
         Task<OrganizationMembership> GetOrganizationMembership(string org, string user);
 
         /// <summary>
-        /// Add a user to the organization or update the user's role withing the organization. 
+        /// Add a user to the organization or update the user's role withing the organization.
         /// </summary>
         /// <remarks>
         /// This method requires authentication.
@@ -351,7 +351,7 @@ namespace Octokit
         /// List failed organization invitations.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/orgs/members#list-failed-organization-invitations">API Documentation</a>
+        /// See the <a href="https://docs.github.com/rest/orgs/members#list-failed-organization-invitations">API Documentation</a>
         /// for more information.
         /// </remarks>
         /// <param name="org">The login for the organization</param>
@@ -362,7 +362,7 @@ namespace Octokit
         /// List failed organization invitations.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/orgs/members#list-failed-organization-invitations">API Documentation</a>
+        /// See the <a href="https://docs.github.com/rest/orgs/members#list-failed-organization-invitations">API Documentation</a>
         /// for more information.
         /// </remarks>
         /// <param name="org">The login for the organization</param>

--- a/Octokit/Clients/IPullRequestReviewCommentReactionsClient.cs
+++ b/Octokit/Clients/IPullRequestReviewCommentReactionsClient.cs
@@ -17,7 +17,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment id</param>        
+        /// <param name="number">The comment id</param>
         Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number);
 
         /// <summary>
@@ -27,7 +27,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
-        /// <param name="options">Options for changing the API response</param>        
+        /// <param name="options">Options for changing the API response</param>
         Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number, ApiOptions options);
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The comment id</param>        
+        /// <param name="number">The comment id</param>
         Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number);
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>
-        /// <param name="options">Options for changing the API response</param>        
+        /// <param name="options">Options for changing the API response</param>
         Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number, ApiOptions options);
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace Octokit
         /// <summary>
         /// Deletes a reaction for a specified Pull Request comment
         /// </summary>
-        /// <remarks>https://docs.github.com/en/rest/reactions#delete-a-pull-request-comment-reaction</remarks>
+        /// <remarks>https://docs.github.com/rest/reactions#delete-a-pull-request-comment-reaction</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="commentId">The issue id</param>
@@ -80,7 +80,7 @@ namespace Octokit
         /// <summary>
         /// Deletes a reaction for a specified Pull Request comment
         /// </summary>
-        /// <remarks>https://docs.github.com/en/rest/reactions#delete-a-pull-request-comment-reaction</remarks>
+        /// <remarks>https://docs.github.com/rest/reactions#delete-a-pull-request-comment-reaction</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="commentId">The issue id</param>
         /// <param name="reactionId">The reaction id</param>

--- a/Octokit/Clients/IReleasesClient.cs
+++ b/Octokit/Clients/IReleasesClient.cs
@@ -17,7 +17,7 @@ namespace Octokit
         /// Generates a <see cref="GeneratedReleaseNotes"/>s for the specified repository with auto generated notes.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/releases/releases#generate-release-notes-content-for-a-release">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/rest/releases/releases#generate-release-notes-content-for-a-release">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
@@ -29,7 +29,7 @@ namespace Octokit
         /// Generates a <see cref="GeneratedReleaseNotes"/>s for the specified repository with auto generated notes.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/releases/releases#generate-release-notes-content-for-a-release">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/rest/releases/releases#generate-release-notes-content-for-a-release">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="data">The request for generating release notes</param>

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -137,7 +137,7 @@ namespace Octokit
         /// Checks if vulnerability alerts are enabled for the specified repository.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/reference/repos#check-if-vulnerability-alerts-are-enabled-for-a-repository">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/rest/reference/repos#check-if-vulnerability-alerts-are-enabled-for-a-repository">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The current owner of the repository</param>
         /// <param name="name">The name of the repository</param>
@@ -303,7 +303,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/statuses/">Commit Status API documentation</a> for more
-        /// details. Also check out the <a href="https://github.com/blog/1227-commit-status-api">blog post</a> 
+        /// details. Also check out the <a href="https://github.com/blog/1227-commit-status-api">blog post</a>
         /// that announced this feature.
         /// </remarks>
         ICommitStatusClient Status { get; }
@@ -317,7 +317,7 @@ namespace Octokit
         /// <summary>
         /// A client for GitHub's Repository Forks API.
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/">Forks API documentation</a> for more information.</remarks>        
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/">Forks API documentation</a> for more information.</remarks>
         IRepositoryForksClient Forks { get; }
 
         /// <summary>
@@ -647,7 +647,7 @@ namespace Octokit
         /// Gets all topics for the specified owner and repository name.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
+        /// See the <a href="https://docs.github.com/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
@@ -659,7 +659,7 @@ namespace Octokit
         /// Gets all topics for the specified owner and repository name.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
+        /// See the <a href="https://docs.github.com/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
@@ -670,7 +670,7 @@ namespace Octokit
         /// Gets all topics for the specified repository ID.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
+        /// See the <a href="https://docs.github.com/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
@@ -681,7 +681,7 @@ namespace Octokit
         /// Gets all topics for the specified repository ID.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
+        /// See the <a href="https://docs.github.com/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <returns>All topics associated with the repository.</returns>
@@ -691,7 +691,7 @@ namespace Octokit
         /// Replaces all topics for the specified repository.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/reference/repos#replace-all-repository-topics">API documentation</a> for more details
+        /// See the <a href="https://docs.github.com/rest/reference/repos#replace-all-repository-topics">API documentation</a> for more details
         ///
         /// This is a replacement operation; it is not additive. To clear repository topics, for example, you could specify an empty list of topics here.
         /// </remarks>
@@ -704,7 +704,7 @@ namespace Octokit
         /// Replaces all topics for the specified repository.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/reference/repos#replace-all-repository-topics">API documentation</a> for more details
+        /// See the <a href="https://docs.github.com/rest/reference/repos#replace-all-repository-topics">API documentation</a> for more details
         ///
         /// This is a replacement operation; it is not additive. To clear repository topics, for example, you could specify an empty list of topics here.
         /// </remarks>

--- a/Octokit/Clients/IssueReactionsClient.cs
+++ b/Octokit/Clients/IssueReactionsClient.cs
@@ -110,7 +110,7 @@ namespace Octokit
         /// <summary>
         /// Deletes a reaction for a specified Issue
         /// </summary>
-        /// <remarks>https://docs.github.com/en/rest/reactions#delete-an-issue-reaction</remarks>
+        /// <remarks>https://docs.github.com/rest/reactions#delete-an-issue-reaction</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue id</param>
@@ -128,7 +128,7 @@ namespace Octokit
         /// <summary>
         /// Deletes a reaction for a specified Issue
         /// </summary>
-        /// <remarks>https://docs.github.com/en/rest/reactions#delete-an-issue-reaction</remarks>
+        /// <remarks>https://docs.github.com/rest/reactions#delete-an-issue-reaction</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="issueNumber">The issue id</param>
         /// <param name="reactionId">The reaction id</param>

--- a/Octokit/Clients/OrganizationMembersClient.cs
+++ b/Octokit/Clients/OrganizationMembersClient.cs
@@ -572,7 +572,7 @@ namespace Octokit
         /// List failed organization invitations.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/orgs/members#list-failed-organization-invitations">API Documentation</a>
+        /// See the <a href="https://docs.github.com/rest/orgs/members#list-failed-organization-invitations">API Documentation</a>
         /// for more information.
         /// </remarks>
         /// <param name="org">The login for the organization</param>
@@ -589,7 +589,7 @@ namespace Octokit
         /// List failed organization invitations.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/orgs/members#list-failed-organization-invitations">API Documentation</a>
+        /// See the <a href="https://docs.github.com/rest/orgs/members#list-failed-organization-invitations">API Documentation</a>
         /// for more information.
         /// </remarks>
         /// <param name="org">The login for the organization</param>

--- a/Octokit/Clients/PackagesClient.cs
+++ b/Octokit/Clients/PackagesClient.cs
@@ -7,7 +7,7 @@ namespace Octokit
     /// A client for GitHub's Packages API.
     /// </summary>
     /// <remarks>
-    /// See the <a href="https://docs.github.com/en/rest/packages">Packages API documentation</a> for more details.
+    /// See the <a href="https://docs.github.com/rest/packages">Packages API documentation</a> for more details.
     /// </remarks>
     public class PackagesClient : ApiClient, IPackagesClient
     {
@@ -55,7 +55,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(packageName, nameof(packageName));
 
             var route = ApiUrls.PackageOrg(org, packageType, packageName);
-            
+
             return ApiConnection.Get<Package>(route);
         }
 
@@ -95,7 +95,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(packageName, nameof(packageName));
 
             var route = ApiUrls.PackageRestoreOrg(org, packageType, packageName);
-            
+
             return ApiConnection.Post(route);
         }
         #endregion

--- a/Octokit/Clients/PullRequestReviewCommentReactionsClient.cs
+++ b/Octokit/Clients/PullRequestReviewCommentReactionsClient.cs
@@ -110,7 +110,7 @@ namespace Octokit
         /// <summary>
         /// Deletes a reaction for a specified Pull Request comment
         /// </summary>
-        /// <remarks>https://docs.github.com/en/rest/reactions#delete-a-pull-request-comment-reaction</remarks>
+        /// <remarks>https://docs.github.com/rest/reactions#delete-a-pull-request-comment-reaction</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="commentId">The comment id</param>
@@ -128,7 +128,7 @@ namespace Octokit
         /// <summary>
         /// Deletes a reaction for a specified Pull Request comment
         /// </summary>
-        /// <remarks>https://docs.github.com/en/rest/reactions#delete-a-pull-request-comment-reaction</remarks>
+        /// <remarks>https://docs.github.com/rest/reactions#delete-a-pull-request-comment-reaction</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="commentId">The comment id</param>
         /// <param name="reactionId">The reaction id</param>

--- a/Octokit/Clients/ReleasesClient.cs
+++ b/Octokit/Clients/ReleasesClient.cs
@@ -24,7 +24,7 @@ namespace Octokit
         /// Generates a <see cref="GeneratedReleaseNotes"/>s for the specified repository with auto generated notes.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/releases/releases#generate-release-notes-content-for-a-release">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/rest/releases/releases#generate-release-notes-content-for-a-release">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
@@ -45,7 +45,7 @@ namespace Octokit
         /// Generates a <see cref="GeneratedReleaseNotes"/>s for the specified repository with auto generated notes.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/releases/releases#generate-release-notes-content-for-a-release">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/rest/releases/releases#generate-release-notes-content-for-a-release">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="data">The request for generating release notes</param>

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -211,7 +211,7 @@ namespace Octokit
         /// Checks if vulnerability alerts are enabled for the specified repository.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/reference/repos#check-if-vulnerability-alerts-are-enabled-for-a-repository">API documentation</a> for more information.
+        /// See the <a href="https://docs.github.com/rest/reference/repos#check-if-vulnerability-alerts-are-enabled-for-a-repository">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The current owner of the repository</param>
         /// <param name="name">The name of the repository</param>
@@ -307,7 +307,7 @@ namespace Octokit
         /// </remarks>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>.</returns>        
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>.</returns>
         [ManualRoute("GET", "/repositories")]
         public Task<IReadOnlyList<Repository>> GetAllPublic()
         {
@@ -749,7 +749,7 @@ namespace Octokit
         /// Gets all topics for the specified repository ID.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
+        /// See the <a href="https://docs.github.com/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
@@ -768,7 +768,7 @@ namespace Octokit
         /// Gets all topics for the specified repository ID.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
+        /// See the <a href="https://docs.github.com/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <returns>All topics associated with the repository.</returns>
@@ -783,7 +783,7 @@ namespace Octokit
         /// Gets all topics for the specified owner and repository name.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
+        /// See the <a href="https://docs.github.com/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
@@ -806,7 +806,7 @@ namespace Octokit
         /// Gets all topics for the specified owner and repository name.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
+        /// See the <a href="https://docs.github.com/rest/reference/repos#get-all-repository-topics">API documentation</a> for more details
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
@@ -822,7 +822,7 @@ namespace Octokit
         /// Replaces all topics for the specified repository.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/reference/repos#replace-all-repository-topics">API documentation</a> for more details
+        /// See the <a href="https://docs.github.com/rest/reference/repos#replace-all-repository-topics">API documentation</a> for more details
         ///
         /// This is a replacement operation; it is not additive. To clear repository topics, for example, you could specify an empty list of topics here.
         /// </remarks>
@@ -847,7 +847,7 @@ namespace Octokit
         /// Replaces all topics for the specified repository.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/reference/repos#replace-all-repository-topics">API documentation</a> for more details
+        /// See the <a href="https://docs.github.com/rest/reference/repos#replace-all-repository-topics">API documentation</a> for more details
         ///
         /// This is a replacement operation; it is not additive. To clear repository topics, for example, you could specify an empty list of topics here.
         /// </remarks>

--- a/Octokit/Exceptions/SecondaryRateLimitExceededException.cs
+++ b/Octokit/Exceptions/SecondaryRateLimitExceededException.cs
@@ -12,7 +12,7 @@ namespace Octokit
     /// This occurs when GitHub perceives misuse of the API. You may get this if
     /// you are polling heavily, creating content rapidly or making concurrent requests.
     /// </para>
-    /// <para>See https://docs.github.com/en/rest/overview/resources-in-the-rest-api#secondary-rate-limits for more details.</para>
+    /// <para>See https://docs.github.com/rest/overview/resources-in-the-rest-api#secondary-rate-limits for more details.</para>
     /// </summary>
     [Serializable]
     [SuppressMessage("Microsoft.Design", "CA1032:ImplementStandardExceptionConstructors",

--- a/Octokit/GitHubClient.cs
+++ b/Octokit/GitHubClient.cs
@@ -230,7 +230,7 @@ namespace Octokit
         /// Access GitHub's Pacakges API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API documentation for more information: https://docs.github.com/en/rest/packages
+        /// Refer to the API documentation for more information: https://docs.github.com/rest/packages
         /// </remarks>
         public IPackagesClient Packages { get; private set; }
 

--- a/Octokit/IGitHubClient.cs
+++ b/Octokit/IGitHubClient.cs
@@ -91,7 +91,7 @@ namespace Octokit
         /// Access GitHub's Pacakges API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API documentation for more information: https://docs.github.com/en/rest/packages
+        /// Refer to the API documentation for more information: https://docs.github.com/rest/packages
         /// </remarks>
         IPackagesClient Packages { get; }
 

--- a/Octokit/Models/Request/GenerateReleaseNotesRequest.cs
+++ b/Octokit/Models/Request/GenerateReleaseNotesRequest.cs
@@ -7,7 +7,7 @@ namespace Octokit
     /// Used to generate release notes for a given tag.
     /// </summary>
     /// <remarks>
-    /// API: https://docs.github.com/en/rest/releases/releases#generate-release-notes-content-for-a-release
+    /// API: https://docs.github.com/rest/releases/releases#generate-release-notes-content-for-a-release
     /// </remarks>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class GenerateReleaseNotesRequest

--- a/Octokit/Models/Response/GeneratedReleaseNotes.cs
+++ b/Octokit/Models/Response/GeneratedReleaseNotes.cs
@@ -7,7 +7,7 @@ namespace Octokit
     /// Used to retrieve generated release notes.
     /// </summary>
     /// <remarks>
-    /// API: https://docs.github.com/en/rest/releases/releases#generate-release-notes-content-for-a-release
+    /// API: https://docs.github.com/rest/releases/releases#generate-release-notes-content-for-a-release
     /// The generated release notes are not saved anywhere.
     /// They are intended to be generated and used when creating a new release.
     /// </remarks>


### PR DESCRIPTION
Supports #2474 

* Updates vs code settings file to stop format on save
* Removes `/en` from the existing docs.github.com links