### PR TITLE
Added support for making branches read-only

### DIFF
--- a/Octokit.Tests.Integration/Clients/RepositoryBranchesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryBranchesClientTests.cs
@@ -296,6 +296,7 @@ namespace Octokit.Tests.Integration.Clients
                     Assert.Null(protection.Restrictions);
 
                     Assert.True(protection.EnforceAdmins.Enabled);
+                    Assert.True(protection.LockBranch.Enabled);
                     Assert.True(protection.RequiredLinearHistory.Enabled);
                     Assert.True(protection.AllowForcePushes.Enabled);
                     Assert.True(protection.AllowDeletions.Enabled);
@@ -323,6 +324,7 @@ namespace Octokit.Tests.Integration.Clients
                     Assert.Null(protection.Restrictions);
 
                     Assert.True(protection.EnforceAdmins.Enabled);
+                    Assert.True(protection.LockBranch.Enabled);
                     Assert.True(protection.RequiredLinearHistory.Enabled);
                     Assert.True(protection.AllowForcePushes.Enabled);
                     Assert.True(protection.AllowDeletions.Enabled);

--- a/Octokit/Models/Request/BranchProtectionUpdate.cs
+++ b/Octokit/Models/Request/BranchProtectionUpdate.cs
@@ -26,6 +26,7 @@ namespace Octokit
             RequiredPullRequestReviews = null;
             Restrictions = null;
             EnforceAdmins = false;
+            LockBranch = false;
         }
 
         /// <summary>
@@ -38,6 +39,7 @@ namespace Octokit
             RequiredPullRequestReviews = requiredPullRequestReviews;
             Restrictions = null;
             EnforceAdmins = false;
+            LockBranch = false;
         }
 
         /// <summary>
@@ -50,18 +52,21 @@ namespace Octokit
             RequiredPullRequestReviews = null;
             Restrictions = restrictions;
             EnforceAdmins = false;
+            LockBranch = false;
         }
 
         /// <summary>
         /// Create a BranchProtection update request
         /// </summary>
         /// <param name="enforceAdmins">Specifies whether the protections applied to this branch also apply to repository admins</param>
-        public BranchProtectionSettingsUpdate(bool enforceAdmins)
+        /// <param name="lockBranch">Optionally specfies that the branch should be read-only.</param>
+        public BranchProtectionSettingsUpdate(bool enforceAdmins, bool lockBranch = false)
         {
             RequiredStatusChecks = null;
             RequiredPullRequestReviews = null;
             Restrictions = null;
             EnforceAdmins = enforceAdmins;
+            LockBranch = lockBranch;
         }
 
         /// <summary>
@@ -70,12 +75,14 @@ namespace Octokit
         /// <param name="requiredStatusChecks">Specifies the requested status check settings. Pass null to disable status checks</param>
         /// <param name="requiredPullRequestReviews">Specifies if reviews are required to merge the pull request. Pass null to disable required reviews</param>
         /// <param name="enforceAdmins">Specifies whether the protections applied to this branch also apply to repository admins</param>
-        public BranchProtectionSettingsUpdate(BranchProtectionRequiredStatusChecksUpdate requiredStatusChecks, BranchProtectionRequiredReviewsUpdate requiredPullRequestReviews, bool enforceAdmins)
+        /// <param name="lockBranch">Optionally specfies that the branch should be read-only.</param>
+        public BranchProtectionSettingsUpdate(BranchProtectionRequiredStatusChecksUpdate requiredStatusChecks, BranchProtectionRequiredReviewsUpdate requiredPullRequestReviews, bool enforceAdmins, bool lockBranch = false)
         {
             RequiredStatusChecks = requiredStatusChecks;
             RequiredPullRequestReviews = requiredPullRequestReviews;
             Restrictions = null;
             EnforceAdmins = enforceAdmins;
+            LockBranch = lockBranch;
         }
 
         /// <summary>
@@ -85,15 +92,18 @@ namespace Octokit
         /// <param name="requiredPullRequestReviews">Specifies if reviews are required to merge the pull request. Pass null to disable required reviews</param>
         /// <param name="restrictions">Specifies the requested push access restrictions (applies only to Organization owned repositories). Pass null to disable push access restrictions</param>
         /// <param name="enforceAdmins">Specifies whether the protections applied to this branch also apply to repository admins</param>
