### PR TITLE
Splitting out the misc client into separate clients as per current documentation

### DIFF
--- a/Octokit.Reactive/Clients/IObservableEmojiClient.cs
+++ b/Octokit.Reactive/Clients/IObservableEmojiClient.cs
@@ -1,7 +1,6 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿using System;
 
-namespace Octokit
+namespace Octokit.Reactive
 {
     /// <summary>
     /// A client for GitHub's Emojis APIs.
@@ -9,14 +8,13 @@ namespace Octokit
     /// <remarks>
     /// See the <a href="https://docs.github.com/rest/emojis">Emojis API documentation</a> for more details.
     /// </remarks>
-    public interface IEmojisClient
+    public interface IObservableEmojisClient
     {
         /// <summary>
         /// Gets all the emojis available to use on GitHub.
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>An <see cref="IReadOnlyDictionary{TKey,TValue}"/> of emoji and their URI.</returns>
-        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
-        Task<IReadOnlyList<Emoji>> GetAllEmojis();
+        /// <returns>An <see cref="IObservable{Emoji}"/> of emoji and their URI.</returns>
+        IObservable<Emoji> GetAllEmojis();
     }
 }

--- a/Octokit.Reactive/Clients/IObservableGitIgnoreClient.cs
+++ b/Octokit.Reactive/Clients/IObservableGitIgnoreClient.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace Octokit.Reactive
+{
+    /// <summary>
+    /// A client for GitHub's gitignore APIs.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://docs.github.com/rest/gitignore">GitIgnore API documentation</a> for more details.
+    /// </remarks>
+    public interface IObservableGitIgnoreClient
+    {
+        /// <summary>
+        /// List all templates available to pass as an option when creating a repository.
+        /// </summary>
+        /// <returns>An observable list of gitignore template names.</returns>
+        IObservable<string> GetAllGitIgnoreTemplates();
+
+        /// <summary>
+        /// Retrieves the source for a single GitIgnore template
+        /// </summary>
+        /// <param name="templateName">Returns the template source for the given template</param>
+        IObservable<GitIgnoreTemplate> GetGitIgnoreTemplate(string templateName);
+    }
+}

--- a/Octokit.Reactive/Clients/IObservableLicensesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableLicensesClient.cs
@@ -1,0 +1,35 @@
+﻿using System;
+
+namespace Octokit.Reactive
+{
+    /// <summary>
+    /// A client for GitHub's licenses APIs.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://docs.github.com/rest/licenses">Licenses API documentation</a> for more details.
+    /// </remarks>
+    public interface IObservableLicensesClient
+    {
+        /// <summary>
+        /// Returns a list of the licenses shown in the license picker on GitHub.com. This is not a comprehensive
+        /// list of all possible OSS licenses.
+        /// </summary>
+        /// <returns>A list of licenses available on the site</returns>
+        IObservable<LicenseMetadata> GetAllLicenses();
+
+        /// <summary>
+        /// Returns a list of the licenses shown in the license picker on GitHub.com. This is not a comprehensive
+        /// list of all possible OSS licenses.
+        /// </summary>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A list of licenses available on the site</returns>
+        IObservable<LicenseMetadata> GetAllLicenses(ApiOptions options);
+
+        /// <summary>
+        /// Retrieves a license based on the license key such as "MIT"
+        /// </summary>
+        /// <param name="key"></param>
+        /// <returns>A <see cref="License" /> that includes the license key, text, and attributes of the license.</returns>
+        IObservable<License> GetLicense(string key);
+    }
+}

--- a/Octokit.Reactive/Clients/IObservableMarkdownClient.cs
+++ b/Octokit.Reactive/Clients/IObservableMarkdownClient.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace Octokit.Reactive
+{
+    /// <summary>
+    /// A client for GitHub's markdown APIs.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://docs.github.com/rest/markdown">Markdown API documentation</a> for more details.
+    /// </remarks>
+    public interface IObservableMarkdownClient
+    {
+        /// <summary>
+        /// Gets the rendered Markdown for an arbitrary markdown document.
+        /// </summary>
+        /// <param name="markdown">An arbitrary Markdown document</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>The rendered Markdown.</returns>
+        IObservable<string> RenderArbitraryMarkdown(NewArbitraryMarkdown markdown);
+
+        /// <summary>
+        /// Gets the rendered Markdown for the specified plain-text Markdown document.
+        /// </summary>
+        /// <param name="markdown">A plain-text Markdown document</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>The rendered Markdown.</returns>
+        IObservable<string> RenderRawMarkdown(string markdown);
+    }
+}

--- a/Octokit.Reactive/Clients/IObservableMetaClient.cs
+++ b/Octokit.Reactive/Clients/IObservableMetaClient.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Octokit.Reactive
+{
+    /// <summary>
+    /// A client for GitHub's meta APIs.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://docs.github.com/rest/meta">Meta API documentation</a> for more details.
+    /// </remarks>
+    public interface IObservableMetaClient
+    {
+        /// <summary>
+        /// Retrieves information about GitHub.com, the service or a GitHub Enterprise installation.
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>An <see cref="Meta"/> containing metadata about the GitHub instance.</returns>
+        IObservable<Meta> GetMetadata();
+    }
+}

--- a/Octokit.Reactive/Clients/IObservableMiscellaneousClient.cs
+++ b/Octokit.Reactive/Clients/IObservableMiscellaneousClient.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Octokit.Reactive
 {
+    [Obsolete("Use individual clients for these methods")]
     public interface IObservableMiscellaneousClient
     {
         /// <summary>
@@ -10,8 +10,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>An <see cref="IObservable{Emoji}"/> of emoji and their URI.</returns>
-        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate",
-            Justification = "Makes a network request")]
+        [Obsolete("This client is being deprecated and will be removed in the future. Use EmojisClient.GetAllEmojis instead.")]
         IObservable<Emoji> GetAllEmojis();
 
         /// <summary>
@@ -20,6 +19,7 @@ namespace Octokit.Reactive
         /// <param name="markdown">An arbitrary Markdown document</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The rendered Markdown.</returns>
+        [Obsolete("This client is being deprecated and will be removed in the future. Use MarkdownClient.RenderArbitraryMarkdown instead.")]
         IObservable<string> RenderArbitraryMarkdown(NewArbitraryMarkdown markdown);
 
         /// <summary>
@@ -28,19 +28,21 @@ namespace Octokit.Reactive
         /// <param name="markdown">A plain-text Markdown document</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The rendered Markdown.</returns>
+        [Obsolete("This client is being deprecated and will be removed in the future. Use MarkdownClient.RenderRawMarkdown instead.")]
         IObservable<string> RenderRawMarkdown(string markdown);
 
         /// <summary>
         /// List all templates available to pass as an option when creating a repository.
         /// </summary>
         /// <returns>An observable list of gitignore template names.</returns>
-        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        [Obsolete("This client is being deprecated and will be removed in the future. Use GitIgnoreClient.GetAllGitIgnoreTemplates instead.")]
         IObservable<string> GetAllGitIgnoreTemplates();
 
         /// <summary>
         /// Retrieves the source for a single GitIgnore template
         /// </summary>
         /// <param name="templateName">Returns the template source for the given template</param>
+        [Obsolete("This client is being deprecated and will be removed in the future. Use GitIgnoreClient.GetGitIgnoreTemplate instead.")]
         IObservable<GitIgnoreTemplate> GetGitIgnoreTemplate(string templateName);
 
         /// <summary>
@@ -48,7 +50,7 @@ namespace Octokit.Reactive
         /// list of all possible OSS licenses.
         /// </summary>
         /// <returns>A list of licenses available on the site</returns>
-        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        [Obsolete("This client is being deprecated and will be removed in the future. Use LicensesClient.GetAllLicenses instead.")]
         IObservable<LicenseMetadata> GetAllLicenses();
 
         /// <summary>
@@ -57,6 +59,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>A list of licenses available on the site</returns>
+        [Obsolete("This client is being deprecated and will be removed in the future. Use LicensesClient.GetAllLicenses instead.")]
         IObservable<LicenseMetadata> GetAllLicenses(ApiOptions options);
 
         /// <summary>
@@ -64,6 +67,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="key"></param>
         /// <returns>A <see cref="License" /> that includes the license key, text, and attributes of the license.</returns>
+        [Obsolete("This client is being deprecated and will be removed in the future. Use LicensesClient.GetLicense instead.")]
         IObservable<License> GetLicense(string key);
 
         /// <summary>
@@ -71,7 +75,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>An <see cref="MiscellaneousRateLimit"/> of Rate Limits.</returns>
-        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        [Obsolete("This client is being deprecated and will be removed in the future. Use RateLimitClient.GetRateLimits instead.")]
         IObservable<MiscellaneousRateLimit> GetRateLimits();
 
         /// <summary>
@@ -79,7 +83,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>An <see cref="Meta"/> containing metadata about the GitHub instance.</returns>
-        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        [Obsolete("This client is being deprecated and will be removed in the future. Use MetaClient.GetMetadata instead.")]
         IObservable<Meta> GetMetadata();
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRateLimitClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRateLimitClient.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Octokit.Reactive
+{
+    /// <summary>
+    /// A client for GitHub's rate-limit APIs.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://docs.github.com/rest/rate-limit">Rate-Limit API documentation</a> for more details.
+    /// </remarks>
+    public interface IObservableRateLimitClient
+    {
+        /// <summary>
+        /// Gets API Rate Limits (API service rather than header info).
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>An <see cref="MiscellaneousRateLimit"/> of Rate Limits.</returns>
+        IObservable<MiscellaneousRateLimit> GetRateLimits();
+    }
+}

--- a/Octokit.Reactive/Clients/ObservableEmojiClient.cs
+++ b/Octokit.Reactive/Clients/ObservableEmojiClient.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+
+namespace Octokit.Reactive
+{
+    /// <summary>
+    /// A client for GitHub's Emojis APIs.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://docs.github.com/rest/emojis">Emojis API documentation</a> for more details.
+    /// </remarks>
+    public class ObservableEmojisClient : IObservableEmojisClient
+    {
+        private readonly IEmojisClient _client;
+
+        public ObservableEmojisClient(IGitHubClient client)
+        {
+            Ensure.ArgumentNotNull(client, nameof(client));
+
+            _client = client.Emojis;
+        }
+
+        /// <summary>
+        /// Gets all the emojis available to use on GitHub.
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>An <see cref="IObservable{Emoji}"/> of emoji and their URI.</returns>
+        public IObservable<Emoji> GetAllEmojis()
+        {
+            return _client.GetAllEmojis().ToObservable().SelectMany(e => e);
+        }
+    }
+}

