### PR TITLE
Fix runner application deserialization

### DIFF
--- a/Octokit.Tests/Clients/ActionsSelfHostedRunnersClientTests.cs
+++ b/Octokit.Tests/Clients/ActionsSelfHostedRunnersClientTests.cs
@@ -133,7 +133,7 @@ namespace Octokit.Tests.Clients
 
                 await client.ListAllRunnerApplicationsForEnterprise("fake");
 
-                connection.Received().GetAll<IReadOnlyList<RunnerApplication>>(
+                connection.Received().GetAll<RunnerApplication>(
                   Arg.Is<Uri>(u => u.ToString() == "enterprises/fake/actions/runners/downloads"), Args.ApiOptions);
 
             }
@@ -167,7 +167,7 @@ namespace Octokit.Tests.Clients
 
                 await client.ListAllRunnerApplicationsForOrganization("fake");
 
-                connection.Received().GetAll<IReadOnlyList<RunnerApplication>>(
+                connection.Received().GetAll<RunnerApplication>(
                   Arg.Is<Uri>(u => u.ToString() == "orgs/fake/actions/runners/downloads"), Args.ApiOptions);
 
             }
@@ -201,7 +201,7 @@ namespace Octokit.Tests.Clients
 
                 await client.ListAllRunnerApplicationsForRepository("fake", "repo");
 
-                connection.Received().GetAll<IReadOnlyList<RunnerApplication>>(
+                connection.Received().GetAll<RunnerApplication>(
                   Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/actions/runners/downloads"), Args.ApiOptions);
 
             }

--- a/Octokit/Clients/ActionsSelfHostedRunnersClient.cs
+++ b/Octokit/Clients/ActionsSelfHostedRunnersClient.cs
@@ -153,9 +153,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(enterprise, nameof(enterprise));
 
-            var results = await ApiConnection.GetAll<IReadOnlyList<RunnerApplication>>(ApiUrls.ActionsListRunnerApplicationsForEnterprise(enterprise), options).ConfigureAwait(false);
-
-            return results.SelectMany(x => x).ToList();
+            return await ApiConnection.GetAll<RunnerApplication>(ApiUrls.ActionsListRunnerApplicationsForEnterprise(enterprise), options).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -184,9 +182,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, nameof(organization));
 
-            var results = await ApiConnection.GetAll<IReadOnlyList<RunnerApplication>>(ApiUrls.ActionsListRunnerApplicationsForOrganization(organization), options).ConfigureAwait(false);
-
-            return results.SelectMany(x => x).ToList();
+            return await ApiConnection.GetAll<RunnerApplication>(ApiUrls.ActionsListRunnerApplicationsForOrganization(organization), options).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -219,9 +215,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(repo, nameof(repo));
 
-            var results = await ApiConnection.GetAll<IReadOnlyList<RunnerApplication>>(ApiUrls.ActionsListRunnerApplicationsForRepository(owner, repo), options).ConfigureAwait(false);
-
-            return results.SelectMany(x => x).ToList();
+            return await ApiConnection.GetAll<RunnerApplication>(ApiUrls.ActionsListRunnerApplicationsForRepository(owner, repo), options).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Octokit/Models/Response/Runner.cs
+++ b/Octokit/Models/Response/Runner.cs
@@ -15,7 +15,7 @@ namespace Octokit
       Id = id;
     }
 
-    public Runner(long id, string name, string os, string status, bool busy, List<Label> labels)
+    public Runner(long id, string name, string os, string status, bool busy, List<RunnerLabel> labels)
     {
       Id = id;
       Name = name;
@@ -30,7 +30,7 @@ namespace Octokit
     public string Os { get; private set; }
     public string Status { get; private set; }
     public bool Busy { get; private set; }
-    public IReadOnlyList<Label> Labels { get; private set; }
+    public IReadOnlyList<RunnerLabel> Labels { get; private set; }
 
     internal string DebuggerDisplay
     {

--- a/Octokit/Models/Response/RunnerApplication.cs
+++ b/Octokit/Models/Response/RunnerApplication.cs
@@ -8,25 +8,27 @@ namespace Octokit
     {
         public RunnerApplication() { }
 
-        public RunnerApplication(string os, string architecture, string downloadUrl, string fileName)
+        public RunnerApplication(string os, string architecture, string downloadUrl, string filename, string tempDownloadToken)
         {
             Os = os;
             Architecture = architecture;
             DownloadUrl = downloadUrl;
-            FileName = fileName;
+            Filename = filename;
+            TempDownloadToken = tempDownloadToken;
         }
 
         public string Os { get; private set; }
         public string Architecture { get; private set; }
         public string DownloadUrl { get; private set; }
-        public string FileName { get; private set; }
+        public string Filename { get; private set; }
+        public string TempDownloadToken { get; private set; }
 
         internal string DebuggerDisplay
         {
             get
             {
-                return string.Format("Os: {0}; Architecture: {1}; DownloadUrl: {2}; FileName: {3};",
-                  Os, Architecture, DownloadUrl, FileName);
+                return string.Format("Os: {0}; Architecture: {1}; DownloadUrl: {2}; Filename: {3}; TempDownloadToken: {4}",
+                  Os, Architecture, DownloadUrl, Filename, TempDownloadToken);
             }
         }
     }

--- a/Octokit/Models/Response/RunnerLabel.cs
+++ b/Octokit/Models/Response/RunnerLabel.cs
@@ -1,0 +1,27 @@
+﻿using System.Diagnostics;
+using System.Globalization;
+
+namespace Octokit
+{
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class RunnerLabel
+    {
+        public RunnerLabel() { }
+
+        public RunnerLabel(long id, string name, string type)
+        {
+            Id = id;
+            Name = name;
+            Type = type;
+        }
+
+        public long Id { get; private set; }
+        public string Name { get; private set; }
+        public string Type { get; private set; }
+
+        internal string DebuggerDisplay
+        {
+            get { return string.Format(CultureInfo.InvariantCulture, "Id: {0}; Name: {1}; Type: {2};", Id, Name, Type); }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #2703

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Octokit throws a deserialization error when calling `ListAllRunnerApplicationsForOrganization` in the `ActionsSelfHostedRunnersClient`

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* No error is thrown


### Other information
<!-- Any other information that is important to this PR  -->

I fixed the issue by removing the extra `IReadOnlyList` layer since `ApiConnection.GetAll` already returns an `IReadOnlyList`. I also made a few other updates to the`RunnerApplication` model:

* Added a missing property in the model
* Fixed a property that was always null because it had the wrong casing (didn't match the JSON payload).
* Created a new `RunnerLabel` model since the `Label` model is for issue/PR labels and didn't match the properties in the JSON payload

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [x] Yes (Please add the `Type: Breaking change` label)
- [ ] No

If `Yes`, what's the impact:  

* The casing for one property has been changed, which should be very low impact since the model was only added a few days ago.
* The model for one property has been changed, which should also be very low impact since most properties on the old model would be null anyway.


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Bugfix

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

