### PR TITLE
[Bug]Fix pagination when ApiOptions.StartPage is explicitly set.

### DIFF
--- a/Octokit.Tests/Helpers/UriExtensionsTests.cs
+++ b/Octokit.Tests/Helpers/UriExtensionsTests.cs
@@ -161,6 +161,64 @@ namespace Octokit.Tests.Helpers
                 Uri uri = null;
                 Assert.Throws<ArgumentNullException>(() => uri.ApplyParameters(new Dictionary<string, string>()));
             }
+
+            [Fact]
+            public void AppendsStartPageIfNone()
+            {
+                var uri = new Uri("https://api.github.com/repositories/1/labels");
+
+                var parameters = new Dictionary<string, string>();
+                Pagination.Setup(parameters, new ApiOptions { StartPage = 3, PageSize = 7 });
+
+                var actual = uri.ApplyParameters(parameters);
+
+                Assert.Equal(
+                    new Uri("https://api.github.com/repositories/1/labels?per_page=7&page=3"),
+                    actual);
+            }
+
+            [Fact]
+            public void AppendsStartPageIfNoneForRelativeUri()
+            {
+                var uri = new Uri("/repositories/1/labels", UriKind.Relative);
+
+                var parameters = new Dictionary<string, string>();
+                Pagination.Setup(parameters, new ApiOptions { StartPage = 3, PageSize = 7 });
+
+                var actual = uri.ApplyParameters(parameters);
+
+                Assert.Equal(
+                    new Uri("/repositories/1/labels?per_page=7&page=3", UriKind.Relative),
+                    actual);
+            }
+
+            [Fact]
+            public void DoesNotChangePageNumberInNextPageUriWithStartPage()
+            {
+                const string nextPageUriString = "https://api.github.com/repositories/1/labels?per_page=5&page=2";
+                var nextPageUri = new Uri(nextPageUriString);
+
+                var parameters = new Dictionary<string, string>();
+                Pagination.Setup(parameters, new ApiOptions { StartPage = 1, PageSize = 5 });
+
+                var actual = nextPageUri.ApplyParameters(parameters);
+
+                Assert.Equal(new Uri(nextPageUriString), actual);
+            }
+
+            [Fact]
+            public void DoesNotChangePageNumberInNextPageUriWithStartPageForRelativeUri()
+            {
+                const string nextPageUriString = "/repositories/1/labels?per_page=5&page=2";
+                var nextPageUri = new Uri(nextPageUriString, UriKind.Relative);
+
+                var parameters = new Dictionary<string, string>();
+                Pagination.Setup(parameters, new ApiOptions { StartPage = 1, PageSize = 5 });
+
+                var actual = nextPageUri.ApplyParameters(parameters);
+
+                Assert.Equal(new Uri(nextPageUriString, UriKind.Relative), actual);
+            }
         }
     }
 }

--- a/Octokit/Helpers/UriExtensions.cs
+++ b/Octokit/Helpers/UriExtensions.cs
@@ -76,7 +76,14 @@ namespace Octokit
 
             foreach (var existing in existingParameters)
             {
-                if (!p.ContainsKey(existing.Key))
+                if (existing.Key == "page")
+                {
+                    // See https://github.com/octokit/octokit.net/issues/1955
+                    // See https://github.com/octokit/octokit.net/issues/2602
+                    // Desired behavior: don't replace page number in nextPageUri
+                    p[existing.Key] = existing.Value;
+                }
+                else if (!p.ContainsKey(existing.Key))
                 {
                     p.Add(existing);
                 }


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #1955, #2602

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Following code never returns a list of release and hits API rate limit:
```
var client = new GitHubClient(new ProductHeaderValue("Test"));
var releases = await client.Repository.Release.GetAll("octokit", "octokit.net",
        new ApiOptions { StartPage = 1, PageSize = 10, PageCount = 2 });
```
* Looks like any method prefixed with `GetAll*` is affected when called with `ApiOptions.StartPage != null` specified and one of the following is true:
  - `ApiOptions.PageCount > 1`
  - `ApiOptions.PageCount == null`

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Example code returns 20 releases as expected

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

