### PR TITLE
Add method to get a single runner group

### DIFF
--- a/Octokit.Reactive/Clients/IObservableActionsSelfHostedRunnerGroupsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableActionsSelfHostedRunnerGroupsClient.cs
@@ -10,6 +10,25 @@ namespace Octokit.Reactive
     /// </remarks>
     public interface IObservableActionsSelfHostedRunnerGroupsClient
     {
+        /// <summary>
+        /// Get a self-hosted runner group for an enterprise
+        /// </summary>
+        /// <remarks>
+        /// https://docs.github.com/en/enterprise-cloud@latest/rest/actions/self-hosted-runner-groups?apiVersion=2022-11-28#get-a-self-hosted-runner-group-for-an-enterprise
+        /// </remarks>
+        /// <param name="enterprise">The enterprise name.</param>
+        /// <param name="runnerGroupId">Unique identifier of the self-hosted runner group.</param>
+        IObservable<RunnerGroup> GetRunnerGroupForEnterprise(string enterprise, long runnerGroupId);
+
+        /// <summary>
+        /// Get a self-hosted runner group for an organization
+        /// </summary>
+        /// <remarks>
+        /// https://docs.github.com/en/enterprise-cloud@latest/rest/actions/self-hosted-runner-groups?apiVersion=2022-11-28#get-a-self-hosted-runner-group-for-an-organization
+        /// </remarks>
+        /// <param name="org">The organization name.</param>
+        /// <param name="runnerGroupId">Unique identifier of the self-hosted runner group.</param>
+        IObservable<RunnerGroup> GetRunnerGroupForOrganization(string org, long runnerGroupId);
 
         /// <summary>
         /// List self-hosted runner groups for an enterprise

--- a/Octokit.Reactive/Clients/ObservableActionsSelfHostedRunnerGroupsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableActionsSelfHostedRunnerGroupsClient.cs
@@ -22,6 +22,36 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Get a self-hosted runner group for an enterprise
+        /// </summary>
+        /// <remarks>
+        /// https://docs.github.com/en/enterprise-cloud@latest/rest/actions/self-hosted-runner-groups?apiVersion=2022-11-28#get-a-self-hosted-runner-group-for-an-enterprise
+        /// </remarks>
+        /// <param name="enterprise">The enterprise name.</param>
+        /// <param name="runnerGroupId">Unique identifier of the self-hosted runner group.</param>
+        public IObservable<RunnerGroup> GetRunnerGroupForEnterprise(string enterprise, long runnerGroupId)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(enterprise, nameof(enterprise));
+
+            return _client.GetRunnerGroupForEnterprise(enterprise, runnerGroupId).ToObservable();
+        }
+
+        /// <summary>
+        /// Get a self-hosted runner group for an organization
+        /// </summary>
+        /// <remarks>
+        /// https://docs.github.com/en/enterprise-cloud@latest/rest/actions/self-hosted-runner-groups?apiVersion=2022-11-28#get-a-self-hosted-runner-group-for-an-organization
+        /// </remarks>
+        /// <param name="org">The organization name.</param>
+        /// <param name="runnerGroupId">Unique identifier of the self-hosted runner group.</param>
+        public IObservable<RunnerGroup> GetRunnerGroupForOrganization(string org, long runnerGroupId)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
+
+            return _client.GetRunnerGroupForOrganization(org, runnerGroupId).ToObservable();
+        }
+
+        /// <summary>
         /// List self-hosted runner groups for an enterprise
         /// </summary>
         /// <remarks>

