### PR TITLE
Getarchive

### DIFF
--- a/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
@@ -4,6 +4,8 @@ using System.Threading.Tasks;
 using NSubstitute;
 using Xunit;
 using System.Collections.Generic;
+using System.Net;
+using Octokit.Internal;
 
 namespace Octokit.Tests.Clients
 {
@@ -881,6 +883,27 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetArchive("org", "repo", ArchiveFormat.Tarball, "ref", TimeSpan.Zero));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetArchive(1, ArchiveFormat.Tarball, "ref", TimeSpan.Zero));
+            }
+
+            [Fact]
+            public async Task ReturnsExpectedContent()
+            {
+                var headers = new Dictionary<string, string>();
+                var response = TestSetup.CreateResponse(HttpStatusCode.OK, new byte[] { 1, 2, 3, 4 }, headers);
+                var responseTask = Task.FromResult<IApiResponse<byte[]>>(new ApiResponse<byte[]>(response));
+
+                var connection = Substitute.For<IConnection>();
+                connection.Get<byte[]>(Arg.Is<Uri>(u => u.ToString() == "repos/org/repo/tarball/"), null)
+                    .Returns(responseTask);
+
+                var apiConnection = Substitute.For<IApiConnection>();
+                apiConnection.Connection.Returns(connection);
+
+                var client = new RepositoryContentsClient(apiConnection);
+
+                var actual = await client.GetArchive("org", "repo");
+
+                Assert.Equal(new byte[] { 1, 2, 3, 4 }, actual);
             }
         }
     }

--- a/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
@@ -750,7 +750,7 @@ namespace Octokit.Tests.Clients
                 const string expectedUri = "repos/org/repo/tarball/";
                 var expectedTimeSpan = TimeSpan.FromMinutes(60);
 
-                connection.Connection.Received().Get<byte[]>(Arg.Is<Uri>(uri => uri.ToString() == expectedUri), Arg.Is<TimeSpan>(span => span == expectedTimeSpan));
+                connection.Connection.Received().GetRaw(Arg.Is<Uri>(uri => uri.ToString() == expectedUri), null, Arg.Is<TimeSpan>(span => span == expectedTimeSpan));
             }
 
             [Fact]
@@ -764,7 +764,7 @@ namespace Octokit.Tests.Clients
                 const string expectedUri = "repositories/1/tarball/";
                 var expectedTimeSpan = TimeSpan.FromMinutes(60);
 
-                connection.Connection.Received().Get<byte[]>(Arg.Is<Uri>(uri => uri.ToString() == expectedUri), Arg.Is<TimeSpan>(span => span == expectedTimeSpan));
+                connection.Connection.Received().GetRaw(Arg.Is<Uri>(uri => uri.ToString() == expectedUri), null, Arg.Is<TimeSpan>(span => span == expectedTimeSpan));
             }
 
             [Fact]
@@ -778,7 +778,7 @@ namespace Octokit.Tests.Clients
                 const string expectedUri = "repos/org/repo/zipball/";
                 var expectedTimeSpan = TimeSpan.FromMinutes(60);
 
-                connection.Connection.Received().Get<byte[]>(Arg.Is<Uri>(uri => uri.ToString() == expectedUri), Arg.Is<TimeSpan>(span => span == expectedTimeSpan));
+                connection.Connection.Received().GetRaw(Arg.Is<Uri>(uri => uri.ToString() == expectedUri), null, Arg.Is<TimeSpan>(span => span == expectedTimeSpan));
             }
 
             [Fact]
@@ -792,7 +792,7 @@ namespace Octokit.Tests.Clients
                 const string expectedUri = "repositories/1/zipball/";
                 var expectedTimeSpan = TimeSpan.FromMinutes(60);
 
-                connection.Connection.Received().Get<byte[]>(Arg.Is<Uri>(uri => uri.ToString() == expectedUri), Arg.Is<TimeSpan>(span => span == expectedTimeSpan));
+                connection.Connection.Received().GetRaw(Arg.Is<Uri>(uri => uri.ToString() == expectedUri), null, Arg.Is<TimeSpan>(span => span == expectedTimeSpan));
             }
 
             [Fact]
@@ -806,7 +806,7 @@ namespace Octokit.Tests.Clients
                 const string expectedUri = "repos/org/repo/zipball/ref";
                 var expectedTimeSpan = TimeSpan.FromMinutes(60);
 
-                connection.Connection.Received().Get<byte[]>(Arg.Is<Uri>(uri => uri.ToString() == expectedUri), Arg.Is<TimeSpan>(span => span == expectedTimeSpan));
+                connection.Connection.Received().GetRaw(Arg.Is<Uri>(uri => uri.ToString() == expectedUri), null, Arg.Is<TimeSpan>(span => span == expectedTimeSpan));
             }
 
             [Fact]
@@ -820,7 +820,7 @@ namespace Octokit.Tests.Clients
                 const string expectedUri = "repositories/1/zipball/ref";
                 var expectedTimeSpan = TimeSpan.FromMinutes(60);
 