--- a/Octokit.Reactive/Clients/ObservableGitIgnoreClient.cs
+++ b/Octokit.Reactive/Clients/ObservableGitIgnoreClient.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+
+namespace Octokit.Reactive
+{
+    /// <summary>
+    /// A client for GitHub's gitignore APIs.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://docs.github.com/rest/gitignore">GitIgnore API documentation</a> for more details.
+    /// </remarks>
+    public class ObservableGitIgnoreClient : IObservableGitIgnoreClient
+    {
+        private readonly IGitIgnoreClient _client;
+
+        public ObservableGitIgnoreClient(IGitHubClient client)
+        {
+            Ensure.ArgumentNotNull(client, nameof(client));
+
+            _client = client.GitIgnore;
+        }
+
+        /// <summary>
+        /// List all templates available to pass as an option when creating a repository.
+        /// </summary>
+        /// <returns>An observable list of gitignore template names.</returns>
+        public IObservable<string> GetAllGitIgnoreTemplates()
+        {
+            return _client.GetAllGitIgnoreTemplates().ToObservable().SelectMany(t => t);
+        }
+
+        /// <summary>
+        /// Retrieves the source for a single GitIgnore template
+        /// </summary>
+        /// <param name="templateName">Returns the template source for the given template</param>
+        public IObservable<GitIgnoreTemplate> GetGitIgnoreTemplate(string templateName)
+        {
+            return _client.GetGitIgnoreTemplate(templateName).ToObservable();
+        }
+    }
+}