--- a/Octokit.Tests/Clients/ActionsSelfHostedRunnerGroupsClientTests.cs
+++ b/Octokit.Tests/Clients/ActionsSelfHostedRunnerGroupsClientTests.cs
@@ -58,7 +58,7 @@ namespace Octokit.Tests.Clients
                 await client.GetRunnerGroupForOrganization("fake", 1);
 
                 connection.Received().Get<RunnerGroup>(
-                  Arg.Is<Uri>(u => u.ToString() == "org/fake/actions/runner-groups/1"));
+                  Arg.Is<Uri>(u => u.ToString() == "orgs/fake/actions/runner-groups/1"));
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/ActionsSelfHostedRunnerGroupsClientTests.cs
+++ b/Octokit.Tests/Clients/ActionsSelfHostedRunnerGroupsClientTests.cs
@@ -16,6 +16,68 @@ namespace Octokit.Tests.Clients
             }
         }
 
+        public class TheGetRunnerGroupForEnterpriseMethod
+        {
+            [Fact]
+            public async Task RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new ActionsSelfHostedRunnerGroupsClient(connection);
+
+                await client.GetRunnerGroupForEnterprise("fake", 1);
+
+                connection.Received().Get<RunnerGroupResponse>(
+                  Arg.Is<Uri>(u => u.ToString() == "enterprises/fake/actions/runner-groups/1"));
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new ActionsSelfHostedRunnerGroupsClient(Substitute.For<IApiConnection>());
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetRunnerGroupForEnterprise(null, 1));
+            }
+
+            [Fact]
+            public async Task EnsuresNonEmptyArguments()
+            {
+                var client = new ActionsSelfHostedRunnerGroupsClient(Substitute.For<IApiConnection>());
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetRunnerGroupForEnterprise("", 1));
+            }
+        }
+
+        public class TheGetRunnerGroupForOrganizationMethod
+        {
+            [Fact]
+            public async Task RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new ActionsSelfHostedRunnerGroupsClient(connection);
+
+                await client.GetRunnerGroupForOrganization("fake", 1);
+
+                connection.Received().Get<RunnerGroupResponse>(
+                  Arg.Is<Uri>(u => u.ToString() == "org/fake/actions/runner-groups/1"));
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new ActionsSelfHostedRunnerGroupsClient(Substitute.For<IApiConnection>());
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetRunnerGroupForOrganization(null, 1));
+            }
+
+            [Fact]
+            public async Task EnsuresNonEmptyArguments()
+            {
+                var client = new ActionsSelfHostedRunnerGroupsClient(Substitute.For<IApiConnection>());
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetRunnerGroupForOrganization("", 1));
+            }
+        }
+
         public class TheListAllRunnerGroupsForEnterpriseMethod
         {
             [Fact]

--- a/Octokit.Tests/Clients/ActionsSelfHostedRunnerGroupsClientTests.cs
+++ b/Octokit.Tests/Clients/ActionsSelfHostedRunnerGroupsClientTests.cs
@@ -26,7 +26,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetRunnerGroupForEnterprise("fake", 1);
 
-                connection.Received().Get<RunnerGroupResponse>(
+                connection.Received().Get<RunnerGroup>(
                   Arg.Is<Uri>(u => u.ToString() == "enterprises/fake/actions/runner-groups/1"));
             }
 
@@ -57,7 +57,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetRunnerGroupForOrganization("fake", 1);
 
-                connection.Received().Get<RunnerGroupResponse>(
+                connection.Received().Get<RunnerGroup>(
                   Arg.Is<Uri>(u => u.ToString() == "org/fake/actions/runner-groups/1"));
             }
 

--- a/Octokit/Clients/ActionsSelfHostedRunnerGroupsClient.cs
+++ b/Octokit/Clients/ActionsSelfHostedRunnerGroupsClient.cs
@@ -21,6 +21,38 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Get a self-hosted runner group for an enterprise
+        /// </summary>
+        /// <remarks>
+        /// https://docs.github.com/en/enterprise-cloud@latest/rest/actions/self-hosted-runner-groups?apiVersion=2022-11-28#get-a-self-hosted-runner-group-for-an-enterprise
+        /// </remarks>
+        /// <param name="enterprise">The enterprise name.</param>
+        /// <param name="runnerGroupId">Unique identifier of the self-hosted runner group.</param>
+        [ManualRoute("GET", "/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}")]
+        public async Task<RunnerGroup> GetRunnerGroupForEnterprise(string enterprise, long runnerGroupId)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(enterprise, nameof(enterprise));
+
+            return await ApiConnection.Get<RunnerGroup>(ApiUrls.ActionsGetEnterpriseRunnerGroup(enterprise, runnerGroupId)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Get a self-hosted runner group for an organization
+        /// </summary>
+        /// <remarks>
+        /// https://docs.github.com/en/enterprise-cloud@latest/rest/actions/self-hosted-runner-groups?apiVersion=2022-11-28#get-a-self-hosted-runner-group-for-an-organization
+        /// </remarks>
+        /// <param name="org">The organization name.</param>
+        /// <param name="runnerGroupId">Unique identifier of the self-hosted runner group.</param>
+        [ManualRoute("GET", "/orgs/{org}/actions/runner-groups/{runner_group_id}")]
+        public async Task<RunnerGroup> GetRunnerGroupForOrganization(string org, long runnerGroupId)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
+
+            return await ApiConnection.Get<RunnerGroup>(ApiUrls.ActionsGetOrganizationRunnerGroup(org, runnerGroupId)).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// List self-hosted runner groups for an enterprise
         /// </summary>
         /// <remarks>

--- a/Octokit/Clients/IActionsSelfHostedRunnerGroupsClient.cs
+++ b/Octokit/Clients/IActionsSelfHostedRunnerGroupsClient.cs
@@ -11,6 +11,25 @@ namespace Octokit
     /// </remarks>
     public interface IActionsSelfHostedRunnerGroupsClient
     {
+        /// <summary>
+        /// Get a self-hosted runner group for an enterprise
+        /// </summary>
+        /// <remarks>
+        /// https://docs.github.com/en/enterprise-cloud@latest/rest/actions/self-hosted-runner-groups?apiVersion=2022-11-28#get-a-self-hosted-runner-group-for-an-enterprise
+        /// </remarks>
+        /// <param name="enterprise">The enterprise name.</param>
+        /// <param name="runnerGroupId">Unique identifier of the self-hosted runner group.</param>
+        Task<RunnerGroup> GetRunnerGroupForEnterprise(string enterprise, long runnerGroupId);
+
+        /// <summary>
+        /// Get a self-hosted runner group for an organization
+        /// </summary>
+        /// <remarks>
+        /// https://docs.github.com/en/enterprise-cloud@latest/rest/actions/self-hosted-runner-groups?apiVersion=2022-11-28#get-a-self-hosted-runner-group-for-an-organization
+        /// </remarks>
+        /// <param name="org">The organization name.</param>
+        /// <param name="runnerGroupId">Unique identifier of the self-hosted runner group.</param>
+        Task<RunnerGroup> GetRunnerGroupForOrganization(string org, long runnerGroupId);
 
         /// <summary>
         /// List self-hosted runner groups for an enterprise

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -5382,6 +5382,28 @@ namespace Octokit
         /// Returns the <see cref="Uri"/> that handles the Actions self-hosted runner groups for an enterprise.
         /// </summary>
         /// <param name="enterprise">The name of the enterprise.</param>
+        /// <param name="runnerGroupId">Unique identifier of the self-hosted runner group.</param>
+        /// <returns>The <see cref="Uri"/> that handles the Actions self-hosted runner groups for an enterprise.</returns>
+        public static Uri ActionsGetEnterpriseRunnerGroup(string enterprise, long runnerGroupId)
+        {
+            return "enterprises/{0}/actions/runner-groups/{1}".FormatUri(enterprise, runnerGroupId);
+        }
+
+        /// <summary>
+        /// Returns the <see cref="Uri"/> that handles the Actions self-hosted runner groups for an organization.
+        /// </summary>
+        /// <param name="org">The name of the organization.</param>
+        /// <param name="runnerGroupId">Unique identifier of the self-hosted runner group.</param>
+        /// <returns>The <see cref="Uri"/> that handles the Actions self-hosted runner groups for an organization.</returns>
+        public static Uri ActionsGetOrganizationRunnerGroup(string org, long runnerGroupId)
+        {
+            return "orgs/{0}/actions/runner-groups/{1}".FormatUri(org, runnerGroupId);
+        }
+
+        /// <summary>
+        /// Returns the <see cref="Uri"/> that handles the Actions self-hosted runner groups for an enterprise.
+        /// </summary>
+        /// <param name="enterprise">The name of the enterprise.</param>
         /// <returns>The <see cref="Uri"/> that handles the Actions self-hosted runner groups for an enterprise.</returns>
         public static Uri ActionsListEnterpriseRunnerGroups(string enterprise)
         {

--- a/Octokit/Models/Response/RunnerGroup.cs
+++ b/Octokit/Models/Response/RunnerGroup.cs
@@ -15,13 +15,14 @@ namespace Octokit
             Id = id;
         }
 
-        public RunnerGroup(long id, string name, string visibility, bool Default, string runnersUrl, bool allowsPublicRepositories, bool restrictedToWorkflows, List<string> selectedWorkflows, bool workflowRestrictionsReadOnly)
+        public RunnerGroup(long id, string name, string visibility, bool @default, string runnersUrl, bool inherited, bool allowsPublicRepositories, bool restrictedToWorkflows, List<string> selectedWorkflows, bool workflowRestrictionsReadOnly)
         {
             Id = id;
             Name = name;
             Visibility = visibility;
-            this.Default = Default; // default is a reserved keyword
+            Default = @default;
             RunnersUrl = runnersUrl;
+            Inherited = inherited;
             AllowsPublicRepositories = allowsPublicRepositories;
             RestrictedToWorkflows = restrictedToWorkflows;
             SelectedWorkflows = selectedWorkflows;
@@ -33,12 +34,13 @@ namespace Octokit
         public string Visibility { get; private set; }
         public bool Default { get; private set; }
         public string RunnersUrl { get; private set; }
+        public bool Inherited { get; private set; }
         public bool AllowsPublicRepositories { get; private set; }
         public bool RestrictedToWorkflows { get; private set; }
         public IReadOnlyList<string> SelectedWorkflows { get; private set; }
         public bool WorkflowRestrictionsReadOnly { get; private set; }
 
-        internal string DebuggerDisplay => string.Format("Id: {0}, Name: {1}, Visibility: {2}, Default: {3}, RunnersUrl: {4}, AllowsPublicRepositories: {5}, RestrictedToWorkflows: {6}, SelectedWorkflows: {7}, WorkflowRestrictionsReadOnly: {8}",
-         Id, Name, Visibility, Default, RunnersUrl, AllowsPublicRepositories, RestrictedToWorkflows, string.Join(", ", SelectedWorkflows.Select(x => x.ToString())), WorkflowRestrictionsReadOnly);
+        internal string DebuggerDisplay => string.Format("Id: {0}, Name: {1}, Visibility: {2}, Default: {3}, RunnersUrl: {4}, Inherited: {5}, AllowsPublicRepositories: {6}, RestrictedToWorkflows: {7}, SelectedWorkflows: {8}, WorkflowRestrictionsReadOnly: {9}",
+         Id, Name, Visibility, Default, RunnersUrl, Inherited, AllowsPublicRepositories, RestrictedToWorkflows, string.Join(", ", SelectedWorkflows.Select(x => x.ToString())), WorkflowRestrictionsReadOnly);
     }
 }


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #2705

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Octokit didn't have a method to get a single self-hosted runner group

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* That API has been implemented


### Other information
<!-- Any other information that is important to this PR  -->

* I also added a missing property to the model

----

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

API additions

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

