### PR TITLE
[feat]: Add archive url to repository info

### DIFF
--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Octokit;
@@ -1041,6 +1042,25 @@ public class RepositoriesClientTests
                 var repository = await github.Repository.Get(context.RepositoryId);
 
                 Assert.NotNull(repository.DeleteBranchOnMerge);
+            }
+        }
+
+        [IntegrationTest]
+        public async Task ReceivesCorrectArchiveUrl()
+        {
+            var github = new GitHubClient(new ProductHeaderValue("OctokitTests"),
+            new ObservableCredentialProvider());
+
+            var repo = await github.Repository.Get("octokit", "octokit.net");
+
+            Assert.Equal("https://api.github.com/repos/octokit/octokit.net/{archive_format}{/ref}", repo.ArchiveUrl);
+        }
+
+        class ObservableCredentialProvider : ICredentialStore
+        {
+            public async Task<Credentials> GetCredentials()
+            {
+                return await Observable.Return(Helper.Credentials);
             }
         }
     }

--- a/Octokit/Models/Response/Repository.cs
+++ b/Octokit/Models/Response/Repository.cs
@@ -17,7 +17,7 @@ namespace Octokit
             Id = id;
         }
 
-        public Repository(string url, string htmlUrl, string cloneUrl, string gitUrl, string sshUrl, string svnUrl, string mirrorUrl, long id, string nodeId, User owner, string name, string fullName, bool isTemplate, string description, string homepage, string language, bool @private, bool fork, int forksCount, int stargazersCount, string defaultBranch, int openIssuesCount, DateTimeOffset? pushedAt, DateTimeOffset createdAt, DateTimeOffset updatedAt, RepositoryPermissions permissions, Repository parent, Repository source, LicenseMetadata license, bool hasDiscussions, bool hasIssues, bool hasWiki, bool hasDownloads, bool hasPages, int subscribersCount, long size, bool? allowRebaseMerge, bool? allowSquashMerge, bool? allowMergeCommit, bool archived, int watchersCount, bool? deleteBranchOnMerge, RepositoryVisibility visibility, IEnumerable<string> topics, bool? allowAutoMerge, bool? allowUpdateBranch, bool? webCommitSignoffRequired)
+        public Repository(string url, string htmlUrl, string cloneUrl, string gitUrl, string sshUrl, string svnUrl, string mirrorUrl, string archiveUrl, long id, string nodeId, User owner, string name, string fullName, bool isTemplate, string description, string homepage, string language, bool @private, bool fork, int forksCount, int stargazersCount, string defaultBranch, int openIssuesCount, DateTimeOffset? pushedAt, DateTimeOffset createdAt, DateTimeOffset updatedAt, RepositoryPermissions permissions, Repository parent, Repository source, LicenseMetadata license, bool hasDiscussions, bool hasIssues, bool hasWiki, bool hasDownloads, bool hasPages, int subscribersCount, long size, bool? allowRebaseMerge, bool? allowSquashMerge, bool? allowMergeCommit, bool archived, int watchersCount, bool? deleteBranchOnMerge, RepositoryVisibility visibility, IEnumerable<string> topics, bool? allowAutoMerge, bool? allowUpdateBranch, bool? webCommitSignoffRequired)
         {
             Url = url;
             HtmlUrl = htmlUrl;
@@ -26,6 +26,7 @@ namespace Octokit
             SshUrl = sshUrl;
             SvnUrl = svnUrl;
             MirrorUrl = mirrorUrl;
+            ArchiveUrl = archiveUrl;
             Id = id;
             NodeId = nodeId;
             Owner = owner;
@@ -83,6 +84,7 @@ namespace Octokit
         public string SvnUrl { get; private set; }
 
         public string MirrorUrl { get; private set; }
+        public string ArchiveUrl { get; private set; }
 
         public long Id { get; private set; }
 


### PR DESCRIPTION
Resolves #2800

----

### Before the change?
There wa sno way to access the archive url field and even if you could just use string concatenation, there's no need for this to not be an option.

### After the change?
Now you can access it through the `Repository.ArchiveUrl` field.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)