### PR TITLE
[Fix]: The methods `GetAllForCurrentWithTimestamps` and `GetAllForUserWithTimestamps` did not return timestamps.

### DIFF
--- a/Octokit.Tests.Integration/Clients/StarredClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/StarredClientTests.cs
@@ -167,6 +167,8 @@ namespace Octokit.Tests.Integration.Clients
 
             var repo = stars.FirstOrDefault(star => star.Repo.Owner.Login == _repositoryContext.RepositoryOwner && star.Repo.Name == _repositoryContext.RepositoryName);
             Assert.NotNull(repo);
+            Assert.NotEqual(DateTimeOffset.MinValue, repo.StarredAt);
+            Assert.NotNull(repo.Repo);
         }
 
         [IntegrationTest]
@@ -232,6 +234,8 @@ namespace Octokit.Tests.Integration.Clients
 
             var repo = stars.FirstOrDefault(star => star.Repo.Owner.Login == _repositoryContext.RepositoryOwner && star.Repo.Name == _repositoryContext.RepositoryName);
             Assert.NotNull(repo);
+            Assert.NotEqual(DateTimeOffset.MinValue, repo.StarredAt);
+            Assert.NotNull(repo.Repo);
 
             for (int i = 1; i < stars.Count; i++)
             {
@@ -456,6 +460,8 @@ namespace Octokit.Tests.Integration.Clients
 
             var star = stars.FirstOrDefault(repositoryStar => repositoryStar.Repo.Owner.Login == _repositoryContext.RepositoryOwner && repositoryStar.Repo.Name == _repositoryContext.RepositoryName);
             Assert.NotNull(star);
+            Assert.NotEqual(DateTimeOffset.MinValue, star.StarredAt);
+            Assert.NotNull(star.Repo);
         }
 
         [IntegrationTest]
@@ -521,6 +527,8 @@ namespace Octokit.Tests.Integration.Clients
 
             var repo = stars.FirstOrDefault(repository => repository.Repo.Owner.Login == _repositoryContext.RepositoryOwner && repository.Repo.Name == _repositoryContext.RepositoryName);
             Assert.NotNull(repo);
+            Assert.NotEqual(DateTimeOffset.MinValue, repo.StarredAt);
+            Assert.NotNull(repo.Repo);
 
             for (int i = 1; i < stars.Count; i++)
             {

--- a/Octokit.Tests/Clients/StarredClientTests.cs
+++ b/Octokit.Tests/Clients/StarredClientTests.cs
@@ -99,7 +99,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForCurrentWithTimestamps();
 
-                connection.Received().GetAll<RepositoryStar>(endpoint, null, Args.ApiOptions);
+                connection.Received().GetAll<RepositoryStar>(endpoint, null, AcceptHeaders.StarJson, Args.ApiOptions);
             }
 
             [Fact]
@@ -118,7 +118,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForCurrentWithTimestamps(options);
 
-                connection.Received().GetAll<RepositoryStar>(endpoint, null, options);
+                connection.Received().GetAll<RepositoryStar>(endpoint, null, AcceptHeaders.StarJson, options);
             }
 
             [Fact]
@@ -132,7 +132,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForCurrentWithTimestamps(request);
 
-                connection.Received().GetAll<RepositoryStar>(endpoint, Arg.Is<IDictionary<string, string>>(d => d.Count == 2 && d["direction"] == "asc"), Args.ApiOptions);
+                connection.Received().GetAll<RepositoryStar>(endpoint, Arg.Is<IDictionary<string, string>>(d => d.Count == 2 && d["direction"] == "asc"), AcceptHeaders.StarJson, Args.ApiOptions);
             }
 
             [Fact]
@@ -153,7 +153,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForCurrentWithTimestamps(request, options);
 
-                connection.Received().GetAll<RepositoryStar>(endpoint, Arg.Is<IDictionary<string, string>>(d => d.Count == 2 && d["direction"] == "asc"), options);
+                connection.Received().GetAll<RepositoryStar>(endpoint, Arg.Is<IDictionary<string, string>>(d => d.Count == 2 && d["direction"] == "asc"), AcceptHeaders.StarJson, options);
             }
 
             [Fact]
