### PR TITLE
Fix deserializing of Emoji types

### DIFF
--- a/Octokit.Tests/Clients/MiscellaneousClientTests.cs
+++ b/Octokit.Tests/Clients/MiscellaneousClientTests.cs
@@ -65,15 +65,15 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task RequestsTheEmojiEndpoint()
             {
-                IReadOnlyList<Emoji> response = new List<Emoji>
+                IDictionary<string, string> response = new Dictionary<string, string>
                 {
-                    { new Emoji("foo", "http://example.com/foo.gif") },
-                    { new Emoji("bar", "http://example.com/bar.gif") }
+                    { "foo", "http://example.com/foo.gif" },
+                    { "bar", "http://example.com/bar.gif" }
                 };
 
                 var apiConnection = Substitute.For<IApiConnection>();
-                apiConnection.GetAll<Emoji>(Args.Uri)
-                          .Returns(Task.FromResult(response));
+                apiConnection.Get<IDictionary<string, string>>(Args.Uri)
+                    .Returns(Task.FromResult(response));
 
                 var client = new MiscellaneousClient(apiConnection);
 
@@ -82,7 +82,7 @@ namespace Octokit.Tests.Clients
                 Assert.Equal(2, emojis.Count);
                 Assert.Equal("foo", emojis[0].Name);
                 apiConnection.Received()
-                    .GetAll<Emoji>(Arg.Is<Uri>(u => u.ToString() == "emojis"));
+                    .Get<IDictionary<string, string>>(Arg.Is<Uri>(u => u.ToString() == "emojis"));
             }
         }
 

--- a/Octokit/Clients/MiscellaneousClient.cs
+++ b/Octokit/Clients/MiscellaneousClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Octokit
@@ -26,11 +27,13 @@ namespace Octokit
         /// Gets all the emojis available to use on GitHub.
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>An <see cref="IReadOnlyDictionary{TKey,TValue}"/> of emoji and their URI.</returns>
+        /// <returns>An <see cref="IReadOnlyList{Emoji}"/> of emoji and their URI.</returns>
         [ManualRoute("GET", "/emojis")]
-        public Task<IReadOnlyList<Emoji>> GetAllEmojis()
+        public async Task<IReadOnlyList<Emoji>> GetAllEmojis()
         {
-            return ApiConnection.GetAll<Emoji>(ApiUrls.Emojis());
+            var result = await ApiConnection.Get<IDictionary<string, string>>(ApiUrls.Emojis());
+
+            return result.Select(x => new Emoji(x.Key, x.Value)).ToList();
         }
 
         /// <summary>

--- a/Octokit/Http/AssignableExtensions.cs
+++ b/Octokit/Http/AssignableExtensions.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Linq;
+
+namespace Octokit
+{
+    public static class AssignableExtensions
+    {
+        /// <summary>
+        /// Determines whether the <paramref name="genericType"/> is assignable from
+        /// <paramref name="givenType"/> taking into account generic definitions
+        /// </summary>
+        public static bool IsAssignableToGenericType(this Type givenType, Type genericType)
+        {
+            if (givenType == null || genericType == null)
+            {
+                return false;
+            }
+
+            return givenType == genericType
+              || givenType.MapsToGenericTypeDefinition(genericType)
+              || givenType.HasInterfaceThatMapsToGenericTypeDefinition(genericType)
+              || givenType.BaseType.IsAssignableToGenericType(genericType);
+        }
+
+        private static bool HasInterfaceThatMapsToGenericTypeDefinition(this Type givenType, Type genericType)
+        {
+            return givenType
+              .GetInterfaces()
+              .Where(it => it.IsGenericType)
+              .Any(it => it.GetGenericTypeDefinition() == genericType);
+        }
+
+        private static bool MapsToGenericTypeDefinition(this Type givenType, Type genericType)
+        {
+            return genericType.IsGenericTypeDefinition
+              && givenType.IsGenericType
+              && givenType.GetGenericTypeDefinition() == genericType;
+        }
+    }
+}

--- a/Octokit/Http/JsonHttpPipeline.cs
+++ b/Octokit/Http/JsonHttpPipeline.cs
@@ -49,7 +49,7 @@ namespace Octokit.Internal
                 // simple json does not support the root node being empty. Will submit a pr but in the mean time....
                 if (!string.IsNullOrEmpty(body) && body != "{}")
                 {
-                    var typeIsDictionary = typeof(IDictionary).IsAssignableFrom(typeof(T));
+                    var typeIsDictionary = typeof(IDictionary).IsAssignableFrom(typeof(T)) || typeof(T).IsAssignableToGenericType(typeof(System.Collections.Generic.IDictionary<,>));
                     var typeIsEnumerable = typeof(IEnumerable).IsAssignableFrom(typeof(T));
                     var responseIsObject = body.StartsWith("{", StringComparison.Ordinal);
 


### PR DESCRIPTION
Adding in assignable extensions to allow us to tell whether a type of IDictionary<T1,T2> which allows us to deserialise an object list to a dictionary. Currently if you use IDictionary<T1,T2> it is not recognised as a dictionary type and the body is wrapped as if it were an array of 1 object.

closes #2576 