--- a/Octokit.Reactive/Clients/ObservableLicensesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableLicensesClient.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+
+namespace Octokit.Reactive
+{
+    /// <summary>
+    /// A client for GitHub's licenses APIs.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://docs.github.com/rest/licenses">Licenses API documentation</a> for more details.
+    /// </remarks>
+    public class ObservableLicensesClient : IObservableLicensesClient
+    {
+        private readonly ILicensesClient _client;
+
+        public ObservableLicensesClient(IGitHubClient client)
+        {
+            Ensure.ArgumentNotNull(client, nameof(client));
+
+            _client = client.Licenses;
+        }
+
+        /// <summary>
+        /// Returns a list of the licenses shown in the license picker on GitHub.com. This is not a comprehensive
+        /// list of all possible OSS licenses.
+        /// </summary>
+        /// <returns>A list of licenses available on the site</returns>
+        public IObservable<LicenseMetadata> GetAllLicenses()
+        {
+            return GetAllLicenses(ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Returns a list of the licenses shown in the license picker on GitHub.com. This is not a comprehensive
+        /// list of all possible OSS licenses.
+        /// </summary>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A list of licenses available on the site</returns>
+        public IObservable<LicenseMetadata> GetAllLicenses(ApiOptions options)
+        {
+            return _client.GetAllLicenses(options).ToObservable().SelectMany(l => l);
+        }
+
+        /// <summary>
+        /// Retrieves a license based on the license key such as "MIT"
+        /// </summary>
+        /// <param name="key"></param>
+        /// <returns>A <see cref="License" /> that includes the license key, text, and attributes of the license.</returns>
+        public IObservable<License> GetLicense(string key)
+        {
+            return _client.GetLicense(key).ToObservable();
+        }
+    }
+}

--- a/Octokit.Reactive/Clients/ObservableMarkdownClient.cs
+++ b/Octokit.Reactive/Clients/ObservableMarkdownClient.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+
+namespace Octokit.Reactive
+{
+    /// <summary>
+    /// A client for GitHub's markdown APIs.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://docs.github.com/rest/markdown">Markdown API documentation</a> for more details.
+    /// </remarks>
+    public class ObservableMarkdownClient : IObservableMarkdownClient
+    {
+        private readonly IMarkdownClient _client;
+
+        public ObservableMarkdownClient(IGitHubClient client)
+        {
+            Ensure.ArgumentNotNull(client, nameof(client));
+
+            _client = client.Markdown;
+        }
+
+        /// <summary>
+        /// Gets the rendered Markdown for an arbitrary markdown document.
+        /// </summary>
+        /// <param name="markdown">An arbitrary Markdown document</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>The rendered Markdown.</returns>
+        public IObservable<string> RenderArbitraryMarkdown(NewArbitraryMarkdown markdown)
+        {
+            return _client.RenderArbitraryMarkdown(markdown).ToObservable();
+        }
+
+        /// <summary>
+        /// Gets the rendered Markdown for the specified plain-text Markdown document.
+        /// </summary>
+        /// <param name="markdown">A plain-text Markdown document</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>The rendered Markdown.</returns>
+        public IObservable<string> RenderRawMarkdown(string markdown)
+        {
+            return _client.RenderRawMarkdown(markdown).ToObservable();
+        }
+    }
+}

--- a/Octokit.Reactive/Clients/ObservableMetaClient.cs
+++ b/Octokit.Reactive/Clients/ObservableMetaClient.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+
+namespace Octokit.Reactive
+{
+    /// <summary>
+    /// A client for GitHub's meta APIs.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://docs.github.com/rest/meta">Meta API documentation</a> for more details.
+    /// </remarks>
+    public class ObservableMetaClient : IObservableMetaClient
+    {
+        private readonly IMetaClient _client;
+
+        public ObservableMetaClient(IGitHubClient client)
+        {
+            Ensure.ArgumentNotNull(client, nameof(client));
+
+            _client = client.Meta;
+        }
+
+        /// <summary>
+        /// Retrieves information about GitHub.com, the service or a GitHub Enterprise installation.
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>An <see cref="Meta"/> containing metadata about the GitHub instance.</returns>
+        public IObservable<Meta> GetMetadata()
+        {
+            return _client.GetMetadata().ToObservable();
+        }
+    }
+}

--- a/Octokit.Reactive/Clients/ObservableMiscellaneousClient.cs
+++ b/Octokit.Reactive/Clients/ObservableMiscellaneousClient.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 
 namespace Octokit.Reactive
 {
+    [Obsolete("Use individual clients available on the GitHubClient for these methods")]
     public class ObservableMiscellaneousClient : IObservableMiscellaneousClient
     {
         readonly IMiscellaneousClient _client;
@@ -21,6 +21,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>An <see cref="IObservable{Emoji}"/> of emoji and their URI.</returns>
+        [Obsolete("This client is being deprecated and will be removed in the future. Use EmojisClient.GetAllEmojis instead.")]
         public IObservable<Emoji> GetAllEmojis()
         {
             return _client.GetAllEmojis().ToObservable().SelectMany(e => e);
@@ -32,6 +33,7 @@ namespace Octokit.Reactive
         /// <param name="markdown">An arbitrary Markdown document</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The rendered Markdown.</returns>
+        [Obsolete("This client is being deprecated and will be removed in the future. Use MarkdownClient.RenderArbitraryMarkdown instead.")]
         public IObservable<string> RenderArbitraryMarkdown(NewArbitraryMarkdown markdown)
         {
             return _client.RenderArbitraryMarkdown(markdown).ToObservable();
@@ -43,6 +45,7 @@ namespace Octokit.Reactive
         /// <param name="markdown">A plain-text Markdown document</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The rendered Markdown.</returns>
+        [Obsolete("This client is being deprecated and will be removed in the future. Use MarkdownClient.RenderRawMarkdown instead.")]
         public IObservable<string> RenderRawMarkdown(string markdown)
         {
             return _client.RenderRawMarkdown(markdown).ToObservable();
@@ -52,6 +55,7 @@ namespace Octokit.Reactive
         /// List all templates available to pass as an option when creating a repository.
         /// </summary>
         /// <returns>An observable list of gitignore template names.</returns>
+        [Obsolete("This client is being deprecated and will be removed in the future. Use GitIgnoreClient.GetAllGitIgnoreTemplates instead.")]
         public IObservable<string> GetAllGitIgnoreTemplates()
         {
             return _client.GetAllGitIgnoreTemplates().ToObservable().SelectMany(t => t);
@@ -61,6 +65,7 @@ namespace Octokit.Reactive
         /// Retrieves the source for a single GitIgnore template
         /// </summary>
         /// <param name="templateName">Returns the template source for the given template</param>
+        [Obsolete("This client is being deprecated and will be removed in the future. Use GitIgnoreClient.GetGitIgnoreTemplate instead.")]
         public IObservable<GitIgnoreTemplate> GetGitIgnoreTemplate(string templateName)
         {
             return _client.GetGitIgnoreTemplate(templateName).ToObservable();
@@ -71,6 +76,7 @@ namespace Octokit.Reactive
         /// list of all possible OSS licenses.
         /// </summary>
         /// <returns>A list of licenses available on the site</returns>
+        [Obsolete("This client is being deprecated and will be removed in the future. Use LicensesClient.GetAllLicenses instead.")]
         public IObservable<LicenseMetadata> GetAllLicenses()
         {
             return GetAllLicenses(ApiOptions.None);
@@ -82,6 +88,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>A list of licenses available on the site</returns>
+        [Obsolete("This client is being deprecated and will be removed in the future. Use LicensesClient.GetAllLicenses instead.")]
         public IObservable<LicenseMetadata> GetAllLicenses(ApiOptions options)
         {
             return _client.GetAllLicenses(options).ToObservable().SelectMany(l => l);
@@ -92,6 +99,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="key"></param>
         /// <returns>A <see cref="License" /> that includes the license key, text, and attributes of the license.</returns>
+        [Obsolete("This client is being deprecated and will be removed in the future. Use LicensesClient.GetLicense instead.")]
         public IObservable<License> GetLicense(string key)
         {
             return _client.GetLicense(key).ToObservable();
@@ -102,7 +110,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>An <see cref="MiscellaneousRateLimit"/> of Rate Limits.</returns>
-        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        [Obsolete("This client is being deprecated and will be removed in the future. Use RateLimitClient.GetRateLimits instead.")]
         public IObservable<MiscellaneousRateLimit> GetRateLimits()
         {
             return _client.GetRateLimits().ToObservable();
@@ -113,7 +121,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>An <see cref="Meta"/> containing metadata about the GitHub instance.</returns>
-        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        [Obsolete("This client is being deprecated and will be removed in the future. Use MetaClient.GetMetadata instead.")]
         public IObservable<Meta> GetMetadata()
         {
             return _client.GetMetadata().ToObservable();

--- a/Octokit.Reactive/Clients/ObservableRateLimitClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRateLimitClient.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+
+namespace Octokit.Reactive
+{
+    /// <summary>
+    /// A client for GitHub's rate-limit APIs.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://docs.github.com/rest/rate-limit">Rate-Limit API documentation</a> for more details.
+    /// </remarks>
+    public class ObservableRateLimitClient : IObservableRateLimitClient
+    {
+        private readonly IRateLimitClient _client;
+
+        public ObservableRateLimitClient(IGitHubClient client)
+        {
+            Ensure.ArgumentNotNull(client, nameof(client));
+
+            _client = client.RateLimit;
+        }
+
+        /// <summary>
+        /// Gets API Rate Limits (API service rather than header info).
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>An <see cref="MiscellaneousRateLimit"/> of Rate Limits.</returns>
+        public IObservable<MiscellaneousRateLimit> GetRateLimits()
+        {
+            return _client.GetRateLimits().ToObservable();
+        }
+    }
+}

--- a/Octokit.Reactive/IObservableGitHubClient.cs
+++ b/Octokit.Reactive/IObservableGitHubClient.cs
@@ -35,5 +35,11 @@ namespace Octokit.Reactive
         IObservableReactionsClient Reaction { get; }
         IObservableChecksClient Check { get; }
         IObservablePackagesClient Packages{ get; }
+        IObservableEmojisClient Emojis { get; }
+        IObservableMarkdownClient Markdown { get; }
+        IObservableGitIgnoreClient GitIgnore { get; }
+        IObservableLicensesClient Licenses { get; }
+        IObservableRateLimitClient RateLimit { get; }
+        IObservableMetaClient Meta { get; }
     }
 }

--- a/Octokit.Reactive/ObservableGitHubClient.cs
+++ b/Octokit.Reactive/ObservableGitHubClient.cs
@@ -50,6 +50,12 @@ namespace Octokit.Reactive
             Reaction = new ObservableReactionsClient(gitHubClient);
             Check = new ObservableChecksClient(gitHubClient);
             Packages = new ObservablePackagesClient(gitHubClient);
+            Emojis = new ObservableEmojisClient(gitHubClient);
+            Markdown = new ObservableMarkdownClient(gitHubClient);
+            GitIgnore = new ObservableGitIgnoreClient(gitHubClient);
+            Licenses = new ObservableLicensesClient(gitHubClient);
+            RateLimit = new ObservableRateLimitClient(gitHubClient);
+            Meta = new ObservableMetaClient(gitHubClient);
         }
 
         public IConnection Connection
@@ -90,6 +96,12 @@ namespace Octokit.Reactive
         public IObservableReactionsClient Reaction { get; private set; }
         public IObservableChecksClient Check { get; private set; }
         public IObservablePackagesClient Packages { get; private set; }
+        public IObservableEmojisClient Emojis { get; private set; }
+        public IObservableMarkdownClient Markdown { get; private set; }
+        public IObservableGitIgnoreClient GitIgnore { get; private set; }
+        public IObservableLicensesClient Licenses { get; private set; }
+        public IObservableRateLimitClient RateLimit { get; private set; }
+        public IObservableMetaClient Meta { get; private set; }
 
         /// <summary>
         /// Gets the latest API Info - this will be null if no API calls have been made

--- a/Octokit.Tests.Integration/Clients/EmojisClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/EmojisClientTests.cs
@@ -1,0 +1,18 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace Octokit.Tests.Integration.Clients
+{
+    public class EmojisClientTests
+    {
+        [IntegrationTest]
+        public async Task GetsAllTheEmojis()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var emojis = await github.Emojis.GetAllEmojis();
+
+            Assert.True(emojis.Count > 1);
+        }
+    }
+}

--- a/Octokit.Tests.Integration/Clients/GitIgnoreClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/GitIgnoreClientTests.cs
@@ -1,0 +1,18 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace Octokit.Tests.Integration.Clients
+{
+    public class GitIgnoreClientTests
+    {
+        [IntegrationTest]
+        public async Task ReturnsListOfGitIgnoreTemplates()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var result = await github.GitIgnore.GetAllGitIgnoreTemplates();
+
+            Assert.True(result.Count > 2);
+        }
+    }
+}

--- a/Octokit.Tests.Integration/Clients/LicensesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/LicensesClientTests.cs
@@ -1,0 +1,85 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace Octokit.Tests.Integration.Clients
+{
+    public class LicensesClientTests
+    {
+        public class TheGetLicensesMethod
+        {
+            [IntegrationTest]
+            public async Task CanRetrieveListOfLicenses()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var result = await github.Licenses.GetAllLicenses();
+
+                Assert.True(result.Count > 2);
+                Assert.Contains(result, license => license.Key == "mit");
+            }
+
+            [IntegrationTest]
+            public async Task CanRetrieveListOfLicensesWithPagination()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 5,
+                };
+
+                var result = await github.Licenses.GetAllLicenses(options);
+
+                Assert.Equal(5, result.Count);
+            }
+
+            [IntegrationTest]
+            public async Task CanRetrieveDistinctListOfLicensesBasedOnPageStart()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1
+                };
+
+                var firstPage = await github.Licenses.GetAllLicenses(startOptions);
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondPage = await github.Licenses.GetAllLicenses(skipStartOptions);
+
+                Assert.NotEqual(firstPage[0].Key, secondPage[0].Key);
+            }
+        }
+
+        public class TheGetLicenseMethod
+        {
+            [IntegrationTest]
+            public async Task CanRetrieveListOfLicenses()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var result = await github.Licenses.GetLicense("mit");
+
+                Assert.Equal("mit", result.Key);
+                Assert.Equal("MIT License", result.Name);
+            }
+
+            [IntegrationTest]
+            public async Task ReportsErrorWhenInvalidLicenseProvided()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                await Assert.ThrowsAsync<NotFoundException>(() => github.Licenses.GetLicense("purple-monkey-dishwasher"));
+            }
+        }
+    }
+}

--- a/Octokit.Tests.Integration/Clients/MarkdownClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/MarkdownClientTests.cs
@@ -1,0 +1,18 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace Octokit.Tests.Integration.Clients
+{
+    public class MarkdownClientTests
+    {
+        [IntegrationTest]
+        public async Task CanRenderGitHubFlavoredMarkdown()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var result = await github.Markdown.RenderRawMarkdown("This is\r\n a **test**");
+
+            Assert.Equal("<p>This is\na <strong>test</strong></p>\n", result);
+        }
+    }
+}

--- a/Octokit.Tests.Integration/Clients/MetaClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/MetaClientTests.cs
@@ -1,0 +1,26 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace Octokit.Tests.Integration.Clients
+{
+    public class MetaClientTests
+    {
+        public class TheGetMetadataMethod
+        {
+            [IntegrationTest]
+            public async Task CanRetrieveMetadata()
+            {
+                var github = Helper.GetAnonymousClient();
+
+                var result = await github.Meta.GetMetadata();
+
+                Assert.True(result.VerifiablePasswordAuthentication);
+                Assert.NotEmpty(result.GitHubServicesSha);
+                Assert.True(result.Hooks.Count > 0);
+                Assert.True(result.Git.Count > 0);
+                Assert.True(result.Pages.Count > 0);
+                Assert.True(result.Importer.Count > 0);
+            }
+        }
+    }
+}

--- a/Octokit.Tests.Integration/Clients/RateLimitClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RateLimitClientTests.cs
@@ -1,0 +1,37 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace Octokit.Tests.Integration.Clients
+{
+    public class RateLimitClientTests
+    {
+        [IntegrationTest]
+        public async Task CanRetrieveResourceRateLimits()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var result = await github.RateLimit.GetRateLimits();
+
+            // Test the core limits
+            Assert.True(result.Resources.Core.Limit > 0);
+            Assert.True(result.Resources.Core.Remaining > -1);
+            Assert.True(result.Resources.Core.Remaining <= result.Resources.Core.Limit);
+            Assert.True(result.Resources.Core.ResetAsUtcEpochSeconds > 0);
+            Assert.NotEqual(default, result.Resources.Core.Reset);
+
+            // Test the search limits
+            Assert.True(result.Resources.Search.Limit > 0);
+            Assert.True(result.Resources.Search.Remaining > -1);
+            Assert.True(result.Resources.Search.Remaining <= result.Resources.Search.Limit);
+            Assert.True(result.Resources.Search.ResetAsUtcEpochSeconds > 0);
+            Assert.NotEqual(default, result.Resources.Search.Reset);
+
+            // Test the depreciated rate limits
+            Assert.True(result.Rate.Limit > 0);
+            Assert.True(result.Rate.Remaining > -1);
+            Assert.True(result.Rate.Remaining <= result.Rate.Limit);
+            Assert.True(result.Resources.Search.ResetAsUtcEpochSeconds > 0);
+            Assert.NotEqual(default, result.Resources.Search.Reset);
+        }
+    }
+}

