### PR TITLE
add islocked filter to SeachIssuesRequest

### DIFF
--- a/Octokit.Tests.Integration/Clients/SearchClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/SearchClientTests.cs
@@ -282,6 +282,28 @@ public class SearchClientTests
     }
 
     [IntegrationTest]
+    public async Task SearchForLockedUnlockedIssues()
+    {
+
+        var lockedIssuesRequest = new SearchIssuesRequest();
+        lockedIssuesRequest.Repos.Add("octokit", "octokit.net");
+        lockedIssuesRequest.Is = new List<IssueIsQualifier> { IssueIsQualifier.Issue, IssueIsQualifier.Locked };
+
+        var lockedIssues = await _gitHubClient.Search.SearchIssues(lockedIssuesRequest);
+
+        var unlockedIssuesRequest = new SearchIssuesRequest();
+
+        unlockedIssuesRequest.Repos.Add("octokit", "octokit.net");
+        unlockedIssuesRequest.Is = new List<IssueIsQualifier> { IssueIsQualifier.Issue, IssueIsQualifier.Unlocked };
+
+
+        var unlockedIssues = await _gitHubClient.Search.SearchIssues(unlockedIssuesRequest);
+
+        Assert.All(lockedIssues.Items, i => Assert.True(i.Locked));
+        Assert.All(unlockedIssues.Items, i => Assert.False(i.Locked));
+    }
+
+    [IntegrationTest]
     public async Task SearchForMergedPullRequests()
     {
         var allRequest = new SearchIssuesRequest();

--- a/Octokit.Tests/Models/SearchIssuesRequestTests.cs
+++ b/Octokit.Tests/Models/SearchIssuesRequestTests.cs
@@ -171,6 +171,17 @@ public class SearchIssuesRequestTests
         }
 
         [Fact]
+        public void HandlesIsLockedUnlockedAttributeCorrectly()
+        {
+            var request = new SearchIssuesRequest("test");
+            Assert.DoesNotContain(request.MergedQualifiers(), x => x.Contains("is:"));
+
+            request.Is = new List<IssueIsQualifier> { IssueIsQualifier.Locked, IssueIsQualifier.Unlocked };
+            Assert.Contains("is:locked", request.MergedQualifiers());
+            Assert.Contains("is:unlocked", request.MergedQualifiers());
+        }
+
+        [Fact]
         public void HandlesStatusAttributeCorrectly()
         {
             var request = new SearchIssuesRequest("test");

--- a/Octokit/Models/Request/SearchIssuesRequest.cs
+++ b/Octokit/Models/Request/SearchIssuesRequest.cs
@@ -489,7 +489,11 @@ namespace Octokit
         [Parameter(Value = "private")]
         Private,
         [Parameter(Value = "public")]
-        Public
+        Public,
+        [Parameter(Value = "locked")]
+        Locked,
+        [Parameter(Value = "unlocked")]
+        Unlocked
     }
 
     public enum IssueNoMetadataQualifier

--- a/docs/search.md
+++ b/docs/search.md
@@ -61,6 +61,14 @@ request.Involves = "terrajobst";
 request.State = ItemState.All;
 // or to just search closed issues
 request.State = ItemState.Closed;
+
+// you can filter by the is qualifier
+// the enum IssueIsQualifier contains the supported values
+// here is how you will can filter with issue and locked
+request.Is = new List<IssueIsQualifier> {
+  IssueIsQualifier.Issue,
+  IssueIsQualifier.Locked
+};
 ```
 
 There's other options available to control how the results are returned:

--- a/docs/search.md
+++ b/docs/search.md
@@ -62,9 +62,9 @@ request.State = ItemState.All;
 // or to just search closed issues
 request.State = ItemState.Closed;
 
-// you can filter by the is qualifier
+// you can filter by the "Is" qualifier
 // the enum IssueIsQualifier contains the supported values
-// here is how you will can filter with issue and locked
+// you can filter for locked issues like this:
 request.Is = new List<IssueIsQualifier> {
   IssueIsQualifier.Issue,
   IssueIsQualifier.Locked


### PR DESCRIPTION

Resolves #2620

----

## Behavior

### Before the change?

* No way to filter issues with locked unlocked status

### After the change?

* Use IssueIsQualifier as Locked and Unlocked to filter

### Other information

* none

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?

- [x] No

### Pull request type

Please add the corresponding label for change this PR introduces:

- Feature/model/API additions: `Type: Feature`

----

