### PR TITLE
Removing empty object paramater in MigrationsClient.DeleteArchive

### DIFF
--- a/Octokit.Tests/Clients/MigrationsClientTests.cs
+++ b/Octokit.Tests/Clients/MigrationsClientTests.cs
@@ -177,8 +177,7 @@ namespace Octokit.Tests.Clients
                 client.DeleteArchive("fake", 69);
 
                 connection.Received().Delete(
-                    Arg.Is<Uri>(u => u.ToString() == "orgs/fake/migrations/69/archive"),
-                    Arg.Any<object>());
+                    Arg.Is<Uri>(u => u.ToString() == "orgs/fake/migrations/69/archive"));
             }
 
             [Fact]

--- a/Octokit/Clients/MigrationsClient.cs
+++ b/Octokit/Clients/MigrationsClient.cs
@@ -130,7 +130,7 @@ namespace Octokit
 
             var endpoint = ApiUrls.EnterpriseMigrationArchive(org, id);
 
-            return ApiConnection.Delete(endpoint, new object());
+            return ApiConnection.Delete(endpoint);
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #2697

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* MigrationsClient.DeleteArchive throws an ArgumentException - The value cannot be null or empty. (Parameter 'mediaType') when invoked in an application compiled using .Net 7.0

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* MigrationsClient.DeleteArchive succeeds on .Net 7.0.  

### Other information
<!-- Any other information that is important to this PR  -->

* Requires modifying Octokit.Tests/Clients/MigrationsClientTests.cs (any object was required by the test, hence the **new object()** parameter being added to pass the test)

----

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

