### PR TITLE
[FEAT] Allow users to fetch all commits for two commits comparision

### DIFF
--- a/Octokit.Reactive/Clients/IObservableRepositoryCommitsClients.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryCommitsClients.cs
@@ -63,6 +63,27 @@ namespace Octokit.Reactive
         IObservable<CompareResult> Compare(long repositoryId, string @base, string head);
 
         /// <summary>
+        /// Compare two references in a repository
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="base">The reference to use as the base commit</param>
+        /// <param name="head">The reference to use as the head commit</param>
+        /// <param name="options">Options for changing the API response</param>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "base")]
+        IObservable<CompareResult> Compare(string owner, string name, string @base, string head, ApiOptions options);
+
+        /// <summary>
+        /// Compare two references in a repository
+        /// </summary>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="base">The reference to use as the base commit</param>
+        /// <param name="head">The reference to use as the head commit</param>
+        /// <param name="options">Options for changing the API response</param>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "base")]
+        IObservable<CompareResult> Compare(long repositoryId, string @base, string head, ApiOptions options);
+
+        /// <summary>
         /// Gets all commits for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>

--- a/Octokit.Reactive/Clients/ObservableRepositoryCommitsClients.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryCommitsClients.cs
@@ -111,6 +111,41 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Compare two references in a repository
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="base">The reference to use as the base commit</param>
+        /// <param name="head">The reference to use as the head commit</param>
+        /// <param name="options">Options for changing the API response</param>
+        public IObservable<CompareResult> Compare(string owner, string name, string @base, string head, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+            Ensure.ArgumentNotNullOrEmptyString(@base, "base");
+            Ensure.ArgumentNotNullOrEmptyString(head, nameof(head));
+            Ensure.ArgumentNotNull(options, nameof(options));
+
+            return _commit.Compare(owner, name, @base, head, options).ToObservable();
+        }
+
+        /// <summary>
+        /// Compare two references in a repository
+        /// </summary>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="base">The reference to use as the base commit</param>
+        /// <param name="head">The reference to use as the head commit</param>
+        /// <param name="options">Options for changing the API response</param>
+        public IObservable<CompareResult> Compare(long repositoryId, string @base, string head, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(@base, "base");
+            Ensure.ArgumentNotNullOrEmptyString(head, nameof(head));
+            Ensure.ArgumentNotNull(options, nameof(options));
+
+            return _commit.Compare(repositoryId, @base, head, options).ToObservable();
+        }
+
+        /// <summary>
         /// Gets all commits for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>

--- a/Octokit.Tests.Integration/Clients/RepositoryCommitsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryCommitsClientTests.cs
@@ -297,6 +297,28 @@ public class RepositoryCommitsClientTests
 
             Assert.NotNull(sha1);
         }
+
+        [IntegrationTest]
+        public async Task CanFetchAllCommitsInComparision()
+        {
+            const string @base = "8dcb1db0da7c86596bf1d63631bd335363c64b8c";
+            const string head = "7349ecd6685c370ba84eb13f4c39f75f33";
+
+            var compareResultWithoutOptions = await _fixture.Compare(octokitNetRepositoryId, @base, head);
+            Assert.Equal(250, compareResultWithoutOptions.Commits.Count);
+
+            var compareResult = await _fixture.Compare(octokitNetRepositoryId, @base, head, new ApiOptions { PageSize = 100 });
+            Assert.Equal(534, compareResult.Commits.Count);
+        }
+
+        [IntegrationTest]
+        public async Task CanCompareTheSameCommitWithApiOptions()
+        {
+            const string head = "7349ecd6685c370ba84eb13f4c39f75f33";
+
+            var compareResult = await _fixture.Compare(octokitNetRepositoryId, head, head, new ApiOptions { PageSize = 100 });
+            Assert.Equal(0, compareResult.Commits.Count);
+        }
     }
 
     public class TestsWithNewRepository : IDisposable

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -1186,6 +1186,23 @@ namespace Octokit.Tests.Clients
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Compare("owner", "repo", "base", null));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Compare("owner", "repo", "base", ""));
+
+
+                var options = new ApiOptions();
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Compare(null, "repo", "base", "head", options));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Compare("", "repo", "base", "head", options));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Compare("owner", null, "base", "head", options));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Compare("owner", "", "base", "head", options));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Compare("owner", "repo", null, "head", options));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Compare("owner", "repo", "", "head", options));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Compare("owner", "repo", "base", null, options));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Compare("owner", "repo", "base", "", options));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Compare("owner", "repo", "base", "head", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Compare("owner", "repo", "base", "head", null));
             }
 
             [Fact]