+        /// <param name="lockBranch">Optionally specfies that the branch should be read-only.</param>
         public BranchProtectionSettingsUpdate(BranchProtectionRequiredStatusChecksUpdate requiredStatusChecks,
                                               BranchProtectionRequiredReviewsUpdate requiredPullRequestReviews,
                                               BranchProtectionPushRestrictionsUpdate restrictions,
-                                              bool enforceAdmins)
+                                              bool enforceAdmins,
+                                              bool lockBranch = false)
         {
             RequiredStatusChecks = requiredStatusChecks;
             RequiredPullRequestReviews = requiredPullRequestReviews;
             Restrictions = restrictions;
             EnforceAdmins = enforceAdmins;
+            LockBranch = lockBranch;
         }
 
         /// <summary>
@@ -108,6 +118,7 @@ namespace Octokit
         /// <param name="allowDeletions">Allows deletion of the protected branch</param>
         /// <param name="blockCreations">The restrictions branch protection settings will also block pushes which create new branches</param>
         /// <param name="requiredConversationResolution">Requires all conversations on code to be resolved before a pull request can be merged</param>
+        /// <param name="lockBranch">Optionally specfies that the branch should be read-only.</param>
         public BranchProtectionSettingsUpdate(BranchProtectionRequiredStatusChecksUpdate requiredStatusChecks,
                                               BranchProtectionRequiredReviewsUpdate requiredPullRequestReviews,
                                               BranchProtectionPushRestrictionsUpdate restrictions,
@@ -116,12 +127,14 @@ namespace Octokit
                                               bool? allowForcePushes,
                                               bool allowDeletions,
                                               bool blockCreations,
-                                              bool requiredConversationResolution)
+                                              bool requiredConversationResolution,
+                                              bool lockBranch = false)
         {
             RequiredStatusChecks = requiredStatusChecks;
             RequiredPullRequestReviews = requiredPullRequestReviews;
             Restrictions = restrictions;
             EnforceAdmins = enforceAdmins;
+            LockBranch = lockBranch;
             RequiredLinearHistory = requiredLinearHistory;
             AllowForcePushes = allowForcePushes;
             AllowDeletions = allowDeletions;
@@ -151,6 +164,11 @@ namespace Octokit
         /// Specifies whether the protections applied to this branch also apply to repository admins
         /// </summary>
         public bool EnforceAdmins { get; set; }
+
+        /// <summary>
+        /// Specifies whether this branch should be read-only.
+        /// </summary>
+        public bool LockBranch { get; set; }
 
         /// <summary>
         /// Enforces a linear commit Git history. Default is false.
@@ -183,11 +201,12 @@ namespace Octokit
             get
             {
                 return string.Format(CultureInfo.InvariantCulture,
-                    "RequiredStatusChecks: {0} RequiredPullRequestReviews: {1} Restrictions: {2} EnforceAdmins: {3}",
+                    "RequiredStatusChecks: {0} RequiredPullRequestReviews: {1} Restrictions: {2} EnforceAdmins: {3} LockBranch: {4}",
                     RequiredStatusChecks?.DebuggerDisplay ?? "disabled",
                     RequiredPullRequestReviews?.DebuggerDisplay ?? "disabled",
                     Restrictions?.DebuggerDisplay ?? "disabled",
-                    EnforceAdmins);
+                    EnforceAdmins,
+                    LockBranch);
             }
         }
     }

--- a/Octokit/Models/Response/BranchProtection.cs
+++ b/Octokit/Models/Response/BranchProtection.cs
@@ -18,25 +18,25 @@ namespace Octokit
                                         BranchProtectionRequiredReviews requiredPullRequestReviews,
                                         BranchProtectionPushRestrictions restrictions,
                                         EnforceAdmins enforceAdmins,
-                                        EnforceLock lockBranch,
                                         BranchProtectionEnabledCommon requiredLinearHistory,
                                         BranchProtectionEnabledCommon allowForcePushes,
                                         BranchProtectionEnabledCommon allowDeletions,
                                         BranchProtectionEnabledCommon blockCreations,
                                         BranchProtectionEnabledCommon requiredConversationResolution,
-                                        BranchProtectionEnabledCommon requiredSignatures)
+                                        BranchProtectionEnabledCommon requiredSignatures,
+                                        EnforceLock lockBranch = null)
         {
             RequiredStatusChecks = requiredStatusChecks;
             RequiredPullRequestReviews = requiredPullRequestReviews;
             Restrictions = restrictions;
             EnforceAdmins = enforceAdmins;
-            LockBranch = lockBranch;
             RequiredLinearHistory = requiredLinearHistory;
             AllowForcePushes = allowForcePushes;
             AllowDeletions = allowDeletions;
             BlockCreations = blockCreations;
             RequiredConversationResolution = requiredConversationResolution;
             RequiredSignatures = requiredSignatures;
+            LockBranch = lockBranch != null ? lockBranch : new EnforceLock(false);
         }
 
         /// <summary>

