### PR TITLE
[BREAKING CHANGE]: Removes the .NET 5.0  support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,11 +1,10 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.234.0/containers/dotnet/.devcontainer/base.Dockerfile
 
-# [Choice] .NET version: 6.0, 5.0, 6.0-bullseye, 5.0-bullseye, 6.0-focal, 5.0-focal
+# [Choice] .NET version: 6.0, 6.0-bullseye, 6.0-focal
 ARG VARIANT="6.0-bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/dotnet
 
-# "install" the dotnet 5.0 & 6.0 runtime for tests
-# COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet/shared /usr/share/dotnet/shared
+# "install" the dotnet 6.0 runtime for tests
 COPY --from=mcr.microsoft.com/dotnet/sdk:6.0 /usr/share/dotnet/shared /usr/share/dotnet/shared
 
 # # Add mkdocs for doc generation

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,7 +5,7 @@ ARG VARIANT="6.0-bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/dotnet
 
 # "install" the dotnet 5.0 & 6.0 runtime for tests
-COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet/shared /usr/share/dotnet/shared
+# COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet/shared /usr/share/dotnet/shared
 COPY --from=mcr.microsoft.com/dotnet/sdk:6.0 /usr/share/dotnet/shared /usr/share/dotnet/shared
 
 # # Add mkdocs for doc generation

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
-      // Update 'VARIANT' to pick a .NET Core version: 5.0, 6.0
+      // Update 'VARIANT' to pick a .NET Core version: 6.0
       // Append -bullseye or -focal to pin to an OS version.
       "VARIANT": "latest"
     }

--- a/.github/workflows/netcore.yml
+++ b/.github/workflows/netcore.yml
@@ -19,10 +19,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Setup .NET 5
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 5.0.*
     - name: Setup .NET 6
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,6 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: Setup .NET 5
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 5.0.*
     - name: Setup .NET 6
       uses: actions/setup-dotnet@v1
       with:


### PR DESCRIPTION
The [.NET 5.0 SDK has been EoL since May 2022 ](https://devblogs.microsoft.com/dotnet/dotnet-5-end-of-support-update/) and should no longer be needed (unless mono requires it), so our tooling here needs to reflect that.

### Before the change 

- .net 5.0 SDK is installed when the container gets instantiated using the dev container file
- Supported versions: net5.0, net5.0-windows, net6.0, net6.0-android, net6.0-ios, net6.0-maccatalys, net6.0-macos , net6.0-tvos, net6.0-windows , net7.0 , net7.0-android , net7.0-ios net7.0-ios , net7.0-maccatalyst , net7.0-macos , net7.0-tvos net7.0-tvos , net7.0-windows

### After the change 

- .net 6.0 SDK is the only version installed when the container gets instantiated using the dev container file
- Supported versions: net6.0, net6.0-android, net6.0-ios, net6.0-maccatalys, net6.0-macos , net6.0-tvos, net6.0-windows , net7.0 , net7.0-android , net7.0-ios net7.0-ios , net7.0-maccatalyst , net7.0-macos , net7.0-tvos net7.0-tvos , net7.0-windows

relates to: https://github.com/octokit/octokit.net/pull/2616
