### PR TITLE
Add missing workflow run conclusions

### DIFF
--- a/Octokit/Models/Response/WorkflowRunConclusion.cs
+++ b/Octokit/Models/Response/WorkflowRunConclusion.cs
@@ -18,5 +18,9 @@ namespace Octokit
         ActionRequired,
         [Parameter(Value = "stale")]
         Stale,
+        [Parameter(Value = "startup_failure")]
+        StartupFailure,
+        [Parameter(Value = "skipped")]
+        Skipped,
     }
 }


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #2684

----

## Behavior

### Before the change?

* The property to get a workflow run conclusion throws an exception when trying to get value of the workflow run with the conclusion of `startup_failure` or `skipped`.

### After the change?

* The property returns the workflow run conclusion correctly and doesn't throw an exception.


### Other information

* I've mentioned in the original issue that GitHub documentation doesn't include these values as well, so it will be great if you  pass this information internally to the docs team 😄

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