--- a/Octokit/Models/Response/BranchProtection.cs
+++ b/Octokit/Models/Response/BranchProtection.cs
@@ -18,6 +18,7 @@ namespace Octokit
                                         BranchProtectionRequiredReviews requiredPullRequestReviews,
                                         BranchProtectionPushRestrictions restrictions,
                                         EnforceAdmins enforceAdmins,
+                                        EnforceLock lockBranch,
                                         BranchProtectionEnabledCommon requiredLinearHistory,
                                         BranchProtectionEnabledCommon allowForcePushes,
                                         BranchProtectionEnabledCommon allowDeletions,
@@ -29,6 +30,7 @@ namespace Octokit
             RequiredPullRequestReviews = requiredPullRequestReviews;
             Restrictions = restrictions;
             EnforceAdmins = enforceAdmins;
+            LockBranch = lockBranch;
             RequiredLinearHistory = requiredLinearHistory;
             AllowForcePushes = allowForcePushes;
             AllowDeletions = allowDeletions;
@@ -36,8 +38,6 @@ namespace Octokit
             RequiredConversationResolution = requiredConversationResolution;
             RequiredSignatures = requiredSignatures;
         }
-
-
 
         /// <summary>
         /// Status check settings for the protected branch
@@ -58,6 +58,11 @@ namespace Octokit
         /// Specifies whether the protections applied to this branch also apply to repository admins
         /// </summary>
         public EnforceAdmins EnforceAdmins { get; private set; }
+
+        /// <summary>
+        /// Indicates whether this branch is read-only.
+        /// </summary>
+        public EnforceLock LockBranch { get; private set; }
 
         /// <summary>
         /// Specifies whether a linear history is required
@@ -112,6 +117,30 @@ namespace Octokit
         public EnforceAdmins() { }
 
         public EnforceAdmins(bool enabled)