-                connection.Connection.Received().Get<byte[]>(Arg.Is<Uri>(uri => uri.ToString() == expectedUri), Arg.Is<TimeSpan>(span => span == expectedTimeSpan));
+                connection.Connection.Received().GetRaw(Arg.Is<Uri>(uri => uri.ToString() == expectedUri), null, Arg.Is<TimeSpan>(span => span == expectedTimeSpan));
             }
 
             [Fact]
@@ -834,7 +834,7 @@ namespace Octokit.Tests.Clients
                 const string expectedUri = "repos/org/repo/zipball/ref";
                 var expectedTimeSpan = TimeSpan.FromMinutes(60);
 
-                connection.Connection.Received().Get<byte[]>(Arg.Is<Uri>(uri => uri.ToString() == expectedUri), Arg.Is<TimeSpan>(span => span == expectedTimeSpan));
+                connection.Connection.Received().GetRaw(Arg.Is<Uri>(uri => uri.ToString() == expectedUri), null, Arg.Is<TimeSpan>(span => span == expectedTimeSpan));
             }
 
             [Fact]
@@ -848,7 +848,7 @@ namespace Octokit.Tests.Clients
                 const string expectedUri = "repositories/1/zipball/ref";
                 var expectedTimeSpan = TimeSpan.FromMinutes(60);
 
-                connection.Connection.Received().Get<byte[]>(Arg.Is<Uri>(uri => uri.ToString() == expectedUri), Arg.Is<TimeSpan>(span => span == expectedTimeSpan));
+                connection.Connection.Received().GetRaw(Arg.Is<Uri>(uri => uri.ToString() == expectedUri), null, Arg.Is<TimeSpan>(span => span == expectedTimeSpan));
             }
 
             [Fact]
@@ -893,7 +893,7 @@ namespace Octokit.Tests.Clients
                 var responseTask = Task.FromResult<IApiResponse<byte[]>>(new ApiResponse<byte[]>(response));
 
                 var connection = Substitute.For<IConnection>();
-                connection.Get<byte[]>(Arg.Is<Uri>(u => u.ToString() == "repos/org/repo/tarball/"), null)
+                connection.GetRaw(Arg.Is<Uri>(u => u.ToString() == "repos/org/repo/tarball/"), null, TimeSpan.FromMinutes(60))
                     .Returns(responseTask);
 
                 var apiConnection = Substitute.For<IApiConnection>();

--- a/Octokit/Clients/RepositoryContentsClient.cs
+++ b/Octokit/Clients/RepositoryContentsClient.cs
@@ -395,7 +395,7 @@ namespace Octokit
 
             var endpoint = ApiUrls.RepositoryArchiveLink(owner, name, archiveFormat, reference);
 
-            var response = await Connection.Get<byte[]>(endpoint, timeout).ConfigureAwait(false);
+            var response = await Connection.GetRaw(endpoint, null, timeout).ConfigureAwait(false);
 
             return response.Body;
         }
@@ -416,7 +416,7 @@ namespace Octokit
 
             var endpoint = ApiUrls.RepositoryArchiveLink(repositoryId, archiveFormat, reference);
 
-            var response = await Connection.Get<byte[]>(endpoint, timeout).ConfigureAwait(false);
+            var response = await Connection.GetRaw(endpoint, null, timeout).ConfigureAwait(false);
 
             return response.Body;
         }

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -244,7 +244,21 @@ namespace Octokit
         }
         
         /// <inheritdoc/>
-        public Task<IApiResponse<Stream>> GetRawStream(Uri uri, IDictionary<string, string> parameters)
+		public Task<IApiResponse<byte[]>> GetRaw(Uri uri, IDictionary<string, string> parameters, TimeSpan timeout)
+        {
+            Ensure.ArgumentNotNull(uri, nameof(uri));
+
+            return GetRaw(new Request
+            {
+                Method = HttpMethod.Get,
+                BaseAddress = BaseAddress,
+                Endpoint = uri.ApplyParameters(parameters),
+                Timeout = timeout
+            });
+        }
+
+        /// <inheritdoc/>
+		public Task<IApiResponse<Stream>> GetRawStream(Uri uri, IDictionary<string, string> parameters)
         {
             Ensure.ArgumentNotNull(uri, nameof(uri));
 

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -242,9 +242,9 @@ namespace Octokit
                 Endpoint = uri.ApplyParameters(parameters)
             });
         }
-        
+
         /// <inheritdoc/>
-		public Task<IApiResponse<byte[]>> GetRaw(Uri uri, IDictionary<string, string> parameters, TimeSpan timeout)
+        public Task<IApiResponse<byte[]>> GetRaw(Uri uri, IDictionary<string, string> parameters, TimeSpan timeout)
         {
             Ensure.ArgumentNotNull(uri, nameof(uri));
 

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -258,7 +258,7 @@ namespace Octokit
         }
 
         /// <inheritdoc/>
