### PR TITLE
[fix] Bump GitVersion.Tool

### DIFF
--- a/build/Lifetime.cs
+++ b/build/Lifetime.cs
@@ -42,7 +42,7 @@ public class Lifetime : FrostingLifetime<Context>
             new Project { Name = "Octokit.Tests.Integration", Path = "./Octokit.Tests.Integration/Octokit.Tests.Integration.csproj", IntegrationTests = true }
         };
 
-        context.GitVersionToolPath = ToolInstaller.DotNetToolInstall(context, "GitVersion.Tool", "5.6.5", "dotnet-gitversion");
+        context.GitVersionToolPath = ToolInstaller.DotNetToolInstall(context, "GitVersion.Tool", "5.12.0", "dotnet-gitversion");
         ToolInstaller.DotNetToolInstall(context, "coverlet.console", "1.7.2", "coverlet");
 
         // Calculate semantic version.


### PR DESCRIPTION
Update to the latest stable version of [GitVersion.Tool](https://www.nuget.org/packages/GitVersion.Tool/5.12.0#supportedframeworks-body-tab) that supports .NET 6.

Resolves #2790

----

### Before the change?

* `build.ps1` fails with `Error: GitVersion: Process returned an error (exit code -2147450730).`

### After the change?

* `build.ps1` successfully compiles and tests Octokit.

### Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

----