--- a/Octokit.Tests/Clients/EmojisClientTests.cs
+++ b/Octokit.Tests/Clients/EmojisClientTests.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NSubstitute;
+using Xunit;
+
+namespace Octokit.Tests.Clients
+{
+    public class EmojisClientTests
+    {
+        public class TheGetEmojisMethod
+        {
+            [Fact]
+            public async Task RequestsTheEmojiEndpoint()
+            {
+                IReadOnlyList<Emoji> response = new List<Emoji>
+                {
+                    { new Emoji("foo", "http://example.com/foo.gif") },
+                    { new Emoji("bar", "http://example.com/bar.gif") }
+                };
+
+                var apiConnection = Substitute.For<IApiConnection>();
+                apiConnection.GetAll<Emoji>(Args.Uri)
+                          .Returns(Task.FromResult(response));
+
+                var client = new EmojisClient(apiConnection);
+
+                var emojis = await client.GetAllEmojis();
+
+                Assert.Equal(2, emojis.Count);
+                Assert.Equal("foo", emojis[0].Name);
+                apiConnection.Received()
+                    .GetAll<Emoji>(Arg.Is<Uri>(u => u.ToString() == "emojis"));
+            }
+        }
+
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(() => new EmojisClient(null));
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Clients/LicensesClientTests.cs
+++ b/Octokit.Tests/Clients/LicensesClientTests.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using NSubstitute;
+using Xunit;
+
+namespace Octokit.Tests.Clients
+{
+    public class LicensesClientTests
+    {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(() => new LicensesClient(null));
+            }
+        }
+
+        public class TheGetAllLicensesMethod
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var client = new LicensesClient(Substitute.For<IApiConnection>());
+
+                Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllLicenses(null));
+            }
+
+            [Fact]
+            public async Task RequestsTheLicensesEndpoint()
+            {
+                IReadOnlyList<LicenseMetadata> response = new ReadOnlyCollection<LicenseMetadata>(new List<LicenseMetadata>()
+                {
+                    new LicenseMetadata("foo1", "node-id-1", "foo2", "something", "http://example.com/foo1",  true),
+                    new LicenseMetadata("bar1", "node-id-1", "bar2", "something else", "http://example.com/bar1", false)
+                });
+
+                var connection = Substitute.For<IApiConnection>();
+                connection.GetAll<LicenseMetadata>(Arg.Is<Uri>(u => u.ToString() == "licenses"), Args.ApiOptions)
+                    .Returns(Task.FromResult(response));
+                var client = new LicensesClient(connection);
+
+                var licenses = await client.GetAllLicenses();
+
+                Assert.Equal(2, licenses.Count);
+                Assert.Equal("foo1", licenses[0].Key);
+                Assert.Equal("foo2", licenses[0].Name);
+                Assert.Equal("http://example.com/foo1", licenses[0].Url);
+                Assert.Equal("bar1", licenses[1].Key);
+                Assert.Equal("bar2", licenses[1].Name);
+                Assert.Equal("http://example.com/bar1", licenses[1].Url);
+                connection.Received()
+                    .GetAll<LicenseMetadata>(Arg.Is<Uri>(u => u.ToString() == "licenses"), Args.ApiOptions);
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Clients/MarkdownClientTests.cs
+++ b/Octokit.Tests/Clients/MarkdownClientTests.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Threading.Tasks;
+using NSubstitute;
+using Xunit;
+
+namespace Octokit.Tests.Clients
+{
+    public class MarkdownClientTests
+    {
+        public class TheRenderRawMarkdownMethod
+        {
+            [Fact]
+            public async Task RequestsTheRawMarkdownEndpoint()
+            {
+                var markdown = "**Test**";
+                var response = "<strong>Test</strong>";
+                var apiConnection = Substitute.For<IApiConnection>();
+                apiConnection.Post<string>(
+                        Arg.Is<Uri>(u => u.ToString() == "markdown/raw"),
+                        markdown,
+                        "text/html",
+                        "text/plain")
+                    .Returns(Task.FromResult(response));
+                var client = new MarkdownClient(apiConnection);
+
+                var html = await client.RenderRawMarkdown(markdown);
+
+                Assert.Equal("<strong>Test</strong>", html);
+                apiConnection.Received()
+                    .Post<string>(Arg.Is<Uri>(u => u.ToString() == "markdown/raw"),
+                    markdown,
+                    "text/html",
+                    "text/plain");
+            }
+        }
+        public class TheRenderArbitraryMarkdownMethod
+        {
+            [Fact]
+            public async Task RequestsTheMarkdownEndpoint()
+            {
+                var response = "<strong>Test</strong>";
+
+                var payload = new NewArbitraryMarkdown("testMarkdown", "gfm", "testContext");
+
+                var apiConnection = Substitute.For<IApiConnection>();
+                apiConnection.Post<string>(Args.Uri, payload, "text/html", "text/plain")
+                    .Returns(Task.FromResult(response));
+
+                var client = new MarkdownClient(apiConnection);
+
+                var html = await client.RenderArbitraryMarkdown(payload);
+                Assert.Equal("<strong>Test</strong>", html);
+                apiConnection.Received()
+                    .Post<string>(Arg.Is<Uri>(u => u.ToString() == "markdown"),
+                    payload,
+                    "text/html",
+                    "text/plain");
+            }
+        }
+
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(() => new MiscellaneousClient(null));
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Clients/MetaClientTests.cs
+++ b/Octokit.Tests/Clients/MetaClientTests.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Threading.Tasks;
+using NSubstitute;
+using Xunit;
+
+namespace Octokit.Tests.Clients
+{
+    public class MetaClientTests
+    {
+        public class TheGetMetadataMethod
+        {
+            [Fact]
+            public async Task RequestsTheMetadataEndpoint()
+            {
+                var meta = new Meta(
+                     false,
+                     "12345ABCDE",
+                     new[] { "1.1.1.1/24", "1.1.1.2/24" },
+                     new[] { "1.1.2.1/24", "1.1.2.2/24" },
+                     new[] { "1.1.3.1/24", "1.1.3.2/24" },
+                     new[] { "1.1.4.1", "1.1.4.2" }
+                 );
+
+                var apiConnection = Substitute.For<IApiConnection>();
+                apiConnection.Get<Meta>(Arg.Is<Uri>(u => u.ToString() == "meta")).Returns(Task.FromResult(meta));
+                var client = new MetaClient(apiConnection);
+
+                var result = await client.GetMetadata();
+
+                Assert.False(result.VerifiablePasswordAuthentication);
+                Assert.Equal("12345ABCDE", result.GitHubServicesSha);
+                Assert.Equal(result.Hooks, new[] { "1.1.1.1/24", "1.1.1.2/24" });
+                Assert.Equal(result.Git, new[] { "1.1.2.1/24", "1.1.2.2/24" });
+                Assert.Equal(result.Pages, new[] { "1.1.3.1/24", "1.1.3.2/24" });
+                Assert.Equal(result.Importer, new[] { "1.1.4.1", "1.1.4.2" });
+
+                apiConnection.Received()
+                    .Get<Meta>(Arg.Is<Uri>(u => u.ToString() == "meta"));
+            }
+        }
+
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(() => new MetaClient(null));
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Clients/MiscellaneousClientTests.cs
+++ b/Octokit.Tests/Clients/MiscellaneousClientTests.cs
@@ -219,33 +219,4 @@ namespace Octokit.Tests.Clients
             }
         }
     }
-
-    public class EmojisClientTests
-    {
-        public class TheGetEmojisMethod
-        {
-            [Fact]
-            public async Task RequestsTheEmojiEndpoint()
-            {
-                IReadOnlyList<Emoji> response = new List<Emoji>
-                {
-                    { new Emoji("foo", "http://example.com/foo.gif") },
-                    { new Emoji("bar", "http://example.com/bar.gif") }
-                };
-
-                var apiConnection = Substitute.For<IApiConnection>();
-                apiConnection.GetAll<Emoji>(Args.Uri)
-                          .Returns(Task.FromResult(response));
-
-                var client = new EmojisClient(apiConnection);
-
-                var emojis = await client.GetAllEmojis();
-
-                Assert.Equal(2, emojis.Count);
-                Assert.Equal("foo", emojis[0].Name);
-                apiConnection.Received()
-                    .GetAll<Emoji>(Arg.Is<Uri>(u => u.ToString() == "emojis"));
-            }
-        }
-    }
 }

--- a/Octokit.Tests/Clients/MiscellaneousClientTests.cs
+++ b/Octokit.Tests/Clients/MiscellaneousClientTests.cs
@@ -219,4 +219,33 @@ namespace Octokit.Tests.Clients
             }
         }
     }
+
+    public class EmojisClientTests
+    {
+        public class TheGetEmojisMethod
+        {
+            [Fact]
+            public async Task RequestsTheEmojiEndpoint()
+            {
+                IReadOnlyList<Emoji> response = new List<Emoji>
+                {
+                    { new Emoji("foo", "http://example.com/foo.gif") },
+                    { new Emoji("bar", "http://example.com/bar.gif") }
+                };
+
+                var apiConnection = Substitute.For<IApiConnection>();
+                apiConnection.GetAll<Emoji>(Args.Uri)
+                          .Returns(Task.FromResult(response));
+
+                var client = new EmojisClient(apiConnection);
+
+                var emojis = await client.GetAllEmojis();
+
+                Assert.Equal(2, emojis.Count);
+                Assert.Equal("foo", emojis[0].Name);
+                apiConnection.Received()
+                    .GetAll<Emoji>(Arg.Is<Uri>(u => u.ToString() == "emojis"));
+            }
+        }
+    }
 }

