### PR TITLE
Use correct methods and URL to generate release notes

### DIFF
--- a/Octokit.Tests/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests/Clients/ReleasesClientTests.cs
@@ -31,7 +31,7 @@ namespace Octokit.Tests.Clients
 
                 await releasesClient.GenerateReleaseNotes("fake", "repo", data);
 
-                client.Received().Post<GeneratedReleaseNotes>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases"),
+                client.Received().Post<GeneratedReleaseNotes>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases/generate-notes"),
                     data,
                     "application/vnd.github.v3");
             }
@@ -45,7 +45,7 @@ namespace Octokit.Tests.Clients
 
                 await releasesClient.GenerateReleaseNotes(1, data);
 
-                client.Received().Post<GeneratedReleaseNotes>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/releases"),
+                client.Received().Post<GeneratedReleaseNotes>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/releases/generate-notes"),
                     data,
                     "application/vnd.github.v3");
             }

--- a/Octokit/Clients/ReleasesClient.cs
+++ b/Octokit/Clients/ReleasesClient.cs
@@ -30,14 +30,14 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="data">The request for generating release notes</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [ManualRoute("GET", "/repos/{owner}/{repo}/releases")]
+        [ManualRoute("POST", "/repos/{owner}/{repo}/releases/generate-notes")]
         public Task<GeneratedReleaseNotes> GenerateReleaseNotes(string owner, string name, GenerateReleaseNotesRequest data)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(data, nameof(data));
 
-            var endpoint = ApiUrls.Releases(owner, name);
+            var endpoint = ApiUrls.ReleasesGenerateNotes(owner, name);
             return ApiConnection.Post<GeneratedReleaseNotes>(endpoint, data, AcceptHeaders.StableVersion);
         }
 
@@ -50,12 +50,12 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="data">The request for generating release notes</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [ManualRoute("GET", "/repos/{owner}/{repo}/releases")]
+        [ManualRoute("POST", "/repositories/{id}/releases/generate-notes")]
         public Task<GeneratedReleaseNotes> GenerateReleaseNotes(long repositoryId, GenerateReleaseNotesRequest data)
         {
             Ensure.ArgumentNotNull(data, nameof(data));
 
-            var endpoint = ApiUrls.Releases(repositoryId);
+            var endpoint = ApiUrls.ReleasesGenerateNotes(repositoryId);
             return ApiConnection.Post<GeneratedReleaseNotes>(endpoint, data, AcceptHeaders.StableVersion);
         }
 

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -192,6 +192,17 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Returns the <see cref="Uri"/> that generates release notes for the specified repository.
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <returns>The <see cref="Uri"/> that generates release notes for the specified repository.</returns>
+        public static Uri ReleasesGenerateNotes(string owner, string name)
+        {
+            return "repos/{0}/{1}/releases/generate-notes".FormatUri(owner, name);
+        }
+
+        /// <summary>
         /// Returns the <see cref="Uri"/> that returns a single release for the specified repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -3439,6 +3450,16 @@ namespace Octokit
         public static Uri Releases(long repositoryId)
         {
             return "repositories/{0}/releases".FormatUri(repositoryId);
+        }
+
+        /// <summary>
+        /// Returns the <see cref="Uri"/> that generates release notes for the specified repository.
+        /// </summary>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <returns>The <see cref="Uri"/> that generates release notes for the specified repository.</returns>
+        public static Uri ReleasesGenerateNotes(long repositoryId)
+        {
+            return "repositories/{0}/releases/generate-notes".FormatUri(repositoryId);
         }
 
         /// <summary>

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -30,18 +30,24 @@ Console.WriteLine("Created release id {0}", result.Id);
 
 Note that the `Draft` flag is used to indicate when a release should be published to the world, whereas the `PreRelease` flag is used to indicate whether a release is unofficial or preview release.
 
-#### Generate release notes
+### Generate release notes
 
-Additionally, you can ask GitHub to generate a name and body before creating a new release.
+GitHub can generate a name and body for a new release [automatically](https://github.blog/2021-10-04-beta-github-releases-improving-release-experience/#introducing-auto-generated-release-notes), based upon merged pull requests.
+[This is an example](https://github.com/MylesBorins/release-notes-test/releases/tag/v2.0.0) of automatically generated text.
 
 ```csharp
-var generationRequest = new GenerateReleaseNotesRequest("v2.0.0");
+var newTag = "v1.5.7";
+var generationRequest = new GenerateReleaseNotesRequest(newTag);
+generationRequest.TargetCommitish = "main"; // Optional, can be a branch, tag, or SHA; defaults to the main branch.
+generationRequest.PreviousTagName = "v1.5.6"; // Optional; default is automagically determined, based on existing tags.
 var releaseNotes = await client.Repository.Release.GenerateReleaseNotes("octokit", "octokit.net", generationRequest);
 
-var newRelease = new NewRelease("v1.0.0");
+var newRelease = new NewRelease(newTag); // Use the same tag as before, because it now appears in generated text.
 newRelease.Name = releaseNotes.Name;
 newRelease.Body = releaseNotes.Body;
 ```
+
+This feature can be customized at the repository level, by following [these instructions](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes).
 
 ### Update
 


### PR DESCRIPTION
Fixes #2589.

I also changed the documentation for `GenerateReleaseNotes`, adding links to relevant GitHub docs, an example of generated text, and clearer example code.
