### PR TITLE
Adding repo allowupdatebranch

### DIFF
--- a/Octokit/Models/Request/RepositoryUpdate.cs
+++ b/Octokit/Models/Request/RepositoryUpdate.cs
@@ -115,7 +115,10 @@ namespace Octokit
         public bool? AllowForking { get; set; }
 
         /// <summary>
-        /// Optional. Get or set whether to always allow a pull request head branch that is behind its base branch to be updated even if it is not required to be up to date before merging, or false otherwise. The default is null (do not update). The default when created is false.
+        /// Optional. Get or set whether to always allow a pull request head branch that is behind its base branch
+        /// to be updated even if it is not required to be up to date before merging, or false otherwise.
+        /// The default is null (do not update). The default when created is false. 
+        /// Available since GitHub Enterprise 3.1 (2021-05-06)
         /// </summary>
         public bool? AllowUpdateBranch { get; set; }
 

--- a/Octokit/Models/Request/RepositoryUpdate.cs
+++ b/Octokit/Models/Request/RepositoryUpdate.cs
@@ -114,6 +114,11 @@ namespace Octokit
         /// </summary>
         public bool? AllowForking { get; set; }
 
+        /// <summary>
+        /// Optional. Get or set whether to always allow a pull request head branch that is behind its base branch to be updated even if it is not required to be up to date before merging, or false otherwise. The default is null (do not update). The default when created is false.
+        /// </summary>
+        public bool? AllowUpdateBranch { get; set; }
+
         internal string DebuggerDisplay => new SimpleJsonSerializer().Serialize(this);
     }
 }

--- a/Octokit/Models/Response/Repository.cs
+++ b/Octokit/Models/Response/Repository.cs
@@ -158,6 +158,8 @@ namespace Octokit
         public RepositoryVisibility? Visibility { get; private set; }
 
         public bool? AllowAutoMerge { get; private set; }
+        
+        public bool? AllowUpdateBranch { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/Repository.cs
+++ b/Octokit/Models/Response/Repository.cs
@@ -17,7 +17,7 @@ namespace Octokit
             Id = id;
         }
 
-        public Repository(string url, string htmlUrl, string cloneUrl, string gitUrl, string sshUrl, string svnUrl, string mirrorUrl, long id, string nodeId, User owner, string name, string fullName, bool isTemplate, string description, string homepage, string language, bool @private, bool fork, int forksCount, int stargazersCount, string defaultBranch, int openIssuesCount, DateTimeOffset? pushedAt, DateTimeOffset createdAt, DateTimeOffset updatedAt, RepositoryPermissions permissions, Repository parent, Repository source, LicenseMetadata license, bool hasIssues, bool hasWiki, bool hasDownloads, bool hasPages, int subscribersCount, long size, bool? allowRebaseMerge, bool? allowSquashMerge, bool? allowMergeCommit, bool archived, int watchersCount, bool? deleteBranchOnMerge, RepositoryVisibility visibility, IEnumerable<string> topics, bool? allowAutoMerge)
+        public Repository(string url, string htmlUrl, string cloneUrl, string gitUrl, string sshUrl, string svnUrl, string mirrorUrl, long id, string nodeId, User owner, string name, string fullName, bool isTemplate, string description, string homepage, string language, bool @private, bool fork, int forksCount, int stargazersCount, string defaultBranch, int openIssuesCount, DateTimeOffset? pushedAt, DateTimeOffset createdAt, DateTimeOffset updatedAt, RepositoryPermissions permissions, Repository parent, Repository source, LicenseMetadata license, bool hasIssues, bool hasWiki, bool hasDownloads, bool hasPages, int subscribersCount, long size, bool? allowRebaseMerge, bool? allowSquashMerge, bool? allowMergeCommit, bool archived, int watchersCount, bool? deleteBranchOnMerge, RepositoryVisibility visibility, IEnumerable<string> topics, bool? allowAutoMerge, bool? allowUpdateBranch)
         {
             Url = url;
             HtmlUrl = htmlUrl;
@@ -65,6 +65,7 @@ namespace Octokit
             DeleteBranchOnMerge = deleteBranchOnMerge;
             Visibility = visibility;
             AllowAutoMerge = allowAutoMerge;
+            AllowUpdateBranch = allowUpdateBranch;
         }
 
         public string Url { get; private set; }


### PR DESCRIPTION
As per https://docs.github.com/en/rest/repos/repos#update-a-repository, there is the following setting:

> `allow_update_branch`  `boolean`
Either `true` to always allow a pull request head branch that is behind its base branch to be updated even if it is not required to be up to date before merging, or false otherwise.
> 
> Default: `false`

- [x] Code change
- [x] Locally tested
- [x] Fix existing Unit/Integration Tests
- [ ] Add new unit/integration tests