### PR TITLE
Get Team By Name implementation

### DIFF
--- a/Octokit.Reactive/Clients/IObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableTeamsClient.cs
@@ -373,7 +373,8 @@ namespace Octokit.Reactive
         /// <param name="org">The organization name. The name is not case sensitive.</param>
         /// <param name="teamSlug">The slug of the team name.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A <see cref="Team"/> instance if found, otherwise null</returns>
+        /// <exception cref="NotFoundException">Thrown when the team wasn't found</exception>
+        /// <returns>A <see cref="Team"/> instance if found, otherwise a <see cref="NotFoundException"/></returns>
         IObservable<Team> GetByName(string org, string teamSlug);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableTeamsClient.cs
@@ -362,5 +362,18 @@ namespace Octokit.Reactive
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns></returns>
         IObservable<Unit> RemoveRepositoryFromATeam(string org, string teamSlug, string owner, string repo);
+        
+        /// <summary>
+        /// Get a team by slug name
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#get-a-team-by-name">API Documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The organization name. The name is not case sensitive.</param>
+        /// <param name="teamSlug">The slug of the team name.</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A <see cref="Team"/> instance if found, otherwise null</returns>
+        IObservable<Team> GetByName(string org, string teamSlug);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableTeamsClient.cs
@@ -534,7 +534,8 @@ namespace Octokit.Reactive
         /// <param name="org">The organization name. The name is not case sensitive.</param>
         /// <param name="teamSlug">The slug of the team name.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A <see cref="Team"/> instance if found, otherwise null</returns>
+        /// <exception cref="NotFoundException">Thrown when the team wasn't found</exception>
+        /// <returns>A <see cref="Team"/> instance if found, otherwise a <see cref="NotFoundException"/></returns>
         [ManualRoute("GET", "/orgs/{org}/teams/{teamSlug}")]
         public IObservable<Team> GetByName(string org, string teamSlug)
         {

--- a/Octokit.Reactive/Clients/ObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableTeamsClient.cs
@@ -523,5 +523,22 @@ namespace Octokit.Reactive
         {
             return _client.RemoveRepositoryFromATeam(org, teamSlug, owner, repo).ToObservable();
         }
+
+        /// <summary>
+        /// Get a team by slug name
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#get-a-team-by-name">API Documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The organization name. The name is not case sensitive.</param>
+        /// <param name="teamSlug">The slug of the team name.</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A <see cref="Team"/> instance if found, otherwise null</returns>
+        [ManualRoute("GET", "/orgs/{org}/teams/{teamSlug}")]
+        public IObservable<Team> GetByName(string org, string teamSlug)
+        {
+            return _client.GetByName(org, teamSlug).ToObservable();
+        }
     }
 }

--- a/Octokit.Tests.Integration/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/TeamsClientTests.cs
@@ -682,4 +682,20 @@ public class TeamsClientTests
             }
         }
     }
+    
+    public class TheGetByNameMethod
+    {
+        [OrganizationTest]
+        public async Task GetsTeamByNameWhenAuthenticated()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            using (var teamContext = await github.CreateTeamContext(Helper.Organization, new NewTeam(Helper.MakeNameWithTimestamp("team"))))
+            {
+                var foundTeam = await github.Organization.Team.GetByName(Helper.Organization, teamContext.TeamName);
+
+                Assert.Equal(foundTeam.Name, teamContext.TeamName);
+            }
+        }
+    }
 }

--- a/Octokit.Tests/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests/Clients/TeamsClientTests.cs
@@ -618,5 +618,29 @@ namespace Octokit.Tests.Clients
                 connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == expected));
             }
         }
+        
+        public class TheGetByNameMethod
+        {
+            [Fact]
+            public void RequestsTheCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new TeamsClient(connection);
+
+                client.GetByName("orgName", "teamSlug");
+
+                connection.Received().Get<Team>(
+                    Arg.Is<Uri>(u => u.ToString() == "orgs/orgName/teams/teamSlug"));
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var teams = new TeamsClient(Substitute.For<IApiConnection>());
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => teams.GetByName(null, "teamSlug"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => teams.GetByName("orgName", null));
+            }
+        }
     }
 }