--- a/Octokit.Tests/Clients/RateLimitClientTests.cs
+++ b/Octokit.Tests/Clients/RateLimitClientTests.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Threading.Tasks;
+using NSubstitute;
+using Xunit;
+using System.Globalization;
+
+namespace Octokit.Tests.Clients
+{
+    public class RateLimitClientTests
+    {
+        public class TheGetResourceRateLimitsMethod
+        {
+            [Fact]
+            public async Task RequestsTheResourceRateLimitEndpoint()
+            {
+                var rateLimit = new MiscellaneousRateLimit(
+                     new ResourceRateLimit(
+                         new RateLimit(5000, 4999, 1372700873),
+                         new RateLimit(30, 18, 1372700873)
+                     ),
+                     new RateLimit(100, 75, 1372700873)
+                 );
+                var apiConnection = Substitute.For<IApiConnection>();
+                apiConnection.Get<MiscellaneousRateLimit>(Arg.Is<Uri>(u => u.ToString() == "rate_limit")).Returns(Task.FromResult(rateLimit));
+
+                var client = new RateLimitClient(apiConnection);
+
+                var result = await client.GetRateLimits();
+
+                // Test the core limits
+                Assert.Equal(5000, result.Resources.Core.Limit);
+                Assert.Equal(4999, result.Resources.Core.Remaining);
+                Assert.Equal(1372700873, result.Resources.Core.ResetAsUtcEpochSeconds);
+                var expectedReset = DateTimeOffset.ParseExact(
+                    "Mon 01 Jul 2013 5:47:53 PM -00:00",
+                    "ddd dd MMM yyyy h:mm:ss tt zzz",
+                    CultureInfo.InvariantCulture);
+                Assert.Equal(expectedReset, result.Resources.Core.Reset);
+
+                // Test the search limits
+                Assert.Equal(30, result.Resources.Search.Limit);
+                Assert.Equal(18, result.Resources.Search.Remaining);
+                Assert.Equal(1372700873, result.Resources.Search.ResetAsUtcEpochSeconds);
+                expectedReset = DateTimeOffset.ParseExact(
+                    "Mon 01 Jul 2013 5:47:53 PM -00:00",
+                    "ddd dd MMM yyyy h:mm:ss tt zzz",
+                    CultureInfo.InvariantCulture);
+                Assert.Equal(expectedReset, result.Resources.Search.Reset);
+
+                // Test the depreciated rate limits
+                Assert.Equal(100, result.Rate.Limit);
+                Assert.Equal(75, result.Rate.Remaining);
+                Assert.Equal(1372700873, result.Rate.ResetAsUtcEpochSeconds);
+                expectedReset = DateTimeOffset.ParseExact(
+                    "Mon 01 Jul 2013 5:47:53 PM -00:00",
+                    "ddd dd MMM yyyy h:mm:ss tt zzz",
+                    CultureInfo.InvariantCulture);
+                Assert.Equal(expectedReset, result.Rate.Reset);
+
+                apiConnection.Received()
+                    .Get<MiscellaneousRateLimit>(Arg.Is<Uri>(u => u.ToString() == "rate_limit"));
+            }
+        }
+
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(() => new RateLimitClient(null));
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Reactive/ObservableEmojiClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableEmojiClientTests.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using NSubstitute;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Reactive
+{
+    public class ObservableEmojiClientTests
+    {
+        public class TheGetAllEmojisMethod
+        {
+            [Fact]
+            public void CallsIntoClient()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableEmojisClient(gitHubClient);
+
+                client.GetAllEmojis();
+
+                gitHubClient.Emojis.Received(1).GetAllEmojis();
+            }
+        }
+
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(() => new ObservableEmojisClient((IGitHubClient)null));
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Reactive/ObservableGitIgnoreClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableGitIgnoreClientTests.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using NSubstitute;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Reactive
+{
+    public class ObservableGitIgnoreClientTests
+    {
+        public class TheGetAllGitIgnoreTemplatesMethod
+        {
+            [Fact]
+            public void CallsIntoClient()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableGitIgnoreClient(gitHubClient);
+
+                client.GetAllGitIgnoreTemplates();
+
+                gitHubClient.GitIgnore.Received(1).GetAllGitIgnoreTemplates();
+            }
+        }
+
+        public class TheGetGitIgnoreTemplate
+        {
+            [Fact]
+            public void CallsIntoClient()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableGitIgnoreClient(gitHubClient);
+
+                client.GetGitIgnoreTemplate("template");
+
+                gitHubClient.GitIgnore.Received(1).GetGitIgnoreTemplate("template");
+            }
+        }
+
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(() => new ObservableGitIgnoreClient((IGitHubClient)null));
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Reactive/ObservableLicensesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableLicensesClientTests.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using NSubstitute;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Reactive
+{
+    public class ObservableLicensesClientTests
+    {
+        public class TheGetAllLicensesMethod
+        {
+            [Fact]
+            public void CallsIntoClient()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableLicensesClient(gitHubClient);
+
+                client.GetAllLicenses();
+
+                gitHubClient.Licenses.Received(1).GetAllLicenses(Args.ApiOptions);
+            }
+        }
+
+        public class TheGetLicenseMethod
+        {
+            [Fact]
+            public void CallsIntoClient()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableLicensesClient(gitHubClient);
+
+                client.GetLicense("key");
+
+                gitHubClient.Licenses.Received(1).GetLicense("key");
+            }
+        }
+
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(() => new ObservableLicensesClient((IGitHubClient)null));
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Reactive/ObservableMarkdownClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableMarkdownClientTests.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using NSubstitute;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Reactive
+{
+    public class ObservableMarkdownClientTests
+    {
+        public class TheRenderArbitraryMarkdownMethod
+        {
+            [Fact]
+            public void CallsIntoClient()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableMarkdownClient(gitHubClient);
+
+                client.RenderArbitraryMarkdown(new NewArbitraryMarkdown("# test"));
+
+                gitHubClient.Markdown.Received(1).RenderArbitraryMarkdown(Arg.Is<NewArbitraryMarkdown>(a => a.Text == "# test"));
+            }
+        }
+
+        public class TheRenderRawMarkdownMethod
+        {
+            [Fact]
+            public void CallsIntoClient()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableMarkdownClient(gitHubClient);
+
+                client.RenderRawMarkdown("# test");
+
+                gitHubClient.Markdown.Received(1).RenderRawMarkdown("# test");
+            }
+        }
+
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(() => new ObservableMarkdownClient((IGitHubClient)null));
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Reactive/ObservableMetaClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableMetaClientTests.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using NSubstitute;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Reactive
+{
+    public class ObservableMetaClientTests
+    {
+        public class TheGetMetadataMethod
+        {
+            [Fact]
+            public void CallsIntoClient()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableMetaClient(gitHubClient);
+
+                client.GetMetadata();
+
+                gitHubClient.Meta.Received(1).GetMetadata();
+            }
+        }
+
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(() => new ObservableMetaClient((IGitHubClient)null));
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Reactive/ObservableRateLimitClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRateLimitClientTests.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using NSubstitute;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Reactive
+{
+    public class ObservableRateLimitClientTests
+    {
+        public class TheGetRateLimitsMethod
+        {
+            [Fact]
+            public void CallsIntoClient()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRateLimitClient(gitHubClient);
+
+                client.GetRateLimits();
+
+                gitHubClient.RateLimit.Received(1).GetRateLimits();
+            }
+        }
+
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(() => new ObservableRateLimitClient((IGitHubClient)null));
+            }
+        }
+    }
+}

--- a/Octokit/Clients/EmojisClient.cs
+++ b/Octokit/Clients/EmojisClient.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Octokit
+{
+    /// <summary>
+    /// A client for GitHub's Emojis APIs.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://docs.github.com/rest/emojis">Emojis API documentation</a> for more details.
+    /// </remarks>
+    public class EmojisClient : ApiClient, IEmojisClient
+    {
+        /// <summary>
+        ///     Initializes a new GitHub emojis API client.
+        /// </summary>
+        /// <param name="apiConnection">An API connection.</param>
+        public EmojisClient(IApiConnection apiConnection)
+            : base(apiConnection)
+        {
+        }
+
+        /// <summary>
+        /// Gets all the emojis available to use on GitHub.
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>An <see cref="IReadOnlyDictionary{TKey,TValue}"/> of emoji and their URI.</returns>
+        [ManualRoute("GET", "/emojis")]
+        public Task<IReadOnlyList<Emoji>> GetAllEmojis()
+        {
+            return ApiConnection.GetAll<Emoji>(ApiUrls.Emojis());
+        }
+    }
+}

--- a/Octokit/Clients/GitIgnoreClient.cs
+++ b/Octokit/Clients/GitIgnoreClient.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Octokit
+{
+    /// <summary>
+    /// A client for GitHub's gitignore APIs.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://docs.github.com/rest/gitignore">GitIgnore API documentation</a> for more details.
+    /// </remarks>
+    public class GitIgnoreClient : ApiClient, IGitIgnoreClient
+    {
+        /// <summary>
+        ///     Initializes a new GitHub gitignore API client.
+        /// </summary>
+        /// <param name="apiConnection">An API connection.</param>
+        public GitIgnoreClient(IApiConnection apiConnection)
+            : base(apiConnection)
+        {
+        }
+
+        /// <summary>
+        /// List all templates available to pass as an option when creating a repository.
+        /// </summary>
+        /// <returns>A list of template names</returns>
+        [ManualRoute("GET", "/gitignore/templates")]
+        public Task<IReadOnlyList<string>> GetAllGitIgnoreTemplates()
+        {
+            return ApiConnection.GetAll<string>(ApiUrls.GitIgnoreTemplates());
+        }
+
+        /// <summary>
+        /// Retrieves the source for a single GitIgnore template
+        /// </summary>
+        /// <param name="templateName"></param>
+        /// <returns>A template and its source</returns>
+        [ManualRoute("GET", "/gitignore/templates/{name}")]
+        public Task<GitIgnoreTemplate> GetGitIgnoreTemplate(string templateName)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(templateName, nameof(templateName));
+
+            return ApiConnection.Get<GitIgnoreTemplate>(ApiUrls.GitIgnoreTemplates(templateName));
+        }
+    }
+}

--- a/Octokit/Clients/IEmojisClient.cs
+++ b/Octokit/Clients/IEmojisClient.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Octokit
+{
+    /// <summary>
+    /// A client for GitHub's Emojis APIs.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://docs.github.com/rest/emojis">Emojis API documentation</a> for more details.
+    /// </remarks>
+    public interface IEmojisClient
+    {
+        /// <summary>
+        /// Gets all the emojis available to use on GitHub.
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>An <see cref="IReadOnlyDictionary{TKey,TValue}"/> of emoji and their URI.</returns>
+        Task<IReadOnlyList<Emoji>> GetAllEmojis();
+    }
+}

--- a/Octokit/Clients/IGitIgnoreClient.cs
+++ b/Octokit/Clients/IGitIgnoreClient.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Octokit
+{
+    /// <summary>
+    /// A client for GitHub's gitignore APIs.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://docs.github.com/rest/gitignore">GitIgnore API documentation</a> for more details.
+    /// </remarks>
+    public interface IGitIgnoreClient
+    {
+        /// <summary>
+        /// List all templates available to pass as an option when creating a repository.
+        /// </summary>
+        /// <returns>A list of template names</returns>
+        Task<IReadOnlyList<string>> GetAllGitIgnoreTemplates();
+
+
+        /// <summary>
+        /// Retrieves the source for a single GitIgnore template
+        /// </summary>
+        /// <param name="templateName"></param>
+        /// <returns>A template and its source</returns>
+        Task<GitIgnoreTemplate> GetGitIgnoreTemplate(string templateName);
+    }
+}