-		public Task<IApiResponse<Stream>> GetRawStream(Uri uri, IDictionary<string, string> parameters)
+        public Task<IApiResponse<Stream>> GetRawStream(Uri uri, IDictionary<string, string> parameters)
         {
             Ensure.ArgumentNotNull(uri, nameof(uri));
 

--- a/Octokit/Http/IConnection.cs
+++ b/Octokit/Http/IConnection.cs
@@ -36,9 +36,19 @@ namespace Octokit
         /// </summary>
         /// <param name="uri">URI endpoint to send request to</param>
         /// <param name="parameters">Querystring parameters for the request</param>
+        /// <param name="timeout">The Timeout value</param>
         /// <returns><seealso cref="IResponse"/> representing the received HTTP response</returns>
         /// <remarks>The <see cref="IResponse.Body"/> property will be <c>null</c> if the <paramref name="uri"/> points to a directory instead of a file</remarks>
-        Task<IApiResponse<Stream>> GetRawStream(Uri uri, IDictionary<string, string> parameters);
+        Task<IApiResponse<byte[]>> GetRaw(Uri uri, IDictionary<string, string> parameters, TimeSpan timeout);
+
+        /// <summary>
+		/// Performs an asynchronous HTTP GET request that expects a <seealso cref="IResponse"/> containing raw data.
+		/// </summary>
+		/// <param name="uri">URI endpoint to send request to</param>
+		/// <param name="parameters">Querystring parameters for the request</param>
+		/// <returns><seealso cref="IResponse"/> representing the received HTTP response</returns>
+		/// <remarks>The <see cref="IResponse.Body"/> property will be <c>null</c> if the <paramref name="uri"/> points to a directory instead of a file</remarks>
+		Task<IApiResponse<Stream>> GetRawStream(Uri uri, IDictionary<string, string> parameters);
 
         /// <summary>
         /// Performs an asynchronous HTTP GET request.

--- a/Octokit/Http/IConnection.cs
+++ b/Octokit/Http/IConnection.cs
@@ -30,7 +30,7 @@ namespace Octokit
         /// <returns><seealso cref="IResponse"/> representing the received HTTP response</returns>
         /// <remarks>The <see cref="IResponse.Body"/> property will be <c>null</c> if the <paramref name="uri"/> points to a directory instead of a file</remarks>
         Task<IApiResponse<byte[]>> GetRaw(Uri uri, IDictionary<string, string> parameters);
-        
+
         /// <summary>
         /// Performs an asynchronous HTTP GET request that expects a <seealso cref="IResponse"/> containing raw data.
         /// </summary>
@@ -42,13 +42,13 @@ namespace Octokit
         Task<IApiResponse<byte[]>> GetRaw(Uri uri, IDictionary<string, string> parameters, TimeSpan timeout);
 
         /// <summary>
-		/// Performs an asynchronous HTTP GET request that expects a <seealso cref="IResponse"/> containing raw data.
-		/// </summary>
-		/// <param name="uri">URI endpoint to send request to</param>
-		/// <param name="parameters">Querystring parameters for the request</param>
-		/// <returns><seealso cref="IResponse"/> representing the received HTTP response</returns>
-		/// <remarks>The <see cref="IResponse.Body"/> property will be <c>null</c> if the <paramref name="uri"/> points to a directory instead of a file</remarks>
-		Task<IApiResponse<Stream>> GetRawStream(Uri uri, IDictionary<string, string> parameters);
+        /// Performs an asynchronous HTTP GET request that expects a <seealso cref="IResponse"/> containing raw data.
+        /// </summary>
+        /// <param name="uri">URI endpoint to send request to</param>
+        /// <param name="parameters">Querystring parameters for the request</param>
+        /// <returns><seealso cref="IResponse"/> representing the received HTTP response</returns>
+        /// <remarks>The <see cref="IResponse.Body"/> property will be <c>null</c> if the <paramref name="uri"/> points to a directory instead of a file</remarks>
+        Task<IApiResponse<Stream>> GetRawStream(Uri uri, IDictionary<string, string> parameters);
 
         /// <summary>
         /// Performs an asynchronous HTTP GET request.


### PR DESCRIPTION
Resolves #2802

----

### Before the change?
RepositoryContentsClient.GetArchive expects the result of the API call to contain a byte[] when in fact a stream is returned. This bug is due to a change introduced [here](https://github.com/octokit/octokit.net/commit/958bc5f1f87cd97cd8520ac74f958c2df12903b3?diff=unified#diff-a2515f648f91f996285bf547708f9e1e8450b04ac226e3f97114510e0cb476e7).

### After the change?
RepositoryContentsClient.GetArchive invokes Connection.GetRaw rather than Connection.Get<byte[]> in order to be the binary content of the response.

### Pull request checklist
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
- [ ] Yes
- [x] No

To ensure that I was not introducing a breaking change, I created an overload of the existing `GetRaw` method to accept a timeout parameter. I could have added an additional parameter to the existing GetRaw method, but that would have been a breaking change. If you prefer the "additional-parameter-to-existing-method" rather than "overload-existing-method", I'll be happy to modifiy my PR.

----