--- a/Octokit/Clients/ITeamsClient.cs
+++ b/Octokit/Clients/ITeamsClient.cs
@@ -354,5 +354,18 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns></returns>
         Task RemoveRepositoryFromATeam(string org, string teamSlug, string owner, string repo);
+        
+        /// <summary>
+        /// Get a team by slug name
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#get-a-team-by-name">API Documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The organization name. The name is not case sensitive.</param>
+        /// <param name="teamSlug">The slug of the team name.</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A <see cref="Team"/> instance if found, otherwise null</returns>
+        Task<Team> GetByName(string org, string teamSlug);
     }
 }

--- a/Octokit/Clients/ITeamsClient.cs
+++ b/Octokit/Clients/ITeamsClient.cs
@@ -365,7 +365,8 @@ namespace Octokit
         /// <param name="org">The organization name. The name is not case sensitive.</param>
         /// <param name="teamSlug">The slug of the team name.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A <see cref="Team"/> instance if found, otherwise null</returns>
+        /// <exception cref="NotFoundException">Thrown when the team wasn't found</exception>
+        /// <returns>A <see cref="Team"/> instance if found, otherwise a <see cref="NotFoundException"/></returns>
         Task<Team> GetByName(string org, string teamSlug);
     }
 }

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -697,7 +697,8 @@ namespace Octokit
         /// <param name="org">The organization name. The name is not case sensitive.</param>
         /// <param name="teamSlug">The slug of the team name.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A <see cref="Team"/> instance if found, otherwise null</returns>
+        /// <exception cref="NotFoundException">Thrown when the team wasn't found</exception>
+        /// <returns>A <see cref="Team"/> instance if found, otherwise a <see cref="NotFoundException"/></returns>
         [ManualRoute("GET", "/orgs/{org}/teams/{teamSlug}")]
         public Task<Team> GetByName(string org, string teamSlug)
         {

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -686,5 +686,26 @@ namespace Octokit
 
             return ApiConnection.Delete(endpoint);
         }
+
+        /// <summary>
+        /// Get a team by slug name
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#get-a-team-by-name">API Documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The organization name. The name is not case sensitive.</param>
+        /// <param name="teamSlug">The slug of the team name.</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A <see cref="Team"/> instance if found, otherwise null</returns>
+        [ManualRoute("GET", "/orgs/{org}/teams/{teamSlug}")]
+        public Task<Team> GetByName(string org, string teamSlug)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
+            Ensure.ArgumentNotNullOrEmptyString(teamSlug, nameof(teamSlug));
+            
+            var endpoint = ApiUrls.TeamsByOrganizationAndSlug(org, teamSlug);
+            return ApiConnection.Get<Team>(endpoint);
+        }
     }
 }


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->

<!-- Issues are required for both bug fixes and features. -->
Resolves #2716 
----

Introduces a new method that allows using the API endpoint to [get a team by slug name](
https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#get-a-team-by-name). In certain integration scenarios, other systems might know a team name that's common between systems, but not know the GitHub ID. This allows retrieving a team instance from the API without needing to work out the ID first. 

## Behaviour

### Before the change?
NA - new feature

### After the change?
New method on Teams Client that supports getting a team by slug name

### Other information

It's the callers responsibility to provide the appropriately formed team slug name to the method, this PR provides no functionality to achieve that. 

Whilst there are rules for forming the slug (all lower case, spaces replaced by hyphens, special chars removed etc) this is non-deterministic depending on the state of the organisation ( for example if there are multiple teams with the same name in an org), and therefore cannot be reliably implemented in a client SDK. 

----

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A

### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Feature/model/API additions: `Type: Feature`

----