--- a/Octokit/Clients/IRepositoryCommitsClient.cs
+++ b/Octokit/Clients/IRepositoryCommitsClient.cs
@@ -64,6 +64,27 @@ namespace Octokit
         Task<CompareResult> Compare(long repositoryId, string @base, string head);
 
         /// <summary>
+        /// Compare two references in a repository
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="base">The reference to use as the base commit</param>
+        /// <param name="head">The reference to use as the head commit</param>
+        /// <param name="options">Options for changing the API response</param>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "base")]
+        Task<CompareResult> Compare(string owner, string name, string @base, string head, ApiOptions options);
+
+        /// <summary>
+        /// Compare two references in a repository
+        /// </summary>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="base">The reference to use as the base commit</param>
+        /// <param name="head">The reference to use as the head commit</param>
+        /// <param name="options">Options for changing the API response</param>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "base")]
+        Task<CompareResult> Compare(long repositoryId, string @base, string head, ApiOptions options);
+
+        /// <summary>
         /// Gets a single commit for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>

--- a/Octokit/Clients/RepositoryCommitsClient.cs
+++ b/Octokit/Clients/RepositoryCommitsClient.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Octokit
@@ -103,6 +105,74 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(head, nameof(head));
 
             return ApiConnection.Get<CompareResult>(ApiUrls.RepoCompare(repositoryId, @base, head));
+        }
+
+        /// <summary>
+        /// Compare two references in a repository
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="base">The reference to use as the base commit</param>
+        /// <param name="head">The reference to use as the head commit</param>
+        /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{repo}/compare/{base}...{head}")]
+        public Task<CompareResult> Compare(string owner, string name, string @base, string head, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+            Ensure.ArgumentNotNullOrEmptyString(@base, nameof(@base));
+            Ensure.ArgumentNotNullOrEmptyString(head, nameof(head));
+            Ensure.ArgumentNotNull(options, nameof(options));
+
+            return Compare(ApiUrls.RepoCompare(owner, name, @base, head), options);
+        }
+
+        /// <summary>
+        /// Compare two references in a repository
+        /// </summary>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="base">The reference to use as the base commit</param>
+        /// <param name="head">The reference to use as the head commit</param>
+        /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/compare/{base}...{head}")]
+        public Task<CompareResult> Compare(long repositoryId, string @base, string head, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(@base, nameof(@base));
+            Ensure.ArgumentNotNullOrEmptyString(head, nameof(head));
+            Ensure.ArgumentNotNull(options, nameof(options));
+
+            return Compare(ApiUrls.RepoCompare(repositoryId, @base, head), options);
+        }
+
+        private async Task<CompareResult> Compare(Uri uri, ApiOptions options)
+        {
+            var results = await ApiConnection.GetAll<CompareResult>(uri, options);
+            if (results.Count == 1) return results[0];
+
+            var firstCompareResult = results[0];
+            var commits = firstCompareResult.Commits.ToList();
+            var files = firstCompareResult.Files.ToList();
+
+            foreach (var compareResult in results.Skip(1))
+            {
+                commits.AddRange(compareResult.Commits ?? Array.Empty<GitHubCommit>());
+                files.AddRange(compareResult.Files ?? Array.Empty<GitHubCommitFile>());
+            }
+
+            return new CompareResult(
+                firstCompareResult.Url,
+                firstCompareResult.HtmlUrl,
+                firstCompareResult.PermalinkUrl,
+                firstCompareResult.DiffUrl,
+                firstCompareResult.PatchUrl,
+                firstCompareResult.BaseCommit,
+                firstCompareResult.MergeBaseCommit,
+                firstCompareResult.Status,
+                firstCompareResult.AheadBy,
+                firstCompareResult.BehindBy,
+                firstCompareResult.TotalCommits,
+                commits,
+                files);
         }
 
         /// <summary>


### PR DESCRIPTION

## Behavior

### Before the change?
Method Compare in RepositoryCommitsClient returns CompareResult with limit  in collections Commits and Files up to 250 items.

* 

### After the change?
Added a parameter `bool fetchAllCommits` to the method that allows users to fetch all Commits and Files. It uses a pagination inside.


* 

----

## Additional info

### Pull request checklist
- [x ] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ x] Added the appropriate label for the given change

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [ x] No



### Pull request type

Type: Feature

----

