### PR TITLE
Add `suspended_at` and `suspended_by` to the `Installation` model

### DIFF
--- a/Octokit.Tests.Integration/Clients/GitHubAppsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/GitHubAppsClientTests.cs
@@ -74,6 +74,8 @@ namespace Octokit.Tests.Integration.Clients
                     Assert.Equal(InstallationReadWritePermissionLevel.Read, installation.Permissions.Metadata);
                     Assert.False(string.IsNullOrEmpty(installation.HtmlUrl));
                     Assert.NotEqual(0, installation.TargetId);
+                    Assert.Null(installation.SuspendedBy);
+                    Assert.Null(installation.SuspendedAt);
                 }
             }
         }

--- a/Octokit.Tests/Models/InstallationTests.cs
+++ b/Octokit.Tests/Models/InstallationTests.cs
@@ -1,0 +1,165 @@
+using System.Collections.Generic;
+using System.Linq;
+using Octokit.Internal;
+using Xunit;
+
+namespace Octokit.Tests.Models
+{
+  public class InstallationResponseTests
+  {
+    [Fact]
+    public void CanBeDeserialized()
+    {
+      const string json = @"[
+  {
+    ""id"": 1,
+    ""account"": {
+      ""login"": ""octocat"",
+      ""id"": 1,
+      ""node_id"": ""MDQ6VXNlcjE="",
+      ""avatar_url"": ""https://github.com/images/error/octocat_happy.gif"",
+      ""gravatar_id"": """",
+      ""url"": ""https://api.github.com/users/octocat"",
+      ""html_url"": ""https://github.com/octocat"",
+      ""followers_url"": ""https://api.github.com/users/octocat/followers"",
+      ""following_url"": ""https://api.github.com/users/octocat/following{/other_user}"",
+      ""gists_url"": ""https://api.github.com/users/octocat/gists{/gist_id}"",
+      ""starred_url"": ""https://api.github.com/users/octocat/starred{/owner}{/repo}"",
+      ""subscriptions_url"": ""https://api.github.com/users/octocat/subscriptions"",
+      ""organizations_url"": ""https://api.github.com/users/octocat/orgs"",
+      ""repos_url"": ""https://api.github.com/users/octocat/repos"",
+      ""events_url"": ""https://api.github.com/users/octocat/events{/privacy}"",
+      ""received_events_url"": ""https://api.github.com/users/octocat/received_events"",
+      ""type"": ""User"",
+      ""site_admin"": false
+    },
+    ""access_tokens_url"": ""https://api.github.com/app/installations/1/access_tokens"",
+    ""repositories_url"": ""https://api.github.com/installation/repositories"",
+    ""html_url"": ""https://github.com/organizations/github/settings/installations/1"",
+    ""app_id"": 1,
+    ""target_id"": 1,
+    ""target_type"": ""Organization"",
+    ""permissions"": {
+      ""checks"": ""write"",
+      ""metadata"": ""read"",
+      ""contents"": ""read""
+    },
+    ""events"": [
+      ""push"",
+      ""pull_request""
+    ],
+    ""single_file_name"": ""config.yaml"",
+    ""has_multiple_single_files"": true,
+    ""single_file_paths"": [
+      ""config.yml"",
+      "".github/issue_TEMPLATE.md""
+    ],
+    ""repository_selection"": ""selected"",
+    ""created_at"": ""2017-07-08T16:18:44-04:00"",
+    ""updated_at"": ""2017-07-08T16:18:44-04:00"",
+    ""app_slug"": ""github-actions"",
+    ""suspended_at"": null,
+    ""suspended_by"": null
+  }
+]";
+
+      var serializer = new SimpleJsonSerializer();
+
+      var installations = serializer.Deserialize<IReadOnlyList<Installation>>(json);
+
+      Assert.NotNull(installations);
+      Assert.NotEmpty(installations);
+      Assert.Equal(1, installations.Count);
+      Assert.Null(installations.First().SuspendedAt);
+      Assert.Null(installations.First().SuspendedBy);
+
+    }
+
+    [Fact]
+    public void CanBeDeserializedWithSuspendedAtValues()
+    {
+      const string json = @"[
+  {
+    ""id"": 1,
+    ""account"": {
+      ""login"": ""octocat"",
+      ""id"": 1,
+      ""node_id"": ""MDQ6VXNlcjE="",
+      ""avatar_url"": ""https://github.com/images/error/octocat_happy.gif"",
+      ""gravatar_id"": """",
+      ""url"": ""https://api.github.com/users/octocat"",
+      ""html_url"": ""https://github.com/octocat"",
+      ""followers_url"": ""https://api.github.com/users/octocat/followers"",
+      ""following_url"": ""https://api.github.com/users/octocat/following{/other_user}"",
+      ""gists_url"": ""https://api.github.com/users/octocat/gists{/gist_id}"",
+      ""starred_url"": ""https://api.github.com/users/octocat/starred{/owner}{/repo}"",
+      ""subscriptions_url"": ""https://api.github.com/users/octocat/subscriptions"",
+      ""organizations_url"": ""https://api.github.com/users/octocat/orgs"",
+      ""repos_url"": ""https://api.github.com/users/octocat/repos"",
+      ""events_url"": ""https://api.github.com/users/octocat/events{/privacy}"",
+      ""received_events_url"": ""https://api.github.com/users/octocat/received_events"",
+      ""type"": ""User"",
+      ""site_admin"": false
+    },
+    ""access_tokens_url"": ""https://api.github.com/app/installations/1/access_tokens"",
+    ""repositories_url"": ""https://api.github.com/installation/repositories"",
+    ""html_url"": ""https://github.com/organizations/github/settings/installations/1"",
+    ""app_id"": 1,
+    ""target_id"": 1,
+    ""target_type"": ""Organization"",
+    ""permissions"": {
+      ""checks"": ""write"",
+      ""metadata"": ""read"",
+      ""contents"": ""read""
+    },
+    ""events"": [
+      ""push"",
+      ""pull_request""
+    ],
+    ""single_file_name"": ""config.yaml"",
+    ""has_multiple_single_files"": true,
+    ""single_file_paths"": [
+      ""config.yml"",
+      "".github/issue_TEMPLATE.md""
+    ],
+    ""repository_selection"": ""selected"",
+    ""created_at"": ""2017-07-08T16:18:44-04:00"",
+    ""updated_at"": ""2017-07-08T16:18:44-04:00"",
+    ""app_slug"": ""github-actions"",
+    ""suspended_at"": ""2017-07-08T16:18:44-04:00"",
+    ""suspended_by"": {
+      ""login"": ""octocat"",
+      ""id"": 1,
+      ""node_id"": ""MDQ6VXNlcjE="",
+      ""avatar_url"": ""https://github.com/images/error/octocat_happy.gif"",
+      ""gravatar_id"": """",
+      ""url"": ""https://api.github.com/users/octocat"",
+      ""html_url"": ""https://github.com/octocat"",
+      ""followers_url"": ""https://api.github.com/users/octocat/followers"",
+      ""following_url"": ""https://api.github.com/users/octocat/following{/other_user}"",
+      ""gists_url"": ""https://api.github.com/users/octocat/gists{/gist_id}"",
+      ""starred_url"": ""https://api.github.com/users/octocat/starred{/owner}{/repo}"",
+      ""subscriptions_url"": ""https://api.github.com/users/octocat/subscriptions"",
+      ""organizations_url"": ""https://api.github.com/users/octocat/orgs"",
+      ""repos_url"": ""https://api.github.com/users/octocat/repos"",
+      ""events_url"": ""https://api.github.com/users/octocat/events{/privacy}"",
+      ""received_events_url"": ""https://api.github.com/users/octocat/received_events"",
+      ""type"": ""User"",
+      ""site_admin"": false
+    }
+  }
+]";
+
+      var serializer = new SimpleJsonSerializer();
+
+      var installations = serializer.Deserialize<IReadOnlyList<Installation>>(json);
+
+      Assert.NotNull(installations);
+      Assert.NotEmpty(installations);
+      Assert.Equal(1, installations.Count);
+      Assert.NotNull(installations.First().SuspendedAt);
+      Assert.NotNull(installations.First().SuspendedBy);
+
+    }
+  }
+}

--- a/Octokit/Models/Response/Installation.cs
+++ b/Octokit/Models/Response/Installation.cs
@@ -16,7 +16,7 @@ namespace Octokit
     {
         public Installation() { }
 
-        public Installation(long id, User account, string accessTokensUrl, string repositoriesUrl, string htmlUrl, long appId, long targetId, AccountType targetType, InstallationPermissions permissions, IReadOnlyList<string> events, string singleFileName, string repositorySelection) : base(id)
+        public Installation(long id, User account, string accessTokensUrl, string repositoriesUrl, string htmlUrl, long appId, long targetId, AccountType targetType, InstallationPermissions permissions, IReadOnlyList<string> events, string singleFileName, string repositorySelection, User suspendedBy, DateTimeOffset? suspendedAt) : base(id)
         {
             Account = account;
             AccessTokensUrl = accessTokensUrl;
@@ -29,6 +29,8 @@ namespace Octokit
             Events = events;
             SingleFileName = singleFileName;
             RepositorySelection = repositorySelection;
+            SuspendedBy = suspendedBy;
+            SuspendedAt = suspendedAt;
         }
 
         /// <summary>
@@ -79,6 +81,16 @@ namespace Octokit
         /// The choice of repositories the installation is on. Can be either "selected" or "all".
         /// </summary>
         public StringEnum<InstallationRepositorySelection> RepositorySelection { get; private set; }
+
+        /// <summary>
+        /// The user who suspended the Installation. Can be null if the Installation is not suspended.
+        /// </summary>
+        public User SuspendedBy { get; private set; }
+
+        /// <summary>
+        /// The date the Installation was suspended. Can be null if the Installation is not suspended.
+        /// </summary>
+        public DateTimeOffset? SuspendedAt { get; private set; }
 
         internal new string DebuggerDisplay => string.Format(CultureInfo.InvariantCulture, "Id: {0} AppId: {1}", Id, AppId);
     }

--- a/Octokit/Models/Response/Installation.cs
+++ b/Octokit/Models/Response/Installation.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using Octokit.Internal;
@@ -16,7 +17,7 @@ namespace Octokit
     {
         public Installation() { }
 
-        public Installation(long id, User account, string accessTokensUrl, string repositoriesUrl, string htmlUrl, long appId, long targetId, AccountType targetType, InstallationPermissions permissions, IReadOnlyList<string> events, string singleFileName, string repositorySelection, User suspendedBy, DateTimeOffset? suspendedAt) : base(id)
+        public Installation(long id, User account, string accessTokensUrl, string repositoriesUrl, string htmlUrl, long appId, long targetId, AccountType targetType, InstallationPermissions permissions, IReadOnlyList<string> events, string singleFileName, string repositorySelection, User? suspendedBy, DateTimeOffset? suspendedAt) : base(id)
         {
             Account = account;
             AccessTokensUrl = accessTokensUrl;
@@ -85,7 +86,7 @@ namespace Octokit
         /// <summary>
         /// The user who suspended the Installation. Can be null if the Installation is not suspended.
         /// </summary>
-        public User SuspendedBy { get; private set; }
+        public User? SuspendedBy { get; private set; }
 
         /// <summary>
         /// The date the Installation was suspended. Can be null if the Installation is not suspended.

--- a/Octokit/Models/Response/Installation.cs
+++ b/Octokit/Models/Response/Installation.cs
@@ -17,7 +17,7 @@ namespace Octokit
     {
         public Installation() { }
 
-        public Installation(long id, User account, string accessTokensUrl, string repositoriesUrl, string htmlUrl, long appId, long targetId, AccountType targetType, InstallationPermissions permissions, IReadOnlyList<string> events, string singleFileName, string repositorySelection, User? suspendedBy, DateTimeOffset? suspendedAt) : base(id)
+        public Installation(long id, User account, string accessTokensUrl, string repositoriesUrl, string htmlUrl, long appId, long targetId, AccountType targetType, InstallationPermissions permissions, IReadOnlyList<string> events, string singleFileName, string repositorySelection, User suspendedBy, DateTimeOffset? suspendedAt) : base(id)
         {
             Account = account;
             AccessTokensUrl = accessTokensUrl;
@@ -86,7 +86,7 @@ namespace Octokit
         /// <summary>
         /// The user who suspended the Installation. Can be null if the Installation is not suspended.
         /// </summary>
-        public User? SuspendedBy { get; private set; }
+        public User SuspendedBy { get; private set; }
 
         /// <summary>
         /// The date the Installation was suspended. Can be null if the Installation is not suspended.

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -17,6 +17,8 @@
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageTags>GitHub API Octokit linqpad-samples dotnetcore</PackageTags>
 		<Copyright>Copyright GitHub 2017</Copyright>
+    <LangVersion>9</LangVersion>
+    <Nullable>enable</Nullable>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -17,8 +17,6 @@
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageTags>GitHub API Octokit linqpad-samples dotnetcore</PackageTags>
 		<Copyright>Copyright GitHub 2017</Copyright>
-    <LangVersion>9</LangVersion>
-    <Nullable>enable</Nullable>
 	</PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2777 by adding `suspended_at` and `suspended_by` properties to the `Installation` model. This will allow consumers of the [List GitHub Installations](https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#list-installations-for-the-authenticated-app) API to filter out suspended installations.

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Calls to list GitHub App installations would not include the `suspended_at` and `suspended_by` properties.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Calls to list GitHub App installations will include both the `suspended_at` and `suspended_by` properties.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