--- a/Octokit/Clients/IGitIgnoreClient.cs
+++ b/Octokit/Clients/IGitIgnoreClient.cs
@@ -15,6 +15,7 @@ namespace Octokit
         /// List all templates available to pass as an option when creating a repository.
         /// </summary>
         /// <returns>A list of template names</returns>
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<string>> GetAllGitIgnoreTemplates();
 
 

--- a/Octokit/Clients/ILicensesClient.cs
+++ b/Octokit/Clients/ILicensesClient.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Octokit
+{
+    /// <summary>
+    /// A client for GitHub's licenses APIs.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://docs.github.com/rest/licenses">Licenses API documentation</a> for more details.
+    /// </remarks>
+    public interface ILicensesClient
+    {
+        /// <summary>
+        /// Returns a list of the licenses shown in the license picker on GitHub.com. This is not a comprehensive
+        /// list of all possible OSS licenses.
+        /// </summary>
+        /// <returns>A list of licenses available on the site</returns>
+        Task<IReadOnlyList<LicenseMetadata>> GetAllLicenses();
+
+        /// <summary>
+        /// Returns a list of the licenses shown in the license picker on GitHub.com. This is not a comprehensive
+        /// list of all possible OSS licenses.
+        /// </summary>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A list of licenses available on the site</returns>
+        Task<IReadOnlyList<LicenseMetadata>> GetAllLicenses(ApiOptions options);
+
+        /// <summary>
+        /// Retrieves a license based on the license key such as "mit"
+        /// </summary>
+        /// <param name="key"></param>
+        /// <returns>A <see cref="License" /> that includes the license key, text, and attributes of the license.</returns>
+        Task<License> GetLicense(string key);
+    }
+}

--- a/Octokit/Clients/IMarkdownClient.cs
+++ b/Octokit/Clients/IMarkdownClient.cs
@@ -1,0 +1,29 @@
+﻿using System.Threading.Tasks;
+
+namespace Octokit
+{
+    /// <summary>
+    /// A client for GitHub's markdown APIs.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://docs.github.com/rest/markdown">Markdown API documentation</a> for more details.
+    /// </remarks>
+    public interface IMarkdownClient
+    {
+        /// <summary>
+        /// Gets the rendered Markdown for the specified plain-text Markdown document.
+        /// </summary>
+        /// <param name="markdown">A plain-text Markdown document</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>The rendered Markdown.</returns>
+        Task<string> RenderArbitraryMarkdown(NewArbitraryMarkdown markdown);
+
+        /// <summary>
+        /// Gets the rendered Markdown for an arbitrary markdown document.
+        /// </summary>
+        /// <param name="markdown">An arbitrary Markdown document</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>The rendered Markdown.</returns>
+        Task<string> RenderRawMarkdown(string markdown);
+    }
+}

--- a/Octokit/Clients/IMetaClient.cs
+++ b/Octokit/Clients/IMetaClient.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading.Tasks;
+
+namespace Octokit
+{
+    /// <summary>
+    /// A client for GitHub's meta APIs.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://docs.github.com/rest/meta">Meta API documentation</a> for more details.
+    /// </remarks>
+    public interface IMetaClient
+    {
+        /// <summary>
+        /// Retrieves information about GitHub.com, the service or a GitHub Enterprise installation.
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>An <see cref="Meta"/> containing metadata about the GitHub instance.</returns>
+        Task<Meta> GetMetadata();
+    }
+}

--- a/Octokit/Clients/IMiscellaneousClient.cs
+++ b/Octokit/Clients/IMiscellaneousClient.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
+using System;
 
 namespace Octokit
 {
@@ -17,8 +17,8 @@ namespace Octokit
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>An <see cref="IReadOnlyDictionary{TKey,TValue}"/> of emoji and their URI.</returns>
-        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
+        [Obsolete("This client is being deprecated and will be removed in the future. Use EmojisClient.GetAllEmojis instead.")]
         Task<IReadOnlyList<Emoji>> GetAllEmojis();
 
         /// <summary>
@@ -27,6 +27,7 @@ namespace Octokit
         /// <param name="markdown">A plain-text Markdown document</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The rendered Markdown.</returns>
+        [Obsolete("This client is being deprecated and will be removed in the future. Use MarkdownClient.RenderRawMarkdown instead.")]
         Task<string> RenderRawMarkdown(string markdown);
 
         /// <summary>
@@ -35,13 +36,13 @@ namespace Octokit
         /// <param name="markdown">An arbitrary Markdown document</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The rendered Markdown.</returns>
+        [Obsolete("This client is being deprecated and will be removed in the future. Use MarkdownClient.RenderArbitraryMarkdown instead.")] 
         Task<string> RenderArbitraryMarkdown(NewArbitraryMarkdown markdown);
 
         /// <summary>
         /// List all templates available to pass as an option when creating a repository.
         /// </summary>
         /// <returns>A list of template names</returns>
-        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<string>> GetAllGitIgnoreTemplates();
 
@@ -50,6 +51,7 @@ namespace Octokit
         /// </summary>
         /// <param name="templateName"></param>
         /// <returns>A template and its source</returns>
+        [Obsolete("This client is being deprecated and will be removed in the future. Use GitIgnoreClient.GetAllGitIgnoreTemplates instead.")] 
         Task<GitIgnoreTemplate> GetGitIgnoreTemplate(string templateName);
 
         /// <summary>
@@ -57,7 +59,7 @@ namespace Octokit
         /// list of all possible OSS licenses.
         /// </summary>
         /// <returns>A list of licenses available on the site</returns>
-        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        [Obsolete("This client is being deprecated and will be removed in the future. Use GitIgnoreClient.GetGitIgnoreTemplate instead.")]
         Task<IReadOnlyList<LicenseMetadata>> GetAllLicenses();
 
         /// <summary>
@@ -66,6 +68,7 @@ namespace Octokit
         /// </summary>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>A list of licenses available on the site</returns>
+        [Obsolete("This client is being deprecated and will be removed in the future. Use LicensesClient.GetAllLicenses instead.")] 
         Task<IReadOnlyList<LicenseMetadata>> GetAllLicenses(ApiOptions options);
 
         /// <summary>
@@ -73,6 +76,7 @@ namespace Octokit
         /// </summary>
         /// <param name="key">The license identifier to look for</param>
         /// <returns>A <see cref="License" /> that includes the license key, text, and attributes of the license.</returns>
+        [Obsolete("This client is being deprecated and will be removed in the future. Use LicensesClient.GetLicense instead.")] 
         Task<License> GetLicense(string key);
 
         /// <summary>
@@ -80,7 +84,7 @@ namespace Octokit
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>An <see cref="MiscellaneousRateLimit"/> of Rate Limits.</returns>
-        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        [Obsolete("This client is being deprecated and will be removed in the future. Use RateLimitClient.GetRateLimits instead.")] 
         Task<MiscellaneousRateLimit> GetRateLimits();
 
         /// <summary>
@@ -88,7 +92,7 @@ namespace Octokit
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>An <see cref="Meta"/> containing metadata about the GitHub instance.</returns>
-        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        [Obsolete("This client is being deprecated and will be removed in the future. Use MetaClient.GetMetadata instead.")] 
         Task<Meta> GetMetadata();
     }
 }

--- a/Octokit/Clients/IMiscellaneousClient.cs
+++ b/Octokit/Clients/IMiscellaneousClient.cs
@@ -10,6 +10,7 @@ namespace Octokit
     /// <remarks>
     /// See the <a href="http://developer.github.com/v3/misc/">Miscellaneous API documentation</a> for more details.
     /// </remarks>
