### PR TITLE
[feat] Expose WebCommitSignoffRequired and HasDiscussions for get and update repository objects

### DIFF
--- a/Octokit/Models/Request/RepositoryUpdate.cs
+++ b/Octokit/Models/Request/RepositoryUpdate.cs
@@ -128,6 +128,11 @@ namespace Octokit
         /// </summary>
         public bool? WebCommitSignoffRequired { get; set; }
 
+        /// <summary>
+        /// Optional. Gets or sets whether to enable discussions for the repository. The default is null (do not update). The default when created is false.
+        /// </summary>
+        public bool? HasDiscussions { get; set; }
+
         internal string DebuggerDisplay => new SimpleJsonSerializer().Serialize(this);
     }
 }

--- a/Octokit/Models/Request/RepositoryUpdate.cs
+++ b/Octokit/Models/Request/RepositoryUpdate.cs
@@ -117,10 +117,16 @@ namespace Octokit
         /// <summary>
         /// Optional. Get or set whether to always allow a pull request head branch that is behind its base branch
         /// to be updated even if it is not required to be up to date before merging, or false otherwise.
-        /// The default is null (do not update). The default when created is false. 
+        /// The default is null (do not update). The default when created is false.
         /// Available since GitHub Enterprise 3.1 (2021-05-06)
         /// </summary>
         public bool? AllowUpdateBranch { get; set; }
+
+         /// <summary>
+        /// Optional. Either true to require contributors to sign off on web-based commits, or false to not require contributors to sign off on web-based commits.
+        /// The default when created is false.
+        /// </summary>
+        public bool? WebCommitSignoffRequired { get; set; }
 
         internal string DebuggerDisplay => new SimpleJsonSerializer().Serialize(this);
     }

--- a/Octokit/Models/Response/Repository.cs
+++ b/Octokit/Models/Response/Repository.cs
@@ -17,7 +17,7 @@ namespace Octokit
             Id = id;
         }
 
-        public Repository(string url, string htmlUrl, string cloneUrl, string gitUrl, string sshUrl, string svnUrl, string mirrorUrl, long id, string nodeId, User owner, string name, string fullName, bool isTemplate, string description, string homepage, string language, bool @private, bool fork, int forksCount, int stargazersCount, string defaultBranch, int openIssuesCount, DateTimeOffset? pushedAt, DateTimeOffset createdAt, DateTimeOffset updatedAt, RepositoryPermissions permissions, Repository parent, Repository source, LicenseMetadata license, bool hasIssues, bool hasWiki, bool hasDownloads, bool hasPages, int subscribersCount, long size, bool? allowRebaseMerge, bool? allowSquashMerge, bool? allowMergeCommit, bool archived, int watchersCount, bool? deleteBranchOnMerge, RepositoryVisibility visibility, IEnumerable<string> topics, bool? allowAutoMerge, bool? allowUpdateBranch, bool? webCommitSignoffRequired)
+        public Repository(string url, string htmlUrl, string cloneUrl, string gitUrl, string sshUrl, string svnUrl, string mirrorUrl, long id, string nodeId, User owner, string name, string fullName, bool isTemplate, string description, string homepage, string language, bool @private, bool fork, int forksCount, int stargazersCount, string defaultBranch, int openIssuesCount, DateTimeOffset? pushedAt, DateTimeOffset createdAt, DateTimeOffset updatedAt, RepositoryPermissions permissions, Repository parent, Repository source, LicenseMetadata license, bool hasDiscussions, bool hasIssues, bool hasWiki, bool hasDownloads, bool hasPages, int subscribersCount, long size, bool? allowRebaseMerge, bool? allowSquashMerge, bool? allowMergeCommit, bool archived, int watchersCount, bool? deleteBranchOnMerge, RepositoryVisibility visibility, IEnumerable<string> topics, bool? allowAutoMerge, bool? allowUpdateBranch, bool? webCommitSignoffRequired)
         {
             Url = url;
             HtmlUrl = htmlUrl;
@@ -48,6 +48,7 @@ namespace Octokit
             Parent = parent;
             Source = source;
             License = license;
+            HasDiscussions = hasDiscussions;
             HasIssues = hasIssues;
             HasWiki = hasWiki;
             HasDownloads = hasDownloads;
@@ -132,6 +133,8 @@ namespace Octokit
         public Repository Source { get; private set; }
 
         public LicenseMetadata License { get; private set; }
+
+        public bool HasDiscussions { get; private set; }
 
         public bool HasIssues { get; private set; }
 

--- a/Octokit/Models/Response/Repository.cs
+++ b/Octokit/Models/Response/Repository.cs
@@ -17,7 +17,7 @@ namespace Octokit
             Id = id;
         }
 
-        public Repository(string url, string htmlUrl, string cloneUrl, string gitUrl, string sshUrl, string svnUrl, string mirrorUrl, long id, string nodeId, User owner, string name, string fullName, bool isTemplate, string description, string homepage, string language, bool @private, bool fork, int forksCount, int stargazersCount, string defaultBranch, int openIssuesCount, DateTimeOffset? pushedAt, DateTimeOffset createdAt, DateTimeOffset updatedAt, RepositoryPermissions permissions, Repository parent, Repository source, LicenseMetadata license, bool hasIssues, bool hasWiki, bool hasDownloads, bool hasPages, int subscribersCount, long size, bool? allowRebaseMerge, bool? allowSquashMerge, bool? allowMergeCommit, bool archived, int watchersCount, bool? deleteBranchOnMerge, RepositoryVisibility visibility, IEnumerable<string> topics, bool? allowAutoMerge, bool? allowUpdateBranch)
+        public Repository(string url, string htmlUrl, string cloneUrl, string gitUrl, string sshUrl, string svnUrl, string mirrorUrl, long id, string nodeId, User owner, string name, string fullName, bool isTemplate, string description, string homepage, string language, bool @private, bool fork, int forksCount, int stargazersCount, string defaultBranch, int openIssuesCount, DateTimeOffset? pushedAt, DateTimeOffset createdAt, DateTimeOffset updatedAt, RepositoryPermissions permissions, Repository parent, Repository source, LicenseMetadata license, bool hasIssues, bool hasWiki, bool hasDownloads, bool hasPages, int subscribersCount, long size, bool? allowRebaseMerge, bool? allowSquashMerge, bool? allowMergeCommit, bool archived, int watchersCount, bool? deleteBranchOnMerge, RepositoryVisibility visibility, IEnumerable<string> topics, bool? allowAutoMerge, bool? allowUpdateBranch, bool? webCommitSignoffRequired)
         {
             Url = url;
             HtmlUrl = htmlUrl;
@@ -66,6 +66,7 @@ namespace Octokit
             Visibility = visibility;
             AllowAutoMerge = allowAutoMerge;
             AllowUpdateBranch = allowUpdateBranch;
+            WebCommitSignoffRequired = webCommitSignoffRequired;
         }
 
         public string Url { get; private set; }
@@ -161,6 +162,8 @@ namespace Octokit
         public bool? AllowAutoMerge { get; private set; }
 
         public bool? AllowUpdateBranch { get; private set; }
+
+        public bool? WebCommitSignoffRequired { get; private set; }
 
         internal string DebuggerDisplay
         {


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2772

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The WebCommitSignoffRequired and HasDiscussions fields exposed by the REST API are not implemented by octokit.net

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The WebCommitSignoffRequired and HasDiscussions fields will be implemented by octokit.net for the get and update repository objects

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

