### PR TITLE
Correctly Deserialize PullRequestReview Event with State "changes_requested"

### DIFF
--- a/Octokit.Tests/Clients/EventsClientTests.cs
+++ b/Octokit.Tests/Clients/EventsClientTests.cs
@@ -837,6 +837,43 @@ namespace Octokit.Tests.Clients
         }
 
         [Fact]
+        public async Task DeserializesPullRequestReviewEventChangesRequestedCorrectly()
+        {
+            var jsonObj = new JsonObject
+            {
+                { "type", "PullRequestReviewEvent" },
+                {
+                    "payload", new
+                    {
+                        action = "submitted",
+                        review = new {
+                            id = 2626884,
+                            body = "Needs changes!",
+                            state = "changes_requested",
+                            html_url = "https://github.com/baxterthehacker/public-repo/pull/8#pullrequestreview-2626884",
+                        },
+                        pull_request = new
+                        {
+                            title = "PR Title"
+                        }
+                    }
+                }
+            };
+
+            var client = GetTestingEventsClient(jsonObj);
+            var activities = await client.GetAll();
+            Assert.Equal(1, activities.Count);
+
+            var payload = activities.FirstOrDefault().Payload as PullRequestReviewEventPayload;
+            Assert.Equal("submitted", payload.Action);
+            Assert.Equal(2626884, payload.Review.Id);
+            Assert.Equal("Needs changes!", payload.Review.Body);
+            Assert.Equal(PullRequestReviewState.ChangesRequested, payload.Review.State.Value);
+            Assert.Equal("https://github.com/baxterthehacker/public-repo/pull/8#pullrequestreview-2626884", payload.Review.HtmlUrl);
+            Assert.Equal("PR Title", payload.PullRequest.Title);
+        }
+
+        [Fact]
         public async Task DeserializesPullRequestCommentEventCorrectly()
         {
             var jsonObj = new JsonObject

--- a/Octokit/Http/SimpleJsonSerializer.cs
+++ b/Octokit/Http/SimpleJsonSerializer.cs
@@ -134,7 +134,7 @@ namespace Octokit.Internal
                 });
 
                 // If type cache does not contain enum value and has no custom attribute, add it for future loops
-                return cachedEnumsForType.GetOrAdd(value.ToUpper(), v => Enum.Parse(type, value, ignoreCase: true));
+                return cachedEnumsForType.GetOrAdd(value, v => Enum.Parse(type, value, ignoreCase: true));
             }
 
             private string _type;

--- a/Octokit/Http/SimpleJsonSerializer.cs
+++ b/Octokit/Http/SimpleJsonSerializer.cs
@@ -134,7 +134,7 @@ namespace Octokit.Internal
                 });
 
                 // If type cache does not contain enum value and has no custom attribute, add it for future loops
-                return cachedEnumsForType.GetOrAdd(value, v => Enum.Parse(type, value, ignoreCase: true));
+                return cachedEnumsForType.GetOrAdd(value.ToUpper(), v => Enum.Parse(type, value, ignoreCase: true));
             }
 
             private string _type;

--- a/Octokit/Models/Response/PullRequestReview.cs
+++ b/Octokit/Models/Response/PullRequestReview.cs
@@ -87,19 +87,19 @@ namespace Octokit
 
     public enum PullRequestReviewState
     {
-        [Parameter(Value = "APPROVED")]
+        [Parameter(Value = "approved")]
         Approved,
 
-        [Parameter(Value = "CHANGES_REQUESTED")]
+        [Parameter(Value = "changes_requested")]
         ChangesRequested,
 
-        [Parameter(Value = "COMMENTED")]
+        [Parameter(Value = "commented")]
         Commented,
 
-        [Parameter(Value = "DISMISSED")]
+        [Parameter(Value = "dismissed")]
         Dismissed,
 
-        [Parameter(Value = "PENDING")]
+        [Parameter(Value = "pending")]
         Pending
     }
 }


### PR DESCRIPTION
## Behavior

### Before the change?

The following error appears when trying to Deserialize a pull request review webhook event with the state "changes_requested"
```
System.ArgumentException : Value 'changes_requested' is not a valid 'PullRequestReviewState' enum value.
```

### After the change?

Pull Request Review events with "changes_requested" are parsed correctly.

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`

----

