### PR TITLE
[feat]: Support make_latest in create and update release

### DIFF
--- a/Octokit/Models/Request/MakeLatestQualifier.cs
+++ b/Octokit/Models/Request/MakeLatestQualifier.cs
@@ -1,0 +1,14 @@
+using Octokit.Internal;
+
+namespace Octokit
+{
+    public enum MakeLatestQualifier
+    {
+        [Parameter(Value = "true")]
+        True = 1,
+        [Parameter(Value = "false")]
+        False = 2,
+        [Parameter(Value = "legacy")]
+        Legacy = 3,
+    }
+}

--- a/Octokit/Models/Request/NewRelease.cs
+++ b/Octokit/Models/Request/NewRelease.cs
@@ -84,6 +84,16 @@ namespace Octokit
         /// </value>
         public bool GenerateReleaseNotes { get; set; }
 
+        /// <summary>
+        /// Specifies whether this release should be set as the latest release for the repository.
+        /// Drafts and prereleases cannot be set as latest. Defaults to true for newly published releases.
+        /// </summary>
+        /// <value>
+        ///   <c>True</c> set release as latest;
+        ///   <c>Legacy</c> specifies that the latest release should be determined based on the release creation date and higher semantic version.
+        /// </value>
+        public MakeLatestQualifier? MakeLatest { get; set; }
+
         internal string DebuggerDisplay
         {
             get

--- a/Octokit/Models/Request/ReleaseUpdate.cs
+++ b/Octokit/Models/Request/ReleaseUpdate.cs
@@ -63,6 +63,15 @@ namespace Octokit
         /// </value>
         public bool? Prerelease { get; set; }
 
+        /// <summary>
+        /// Specifies whether this release should be set as the latest release for the repository.
+        /// Drafts and prereleases cannot be set as latest. Defaults to true for newly published releases.
+        /// </summary>
+        /// <value>
+        ///   <c>True</c> set release as latest;
+        ///   <c>Legacy</c> specifies that the latest release should be determined based on the release creation date and higher semantic version.
+        /// </value>
+        public MakeLatestQualifier? MakeLatest { get; set; }
         internal string DebuggerDisplay
         {
             get


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2756

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

It is not possible to set make_latest parameter when creating and updating a release

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

It is possible to set make_latest parameter when creating and updating a release

### Pull request checklist
- [ X ] Tests for the changes have been added (for bug fixes / features)
- [ X ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ X ] No

----

