### PR TITLE
Remove Microsoft.Bcl.AsyncInterfaces dependency

### DIFF
--- a/Octokit.AsyncPaginationExtension/Octokit.AsyncPaginationExtension.csproj
+++ b/Octokit.AsyncPaginationExtension/Octokit.AsyncPaginationExtension.csproj
@@ -30,10 +30,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Octokit\Octokit.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
I don't believe that this package is required anymore given [this comment](https://www.nuget.org/packages/Microsoft.Bcl.AsyncInterfaces/#readme-body-tab) on its Nuget page:

> This package is not required starting with .NET Standard 2.1 and .NET Core 3.0.

I'd like to test that assumption by running the Actions builds.