+        {
+            Enabled = enabled;
+        }
+
+        public bool Enabled { get; private set; }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format(CultureInfo.InvariantCulture, "Enabled: {0}", Enabled);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Specifies whether the this branch also should be read-only.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class EnforceLock
+    {
+        public EnforceLock() { }
+
+        public EnforceLock(bool enabled)
         {
             Enabled = enabled;
         }

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -1,51 +1,50 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <Description>An async-based GitHub API client library for .NET and .NET Core</Description>
-    <AssemblyTitle>Neon.Octokit</AssemblyTitle>
-    <Authors>GitHub</Authors>
-    <Version>0.0.0-dev</Version>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyName>Octokit</AssemblyName>
-    <PackageId>Neon.Octokit</PackageId>
-    <DebugType>embedded</DebugType>
-    <RepositoryUrl>https://github.com/neonforge-forks/octokit.net</RepositoryUrl>
-    <PackageProjectUrl>https://github.com/neonforge-forks/octokit.net</PackageProjectUrl>
-    <PackageIconUrl>https://f.cloud.github.com/assets/19977/1510987/64af2b26-4a9d-11e3-89fc-96a185171c75.png</PackageIconUrl>
-    <PackageIcon>octokit.png</PackageIcon>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageTags>GitHub API Octokit linqpad-samples dotnetcore</PackageTags>
-    <Copyright>Copyright GitHub 2017</Copyright>
-	<Description>NEONFORGE: This is a temporary Octokit upgrade that supports locking branches.  This is currently required by the Neon.GitHub package but we've submitted a pull request, so hopefully that will be accepted and we'll be able to deprecate this package.</Description>
-  </PropertyGroup>
+	<PropertyGroup>
+		<Description>An async-based GitHub API client library for .NET and .NET Core</Description>
+		<AssemblyTitle>Octokit</AssemblyTitle>
+		<Authors>GitHub</Authors>
+		<Version>0.0.0-dev</Version>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<AssemblyName>Octokit</AssemblyName>
+		<PackageId>Octokit</PackageId>
+		<DebugType>embedded</DebugType>
+		<RepositoryUrl>https://github.com/octokit/octokit.net</RepositoryUrl>
+		<PackageProjectUrl>https://github.com/octokit/octokit.net</PackageProjectUrl>
+		<PackageIconUrl>https://f.cloud.github.com/assets/19977/1510987/64af2b26-4a9d-11e3-89fc-96a185171c75.png</PackageIconUrl>
+		<PackageIcon>octokit.png</PackageIcon>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageTags>GitHub API Octokit linqpad-samples dotnetcore</PackageTags>
+		<Copyright>Copyright GitHub 2017</Copyright>
+	</PropertyGroup>
 
-  <PropertyGroup>
-    <DefineConstants>$(DefineConstants);SIMPLE_JSON_INTERNAL;SIMPLE_JSON_OBJARRAYINTERNAL;SIMPLE_JSON_READONLY_COLLECTIONS;SIMPLE_JSON_TYPEINFO</DefineConstants>
-    <NoWarn>$(NoWarn);1591;1701;1702;1705</NoWarn>
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-  </PropertyGroup>
+	<PropertyGroup>
+		<DefineConstants>$(DefineConstants);SIMPLE_JSON_INTERNAL;SIMPLE_JSON_OBJARRAYINTERNAL;SIMPLE_JSON_READONLY_COLLECTIONS;SIMPLE_JSON_TYPEINFO</DefineConstants>
+		<NoWarn>$(NoWarn);1591;1701;1702;1705</NoWarn>
+		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+	</PropertyGroup>
 
-  <PropertyGroup Label="Source Link">
-    <!-- Optional: Declare that the Repository URL can be published to NuSpec -->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <!-- Optional: Embed source files that are not tracked by the source control manager to the PDB -->
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <!-- Optional: Include PDB in the built .nupkg -->
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-  </PropertyGroup>
+	<PropertyGroup Label="Source Link">
+		<!-- Optional: Declare that the Repository URL can be published to NuSpec -->
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<!-- Optional: Embed source files that are not tracked by the source control manager to the PDB -->
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+		<!-- Optional: Include PDB in the built .nupkg -->
+		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Include="images\octokit.png" Pack="true" PackagePath="\" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="images\octokit.png" Pack="true" PackagePath="\" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+	</ItemGroup>
 
-  <ItemGroup Label="InternalsVisibleTo attributes">
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-      <_Parameter1>Octokit.Tests$(StrongNameSuffix)</_Parameter1>
-    </AssemblyAttribute>
-  </ItemGroup>
+	<ItemGroup Label="InternalsVisibleTo attributes">
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>Octokit.Tests$(StrongNameSuffix)</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
 </Project>

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -2,21 +2,22 @@
 
   <PropertyGroup>
     <Description>An async-based GitHub API client library for .NET and .NET Core</Description>
-    <AssemblyTitle>Octokit</AssemblyTitle>
+    <AssemblyTitle>Neon.Octokit</AssemblyTitle>
     <Authors>GitHub</Authors>
     <Version>0.0.0-dev</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Octokit</AssemblyName>
-    <PackageId>Octokit</PackageId>
+    <PackageId>Neon.Octokit</PackageId>
     <DebugType>embedded</DebugType>
-    <RepositoryUrl>https://github.com/octokit/octokit.net</RepositoryUrl>
-    <PackageProjectUrl>https://github.com/octokit/octokit.net</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/neonforge-forks/octokit.net</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/neonforge-forks/octokit.net</PackageProjectUrl>
     <PackageIconUrl>https://f.cloud.github.com/assets/19977/1510987/64af2b26-4a9d-11e3-89fc-96a185171c75.png</PackageIconUrl>
     <PackageIcon>octokit.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>GitHub API Octokit linqpad-samples dotnetcore</PackageTags>
     <Copyright>Copyright GitHub 2017</Copyright>
+	<Description>NEONFORGE: This is a temporary Octokit upgrade that supports locking branches.  This is currently required by the Neon.GitHub package but we've submitted a pull request, so hopefully that will be accepted and we'll be able to deprecate this package.</Description>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #2714

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Octokit.net doesn't currently support making branches **read-only**

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* I've added **LockBranch** properties to the various branch protection models, next to the existing **EnforceAdmins** properties.
* I've also published a temporary nuget with this functionality to: https://www.nuget.org/packages/Neon.Octokit/6.0.2

### Other information
<!-- Any other information that is important to this PR  -->

* The existing unit tests pass
* I didn't see any related integration unit tests in your repo, but I have verified this in unit tests for our repo using this.

----

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
    I didn't see any related integration unit tests in your repo, but I have verified this in unit tests for our repo using this.
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:

Type: Feature

----

