### PR TITLE
[fix] Fix handling for Streams in IConnection for raw content

### DIFF
--- a/Octokit.Tests/Http/ConnectionTests.cs
+++ b/Octokit.Tests/Http/ConnectionTests.cs
@@ -416,6 +416,116 @@ namespace Octokit.Tests.Http
             }
         }
 
+        public class TheGetRawMethod
+        {
+            [Fact]
+            public async Task SendsProperlyFormattedRequestWithProperAcceptHeader()
+            {
+                var httpClient = Substitute.For<IHttpClient>();
+                var response = CreateResponse(HttpStatusCode.OK);
+                httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
+                    _exampleUri,
+                    Substitute.For<ICredentialStore>(),
+                    httpClient,
+                    Substitute.For<IJsonSerializer>());
+
+                await connection.GetRaw(new Uri("endpoint", UriKind.Relative), new Dictionary<string, string>());
+
+                httpClient.Received(1).Send(Arg.Is<IRequest>(req =>
+                    req.BaseAddress == _exampleUri &&
+                    req.ContentType == null &&
+                    req.Body == null &&
+                    req.Method == HttpMethod.Get &&
+                    req.Headers["Accept"] == "application/vnd.github.v3.raw" &&
+                    req.Endpoint == new Uri("endpoint", UriKind.Relative)), Args.CancellationToken);
+            }
+
+            [Fact]
+            public async Task SendsProperlyFormattedRequestWithProperAcceptHeaderAndTimeout()
+            {
+                var httpClient = Substitute.For<IHttpClient>();
+                var response = CreateResponse(HttpStatusCode.OK);
+                httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
+                    _exampleUri,
+                    Substitute.For<ICredentialStore>(),
+                    httpClient,
+                    Substitute.For<IJsonSerializer>());
+
+                await connection.GetRaw(new Uri("endpoint", UriKind.Relative), new Dictionary<string, string>(), TimeSpan.FromSeconds(1));
+
+                httpClient.Received(1).Send(Arg.Is<IRequest>(req =>
+                    req.BaseAddress == _exampleUri &&
+                    req.Timeout == TimeSpan.FromSeconds(1) &&
+                    req.ContentType == null &&
+                    req.Body == null &&
+                    req.Method == HttpMethod.Get &&
+                    req.Headers["Accept"] == "application/vnd.github.v3.raw" &&
+                    req.Endpoint == new Uri("endpoint", UriKind.Relative)), Args.CancellationToken);
+            }
+
+            [Fact]
+            public async Task ReturnsCorrectContentForNull()
+            {
+                object body = null;
+                var httpClient = Substitute.For<IHttpClient>();
+                var response = CreateResponse(HttpStatusCode.OK, body);
+                httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
+                    _exampleUri,
+                    Substitute.For<ICredentialStore>(),
+                    httpClient,
+                    Substitute.For<IJsonSerializer>());
+
+                var actual = await connection.GetRaw(new Uri("endpoint", UriKind.Relative), new Dictionary<string, string>());
+
+                Assert.NotNull(actual);
+                Assert.Null(actual.Body);
+            }
+
+            [Fact]
+            public async Task ReturnsCorrectContentForByteArray()
+            {
+                var body = new byte[] { 1, 2, 3 };
+
+                var httpClient = Substitute.For<IHttpClient>();
+                var response = CreateResponse(HttpStatusCode.OK, body);
+                httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
+                    _exampleUri,
+                    Substitute.For<ICredentialStore>(),
+                    httpClient,
+                    Substitute.For<IJsonSerializer>());
+
+                var actual = await connection.GetRaw(new Uri("endpoint", UriKind.Relative), new Dictionary<string, string>());
+
+                Assert.NotNull(actual);
+                Assert.Equal(body, actual.Body);
+            }
+
+            [Fact]
+            public async Task ReturnsCorrectContentForStream()
+            {
+                var bytes = new byte[] { 1, 2, 3 };
+                var body = new MemoryStream(bytes);
+
+                var httpClient = Substitute.For<IHttpClient>();
+                var response = CreateResponse(HttpStatusCode.OK, body);
+                httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
+                    _exampleUri,
+                    Substitute.For<ICredentialStore>(),
+                    httpClient,
+                    Substitute.For<IJsonSerializer>());
+
+                var actual = await connection.GetRaw(new Uri("endpoint", UriKind.Relative), new Dictionary<string, string>());
+
+                Assert.NotNull(actual);
+                Assert.Equal(bytes, actual.Body);
+            }
+        }
+
         public class ThePatchMethod
         {
             [Fact]

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -714,8 +714,13 @@ namespace Octokit
         {
             request.Headers.Add("Accept", AcceptHeaders.RawContentMediaType);
             var response = await RunRequest(request, CancellationToken.None).ConfigureAwait(false);
-            
-            return new ApiResponse<byte[]>(response, await StreamToByteArray(response.Body as Stream));
+
+            if (response.Body is Stream stream)
+            {
+                return new ApiResponse<byte[]>(response, await StreamToByteArray(stream));
+            }
+
+            return new ApiResponse<byte[]>(response, response.Body as byte[]);
         }
         
         async Task<IApiResponse<Stream>> GetRawStream(IRequest request)


### PR DESCRIPTION
Fix `NullReferenceException` if raw content was handled as a string rather than a stream by `HttpClientAdapter.BuildResponse()`.

I haven't added a test for this, but have validated that the apps that surfaced this issue are working when using a local build of Octokit including this change. If you can direct me to exactly where you'd like a test for this, I'll add one.

Resolves #2789

----

### Before the change?

* A `NullReferenceException` would be thrown.

### After the change?

* The call succeeds.

### Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

----