+    [Obsolete("Use individual clients available on the GitHubClient for these methods")]
     public interface IMiscellaneousClient
     {
         /// <summary>
@@ -44,6 +45,7 @@ namespace Octokit
         /// </summary>
         /// <returns>A list of template names</returns>
         [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
+        [Obsolete("This client is being deprecated and will be removed in the future. Use GitIgnoreClient.GetAllGitIgnoreTemplates instead.")]
         Task<IReadOnlyList<string>> GetAllGitIgnoreTemplates();
 
         /// <summary>

--- a/Octokit/Clients/IRateLimitClient.cs
+++ b/Octokit/Clients/IRateLimitClient.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading.Tasks;
+
+namespace Octokit
+{
+    /// <summary>
+    /// A client for GitHub's rate-limit APIs.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://docs.github.com/rest/rate-limit">Rate-Limit API documentation</a> for more details.
+    /// </remarks>
+    public interface IRateLimitClient
+    {
+        /// <summary>
+        /// Gets API Rate Limits (API service rather than header info).
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>An <see cref="MiscellaneousRateLimit"/> of Rate Limits.</returns>
+        Task<MiscellaneousRateLimit> GetRateLimits();
+    }
+}

--- a/Octokit/Clients/LicensesClient.cs
+++ b/Octokit/Clients/LicensesClient.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Octokit
+{
+    /// <summary>
+    /// A client for GitHub's licenses APIs.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://docs.github.com/rest/licenses">Licenses API documentation</a> for more details.
+    /// </remarks>
+    public class LicensesClient : ApiClient, ILicensesClient
+    {
+        /// <summary>
+        ///     Initializes a new GitHub gitignore API client.
+        /// </summary>
+        /// <param name="apiConnection">An API connection.</param>
+        public LicensesClient(IApiConnection apiConnection)
+            : base(apiConnection)
+        {
+        }
+
+        /// <summary>
+        /// Returns a list of the licenses shown in the license picker on GitHub.com. This is not a comprehensive
+        /// list of all possible OSS licenses.
+        /// </summary>
+        /// <returns>A list of licenses available on the site</returns>
+        [ManualRoute("GET", "/licenses")]
+        public Task<IReadOnlyList<LicenseMetadata>> GetAllLicenses()
+        {
+            return GetAllLicenses(ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Returns a list of the licenses shown in the license picker on GitHub.com. This is not a comprehensive
+        /// list of all possible OSS licenses.
+        /// </summary>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A list of licenses available on the site</returns>
+        [ManualRoute("GET", "/licenses")]
+        public Task<IReadOnlyList<LicenseMetadata>> GetAllLicenses(ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<LicenseMetadata>(ApiUrls.Licenses(), options);
+        }
+
+        /// <summary>
+        /// Retrieves a license based on the license key such as "mit"
+        /// </summary>
+        /// <param name="key"></param>
+        /// <returns>A <see cref="License" /> that includes the license key, text, and attributes of the license.</returns>
+        [ManualRoute("GET", "/licenses/{key}")]
+        public Task<License> GetLicense(string key)
+        {
+            return ApiConnection.Get<License>(ApiUrls.Licenses(key));
+        }
+    }
+}

--- a/Octokit/Clients/MarkdownClient.cs
+++ b/Octokit/Clients/MarkdownClient.cs
@@ -1,0 +1,46 @@
+﻿using System.Threading.Tasks;
+
+namespace Octokit
+{
+    /// <summary>
+    /// A client for GitHub's markdown APIs.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://docs.github.com/rest/markdown">Markdown API documentation</a> for more details.
+    /// </remarks>
+    public class MarkdownClient : ApiClient, IMarkdownClient
+    {
+        /// <summary>
+        ///     Initializes a new GitHub markdown API client.
+        /// </summary>
+        /// <param name="apiConnection">An API connection.</param>
+        public MarkdownClient(IApiConnection apiConnection)
+            : base(apiConnection)
+        {
+        }
+
+        /// <summary>
+        /// Gets the rendered Markdown for the specified plain-text Markdown document.
+        /// </summary>
+        /// <param name="markdown">A plain-text Markdown document</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>The rendered Markdown.</returns>
+        [ManualRoute("POST", "/markdown/raw")]
+        public Task<string> RenderRawMarkdown(string markdown)
+        {
+            return ApiConnection.Post<string>(ApiUrls.RawMarkdown(), markdown, "text/html", "text/plain");
+        }
+
+        /// <summary>
+        /// Gets the rendered Markdown for an arbitrary markdown document.
+        /// </summary>
+        /// <param name="markdown">An arbitrary Markdown document</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>The rendered Markdown.</returns>
+        [ManualRoute("POST", "/markdown")]
+        public Task<string> RenderArbitraryMarkdown(NewArbitraryMarkdown markdown)
+        {
+            return ApiConnection.Post<string>(ApiUrls.Markdown(), markdown, "text/html", "text/plain");
+        }
+    }
+}

--- a/Octokit/Clients/MetaClient.cs
+++ b/Octokit/Clients/MetaClient.cs
@@ -1,0 +1,35 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+
+namespace Octokit
+{
+    /// <summary>
+    /// A client for GitHub's meta APIs.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://docs.github.com/rest/meta">Meta API documentation</a> for more details.
+    /// </remarks>
+    public class MetaClient : ApiClient, IMetaClient
+    {
+        /// <summary>
+        ///     Initializes a new GitHub meta API client.
+        /// </summary>
+        /// <param name="apiConnection">An API connection.</param>
+        public MetaClient(IApiConnection apiConnection)
+            : base(apiConnection)
+        {
+        }
+
+        /// <summary>
+        /// Retrieves information about GitHub.com, the service or a GitHub Enterprise installation.
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>An <see cref="Meta"/> containing metadata about the GitHub instance.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        [ManualRoute("GET", "/meta")]
+        public Task<Meta> GetMetadata()
+        {
+            return ApiConnection.Get<Meta>(ApiUrls.Meta());
+        }
+    }
+}

--- a/Octokit/Clients/MiscellaneousClient.cs
+++ b/Octokit/Clients/MiscellaneousClient.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 
 namespace Octokit
@@ -13,6 +12,9 @@ namespace Octokit
     /// </remarks>
     public class MiscellaneousClient : ApiClient, IMiscellaneousClient
     {
+        private readonly IEmojisClient _emojisClient;
+        private readonly IMarkdownClient _markdownClient;
+
         /// <summary>
         ///     Initializes a new GitHub miscellaneous API client.
         /// </summary>
@@ -20,6 +22,8 @@ namespace Octokit
         public MiscellaneousClient(IApiConnection apiConnection)
             : base(apiConnection)
         {
+            _emojisClient = new EmojisClient(apiConnection);
+            _markdownClient = new MarkdownClient(apiConnection);
         }
 
         /// <summary>
@@ -28,9 +32,10 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>An <see cref="IReadOnlyDictionary{TKey,TValue}"/> of emoji and their URI.</returns>
         [ManualRoute("GET", "/emojis")]
+        [Obsolete("This client is being deprecated and will be removed in the future. Use EmojisClient.GetAllEmojis instead.")]
         public Task<IReadOnlyList<Emoji>> GetAllEmojis()
         {
-            return ApiConnection.GetAll<Emoji>(ApiUrls.Emojis());
+            return _emojisClient.GetAllEmojis();
         }
 
         /// <summary>
@@ -40,9 +45,10 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The rendered Markdown.</returns>
         [ManualRoute("POST", "/markdown/raw")]
+        [Obsolete("This client is being deprecated and will be removed in the future. Use MarkdownClient.RenderRawMarkdown instead.")]
         public Task<string> RenderRawMarkdown(string markdown)
         {
-            return ApiConnection.Post<string>(ApiUrls.RawMarkdown(), markdown, "text/html", "text/plain");
+            return _markdownClient.RenderRawMarkdown(markdown);
         }
 
         /// <summary>
@@ -52,9 +58,10 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The rendered Markdown.</returns>
         [ManualRoute("POST", "/markdown")]
+        [Obsolete("This client is being deprecated and will be removed in the future. Use MarkdownClient.RenderArbitraryMarkdown instead.")]
         public Task<string> RenderArbitraryMarkdown(NewArbitraryMarkdown markdown)
         {
-            return ApiConnection.Post<string>(ApiUrls.Markdown(), markdown, "text/html", "text/plain");
+            return _markdownClient.RenderArbitraryMarkdown(markdown);
         }
 
         /// <summary>
@@ -62,6 +69,7 @@ namespace Octokit
         /// </summary>
         /// <returns>A list of template names</returns>
         [ManualRoute("GET", "/gitignore/templates")]
+        [Obsolete("This client is being deprecated and will be removed in the future. Use GitIgnoreClient.GetAllGitIgnoreTemplates instead.")]
         public Task<IReadOnlyList<string>> GetAllGitIgnoreTemplates()
         {
             return ApiConnection.GetAll<string>(ApiUrls.GitIgnoreTemplates());
@@ -73,6 +81,7 @@ namespace Octokit
         /// <param name="templateName"></param>
         /// <returns>A template and its source</returns>
         [ManualRoute("GET", "/gitignore/templates/{name}")]
+        [Obsolete("This client is being deprecated and will be removed in the future. Use GitIgnoreClient.GetGitIgnoreTemplate instead.")]
         public Task<GitIgnoreTemplate> GetGitIgnoreTemplate(string templateName)
         {
             Ensure.ArgumentNotNullOrEmptyString(templateName, nameof(templateName));
@@ -85,6 +94,7 @@ namespace Octokit
         /// list of all possible OSS licenses.
         /// </summary>
         /// <returns>A list of licenses available on the site</returns>
+        [Obsolete("This client is being deprecated and will be removed in the future. Use LicensesClient.GetAllLicenses instead.")]
         [ManualRoute("GET", "/licenses")]
         public Task<IReadOnlyList<LicenseMetadata>> GetAllLicenses()
         {
@@ -98,6 +108,7 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <returns>A list of licenses available on the site</returns>
         [ManualRoute("GET", "/licenses")]
+        [Obsolete("This client is being deprecated and will be removed in the future. Use LicensesClient.GetAllLicenses instead.")]
         public Task<IReadOnlyList<LicenseMetadata>> GetAllLicenses(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -111,6 +122,7 @@ namespace Octokit
         /// <param name="key"></param>
         /// <returns>A <see cref="License" /> that includes the license key, text, and attributes of the license.</returns>
         [ManualRoute("GET", "/licenses/{key}")]
+        [Obsolete("This client is being deprecated and will be removed in the future. Use LicensesClient.GetLicense instead.")]
         public Task<License> GetLicense(string key)
         {
             return ApiConnection.Get<License>(ApiUrls.Licenses(key));
@@ -121,8 +133,8 @@ namespace Octokit
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>An <see cref="MiscellaneousRateLimit"/> of Rate Limits.</returns>
-        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         [ManualRoute("GET", "/rate_limit")]
+        [Obsolete("This client is being deprecated and will be removed in the future. Use RateLimitClient.GetRateLimits instead.")]
         public Task<MiscellaneousRateLimit> GetRateLimits()
         {
             return ApiConnection.Get<MiscellaneousRateLimit>(ApiUrls.RateLimit());
@@ -133,8 +145,8 @@ namespace Octokit
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>An <see cref="Meta"/> containing metadata about the GitHub instance.</returns>
-        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         [ManualRoute("GET", "/meta")]
+        [Obsolete("This client is being deprecated and will be removed in the future. Use MetaClient.GetMetadata instead.")]
         public Task<Meta> GetMetadata()
         {
             return ApiConnection.Get<Meta>(ApiUrls.Meta());

--- a/Octokit/Clients/MiscellaneousClient.cs
+++ b/Octokit/Clients/MiscellaneousClient.cs
@@ -10,10 +10,15 @@ namespace Octokit
     /// <remarks>
     /// See the <a href="http://developer.github.com/v3/misc/">Miscellaneous API documentation</a> for more details.
     /// </remarks>
+    [Obsolete("Use individual clients available on the GitHubClient for these methods")]
     public class MiscellaneousClient : ApiClient, IMiscellaneousClient
     {
         private readonly IEmojisClient _emojisClient;
         private readonly IMarkdownClient _markdownClient;
+        private readonly IGitIgnoreClient _gitIgnoreClient;
+        private readonly ILicensesClient _licensesClient;
+        private readonly IRateLimitClient _rateLimitClient;
+        private readonly IMetaClient _metaClient;
 
         /// <summary>
         ///     Initializes a new GitHub miscellaneous API client.
@@ -24,6 +29,10 @@ namespace Octokit
         {
             _emojisClient = new EmojisClient(apiConnection);
             _markdownClient = new MarkdownClient(apiConnection);
+            _gitIgnoreClient = new GitIgnoreClient(apiConnection);
+            _licensesClient = new LicensesClient(apiConnection);
+            _rateLimitClient = new RateLimitClient(apiConnection);
+            _metaClient = new MetaClient(apiConnection);
         }
 
         /// <summary>
@@ -72,7 +81,7 @@ namespace Octokit
         [Obsolete("This client is being deprecated and will be removed in the future. Use GitIgnoreClient.GetAllGitIgnoreTemplates instead.")]
         public Task<IReadOnlyList<string>> GetAllGitIgnoreTemplates()
         {
-            return ApiConnection.GetAll<string>(ApiUrls.GitIgnoreTemplates());
+            return _gitIgnoreClient.GetAllGitIgnoreTemplates();
         }
 
         /// <summary>
@@ -86,7 +95,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(templateName, nameof(templateName));
 
-            return ApiConnection.Get<GitIgnoreTemplate>(ApiUrls.GitIgnoreTemplates(templateName));
+            return _gitIgnoreClient.GetGitIgnoreTemplate(templateName);
         }
 
         /// <summary>
@@ -98,7 +107,7 @@ namespace Octokit
         [ManualRoute("GET", "/licenses")]
         public Task<IReadOnlyList<LicenseMetadata>> GetAllLicenses()
         {
-            return GetAllLicenses(ApiOptions.None);
+            return _licensesClient.GetAllLicenses();
         }
 
         /// <summary>
@@ -113,7 +122,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNull(options, "options");
 
-            return ApiConnection.GetAll<LicenseMetadata>(ApiUrls.Licenses(), options);
+            return _licensesClient.GetAllLicenses(options);
         }
 
         /// <summary>
@@ -125,7 +134,7 @@ namespace Octokit
         [Obsolete("This client is being deprecated and will be removed in the future. Use LicensesClient.GetLicense instead.")]
         public Task<License> GetLicense(string key)
         {
-            return ApiConnection.Get<License>(ApiUrls.Licenses(key));
+            return _licensesClient.GetLicense(key);
         }
 
         /// <summary>
@@ -137,7 +146,7 @@ namespace Octokit
         [Obsolete("This client is being deprecated and will be removed in the future. Use RateLimitClient.GetRateLimits instead.")]
         public Task<MiscellaneousRateLimit> GetRateLimits()
         {
-            return ApiConnection.Get<MiscellaneousRateLimit>(ApiUrls.RateLimit());
+            return _rateLimitClient.GetRateLimits();
         }
 
         /// <summary>
@@ -149,7 +158,7 @@ namespace Octokit
         [Obsolete("This client is being deprecated and will be removed in the future. Use MetaClient.GetMetadata instead.")]
         public Task<Meta> GetMetadata()
         {
-            return ApiConnection.Get<Meta>(ApiUrls.Meta());
+            return _metaClient.GetMetadata();
         }
     }
 }

--- a/Octokit/Clients/RateLimitClient.cs
+++ b/Octokit/Clients/RateLimitClient.cs
@@ -1,0 +1,35 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+
+namespace Octokit
+{
+    /// <summary>
+    /// A client for GitHub's rate-limit APIs.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://docs.github.com/rest/rate-limit">Rate-Limit API documentation</a> for more details.
+    /// </remarks>
+    public class RateLimitClient : ApiClient, IRateLimitClient
+    {
+        /// <summary>
+        ///     Initializes a new GitHub rate-limit API client.
+        /// </summary>
+        /// <param name="apiConnection">An API connection.</param>
+        public RateLimitClient(IApiConnection apiConnection)
+            : base(apiConnection)
+        {
+        }
+
+        /// <summary>
+        /// Gets API Rate Limits (API service rather than header info).
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>An <see cref="MiscellaneousRateLimit"/> of Rate Limits.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        [ManualRoute("GET", "/rate_limit")]
+        public Task<MiscellaneousRateLimit> GetRateLimits()
+        {
+            return ApiConnection.Get<MiscellaneousRateLimit>(ApiUrls.RateLimit());
+        }
+    }
+}

--- a/Octokit/GitHubClient.cs
+++ b/Octokit/GitHubClient.cs
@@ -96,6 +96,7 @@ namespace Octokit
             var apiConnection = new ApiConnection(connection);
             Activity = new ActivitiesClient(apiConnection);
             Authorization = new AuthorizationsClient(apiConnection);
+            Emojis = new EmojisClient(apiConnection);
             Enterprise = new EnterpriseClient(apiConnection);
             Gist = new GistsClient(apiConnection);
             Git = new GitDatabaseClient(apiConnection);
@@ -185,6 +186,14 @@ namespace Octokit
         /// Refer to the API documentation for more information: https://developer.github.com/v3/activity/
         /// </remarks>
         public IActivitiesClient Activity { get; private set; }
+
+        /// <summary>
+        /// Access GitHub's Emojis API.
+        /// </summary>
+        /// <remarks>
+        /// Refer to the API documentation for more information: https://docs.github.com/rest/emojis
+        /// </remarks>
+        public IEmojisClient Emojis { get; private set; }
 
         /// <summary>
         /// Access GitHub's Issue API.

--- a/Octokit/GitHubClient.cs
+++ b/Octokit/GitHubClient.cs
@@ -96,7 +96,6 @@ namespace Octokit
             var apiConnection = new ApiConnection(connection);
             Activity = new ActivitiesClient(apiConnection);
             Authorization = new AuthorizationsClient(apiConnection);
-            Emojis = new EmojisClient(apiConnection);
             Enterprise = new EnterpriseClient(apiConnection);
             Gist = new GistsClient(apiConnection);
             Git = new GitDatabaseClient(apiConnection);
@@ -113,6 +112,12 @@ namespace Octokit
             Reaction = new ReactionsClient(apiConnection);
             Check = new ChecksClient(apiConnection);
             Packages = new PackagesClient(apiConnection);
+            Emojis = new EmojisClient(apiConnection);
+            Markdown = new MarkdownClient(apiConnection);
+            GitIgnore = new GitIgnoreClient(apiConnection);
+            Licenses = new LicensesClient(apiConnection);
+            RateLimit = new RateLimitClient(apiConnection);
+            Meta = new MetaClient(apiConnection);
         }
 
         /// <summary>
@@ -322,6 +327,46 @@ namespace Octokit
         /// Refer to the API documentation for more information: https://developer.github.com/v3/checks/
         /// </remarks>
         public IChecksClient Check { get; private set; }
+
+        /// <summary>
+        /// Access GitHub's Meta API.
+        /// </summary>
+        /// <remarks>
+        /// Refer to the API documentation for more information: https://docs.github.com/rest/meta
+        /// </remarks>
+        public IMetaClient Meta { get; private set; }
+
+        /// <summary>
+        /// Access GitHub's Rate Limit API
+        /// </summary>
+        /// <remarks>
+        /// Refer to the API documentation for more information: https://docs.github.com/rest/rate-limit
+        /// </remarks>
+        public IRateLimitClient RateLimit { get; private set; }
+
+        /// <summary>
+        /// Access GitHub's Licenses API
+        /// </summary>
+        /// <remarks>
+        /// Refer to the API documentation for more information: https://docs.github.com/rest/licenses
+        /// </remarks>
+        public ILicensesClient Licenses { get; private set; }
+
+        /// <summary>
+        /// Access GitHub's Git Ignore API
+        /// </summary>
+        /// <remarks>
+        /// Refer to the API documentation for more information: https://docs.github.com/rest/gitignore
+        /// </remarks>
+        public IGitIgnoreClient GitIgnore { get; private set; }
+
+        /// <summary>
+        /// Access GitHub's Markdown API
+        /// </summary>
+        /// <remarks>
+        /// Refer to the API documentation for more information: https://docs.github.com/rest/markdown
+        /// </remarks>
+        public IMarkdownClient Markdown { get; private set; }
 
         static Uri FixUpBaseUri(Uri uri)
         {

--- a/Octokit/IGitHubClient.cs
+++ b/Octokit/IGitHubClient.cs
@@ -166,5 +166,46 @@ namespace Octokit
         /// Refer to the API documentation for more information: https://developer.github.com/v3/checks/
         /// </remarks>
         IChecksClient Check { get; }
+
+        /// <summary>
+        /// Access GitHub's Meta API.
+        /// </summary>
+        /// <remarks>
+        /// Refer to the API documentation for more information: https://docs.github.com/rest/meta
+        /// </remarks>
+        IMetaClient Meta { get; }
+
+        /// <summary>
+        /// Access GitHub's Rate Limit API
+        /// </summary>
+        /// <remarks>
+        /// Refer to the API documentation for more information: https://docs.github.com/rest/rate-limit
+        /// </remarks>
+        IRateLimitClient RateLimit { get; }
+        
+        /// <summary>
+        /// Access GitHub's Markdown API
+        /// </summary>
+        /// <remarks>
+        /// Refer to the API documentation for more information: https://docs.github.com/rest/markdown
+        /// </remarks>
+        IMarkdownClient Markdown { get; }
+
+        /// <summary>
+        /// Access GitHub's Git Ignore API
+        /// </summary>
+        /// <remarks>
+        /// Refer to the API documentation for more information: https://docs.github.com/rest/gitignore
+        /// </remarks>
+        IGitIgnoreClient GitIgnore { get; }
+
+        /// <summary>
+        /// Access GitHub's Licenses API
+        /// </summary>
+        /// <remarks>
+        /// Refer to the API documentation for more information: https://docs.github.com/rest/licenses
+        /// </remarks>
+        ILicensesClient Licenses { get; }
+        IEmojisClient Emojis { get; }
     }
 }


### PR DESCRIPTION
Splitting out Miscellaneous client into new clients.

1. Split clients and interfaces
2. Redirect misc client to new interfaces
3. Obsolete methods with descriptions
4. Repeat for Observable
5. Duplicate unit tests
6. Duplicate integration tests