### PR TITLE
Improve repo debugger display

### DIFF
--- a/Octokit/Models/Response/Repository.cs
+++ b/Octokit/Models/Response/Repository.cs
@@ -159,7 +159,7 @@ namespace Octokit
         public RepositoryVisibility? Visibility { get; private set; }
 
         public bool? AllowAutoMerge { get; private set; }
-        
+
         public bool? AllowUpdateBranch { get; private set; }
 
         internal string DebuggerDisplay
@@ -167,7 +167,7 @@ namespace Octokit
             get
             {
                 return string.Format(CultureInfo.InvariantCulture,
-                    "Repository: Id: {0} Owner: {1}, Name: {2}", Id, Owner, Name);
+                    "Repository: Id: {0} Owner: {1}, Name: {2}", Id, Owner?.Login, Name);
             }
         }
     }


### PR DESCRIPTION
Resolves #2711.

----

## Behavior

### Before the change?

* The debugger display string for `Repository` shows `Owner: Octokit.User`.

### After the change?

* The debugger display string for `Repository` shows `Owner: {repository owner login}`.


### Other information

* N/A

----

## Additional info

### Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A

### Pull request type

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

