### PR TITLE
[feat]: Adding missing properties to PushEventPayload

### DIFF
--- a/Octokit.Tests/Clients/EventsClientTests.cs
+++ b/Octokit.Tests/Clients/EventsClientTests.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Internal;
+using Octokit.Tests.Helpers;
 using Xunit;
 
 using static Octokit.Internal.TestSetup;
@@ -880,6 +881,9 @@ namespace Octokit.Tests.Clients
                         head = "head",
                         @ref = "ref",
                         size = 1337,
+                        before = "before",
+                        distinct_size = 1337,
+                        push_id = 1337,
                         commits = new []
                         {
                             new
@@ -902,6 +906,9 @@ namespace Octokit.Tests.Clients
             Assert.NotNull(payload.Commits);
             Assert.Equal(1, payload.Commits.Count);
             Assert.Equal("message", payload.Commits.FirstOrDefault().Message);
+            Assert.Equal("before", payload.Before);
+            Assert.Equal(1337, payload.DistinctSize);
+            Assert.Equal(1337, payload.PushId);
         }
 
         [Fact]

--- a/Octokit/Models/Response/ActivityPayloads/PushEventPayload.cs
+++ b/Octokit/Models/Response/ActivityPayloads/PushEventPayload.cs
@@ -6,6 +6,9 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class PushEventPayload : ActivityPayload
     {
+        public int PushId { get; private set; }
+        public int DistinctSize { get; private set; }
+        public string Before { get; private set; }
         public string Head { get; private set; }
         public string Ref { get; private set; }
         public int Size { get; private set; }


### PR DESCRIPTION
Resolves #2720

----

### Before the change?

The `PushEventPayload` class was missing the `before`, `distinct_size`, and `push_id` properties documented at https://docs.github.com/en/webhooks-and-events/events/github-event-types#pushevent

### After the change?

Those three properties are added to the `PushEventPayload` class as `DistinctSize`, `PushId`, and `Before`.

### Pull request checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