@@ -250,7 +250,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForUserWithTimestamps("banana");
 
-                connection.Received().GetAll<RepositoryStar>(endpoint, null, Args.ApiOptions);
+                connection.Received().GetAll<RepositoryStar>(endpoint, null, AcceptHeaders.StarJson, Args.ApiOptions);
             }
 
             [Fact]
@@ -269,7 +269,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForUserWithTimestamps("banana", options);
 
-                connection.Received().GetAll<RepositoryStar>(endpoint, null, options);
+                connection.Received().GetAll<RepositoryStar>(endpoint, null, AcceptHeaders.StarJson, options);
             }
 
             [Fact]
@@ -283,7 +283,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForUserWithTimestamps("banana", starredRequest);
 
-                connection.Received().GetAll<RepositoryStar>(endpoint, Arg.Is<IDictionary<string, string>>(d => d.Count == 2 && d["direction"] == "asc"), Args.ApiOptions);
+                connection.Received().GetAll<RepositoryStar>(endpoint, Arg.Is<IDictionary<string, string>>(d => d.Count == 2 && d["direction"] == "asc"), AcceptHeaders.StarJson, Args.ApiOptions);
             }
 
             [Fact]
@@ -304,7 +304,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForUserWithTimestamps("banana", starredRequest, options);
 
-                connection.Received().GetAll<RepositoryStar>(endpoint, Arg.Is<IDictionary<string, string>>(d => d.Count == 2 && d["direction"] == "asc"), options);
+                connection.Received().GetAll<RepositoryStar>(endpoint, Arg.Is<IDictionary<string, string>>(d => d.Count == 2 && d["direction"] == "asc"), AcceptHeaders.StarJson, options);
             }
 
             [Fact]

--- a/Octokit/Clients/StarredClient.cs
+++ b/Octokit/Clients/StarredClient.cs
@@ -177,7 +177,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return ApiConnection.GetAll<RepositoryStar>(ApiUrls.Starred(), null, options);
+            return ApiConnection.GetAll<RepositoryStar>(ApiUrls.Starred(), null, AcceptHeaders.StarJson, options);
         }
 
         /// <summary>
@@ -237,7 +237,7 @@ namespace Octokit
             Ensure.ArgumentNotNull(request, nameof(request));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return ApiConnection.GetAll<RepositoryStar>(ApiUrls.Starred(), request.ToParametersDictionary(), options);
+            return ApiConnection.GetAll<RepositoryStar>(ApiUrls.Starred(), request.ToParametersDictionary(), AcceptHeaders.StarJson, options);
         }
 
         /// <summary>
@@ -293,7 +293,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return ApiConnection.GetAll<RepositoryStar>(ApiUrls.StarredByUser(user), null, options);
+            return ApiConnection.GetAll<RepositoryStar>(ApiUrls.StarredByUser(user), null, AcceptHeaders.StarJson, options);
         }
 
         /// <summary>
@@ -359,7 +359,7 @@ namespace Octokit
             Ensure.ArgumentNotNull(request, nameof(request));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return ApiConnection.GetAll<RepositoryStar>(ApiUrls.StarredByUser(user), request.ToParametersDictionary(), options);
+            return ApiConnection.GetAll<RepositoryStar>(ApiUrls.StarredByUser(user), request.ToParametersDictionary(), AcceptHeaders.StarJson, options);
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2827

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

`StarredClient.GetAllForCurrentWithTimestamps` and `StarredClient.GetAllForUserWithTimestamps` expect to be returned with the `StarredAt` and `Repo` properties set, but default values are returned.

![image](https://github.com/octokit/octokit.net/assets/807378/4e694625-cc54-4249-b679-f67938ac1393)

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The `StarredAt` and `Repo` property values are returned with the received values set.

![image](https://github.com/octokit/octokit.net/assets/807378/0e67ae87-5c58-495c-bd79-e41743306663)

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

