### PR TITLE
[FEAT] Add support for "Require approval of the most recent reviewable push"

### DIFF
--- a/Octokit.Tests.Integration/Clients/RepositoryBranchesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryBranchesClientTests.cs
@@ -292,6 +292,7 @@ namespace Octokit.Tests.Integration.Clients
                     Assert.Null(protection.RequiredPullRequestReviews.DismissalRestrictions);
                     Assert.True(protection.RequiredPullRequestReviews.DismissStaleReviews);
                     Assert.True(protection.RequiredPullRequestReviews.RequireCodeOwnerReviews);
+                    Assert.True(protection.RequiredPullRequestReviews.RequireLastPushApproval);
 
                     Assert.Null(protection.Restrictions);
 
@@ -320,6 +321,7 @@ namespace Octokit.Tests.Integration.Clients
                     Assert.Null(protection.RequiredPullRequestReviews.DismissalRestrictions);
                     Assert.True(protection.RequiredPullRequestReviews.DismissStaleReviews);
                     Assert.True(protection.RequiredPullRequestReviews.RequireCodeOwnerReviews);
+                    Assert.True(protection.RequiredPullRequestReviews.RequireLastPushApproval);
 
                     Assert.Null(protection.Restrictions);
 
@@ -349,6 +351,7 @@ namespace Octokit.Tests.Integration.Clients
                     Assert.Equal(0, protection.RequiredPullRequestReviews.DismissalRestrictions.Users.Count);
                     Assert.True(protection.RequiredPullRequestReviews.DismissStaleReviews);
                     Assert.True(protection.RequiredPullRequestReviews.RequireCodeOwnerReviews);
+                    Assert.True(protection.RequiredPullRequestReviews.RequireLastPushApproval);
 
                     Assert.Equal(1, protection.Restrictions.Teams.Count);
                     Assert.Equal(0, protection.Restrictions.Users.Count);
@@ -373,6 +376,7 @@ namespace Octokit.Tests.Integration.Clients
                     Assert.Equal(0, protection.RequiredPullRequestReviews.DismissalRestrictions.Users.Count);
                     Assert.True(protection.RequiredPullRequestReviews.DismissStaleReviews);
                     Assert.True(protection.RequiredPullRequestReviews.RequireCodeOwnerReviews);
+                    Assert.True(protection.RequiredPullRequestReviews.RequireLastPushApproval);
 
                     Assert.Equal(1, protection.Restrictions.Teams.Count);
                     Assert.Equal(0, protection.Restrictions.Users.Count);
@@ -404,6 +408,7 @@ namespace Octokit.Tests.Integration.Clients
                     Assert.Null(protection.RequiredPullRequestReviews.DismissalRestrictions);
                     Assert.False(protection.RequiredPullRequestReviews.DismissStaleReviews);
                     Assert.True(protection.RequiredPullRequestReviews.RequireCodeOwnerReviews);
+                    Assert.True(protection.RequiredPullRequestReviews.RequireLastPushApproval);
                     Assert.Equal(2, protection.RequiredPullRequestReviews.RequiredApprovingReviewCount);
 
                     Assert.Null(protection.Restrictions);
@@ -432,6 +437,7 @@ namespace Octokit.Tests.Integration.Clients
                     Assert.Null(protection.RequiredPullRequestReviews.DismissalRestrictions);
                     Assert.False(protection.RequiredPullRequestReviews.DismissStaleReviews);
                     Assert.True(protection.RequiredPullRequestReviews.RequireCodeOwnerReviews);
+                    Assert.True(protection.RequiredPullRequestReviews.RequireLastPushApproval);
                     Assert.Equal(2, protection.RequiredPullRequestReviews.RequiredApprovingReviewCount);
 
                     Assert.Null(protection.Restrictions);
@@ -461,6 +467,7 @@ namespace Octokit.Tests.Integration.Clients
                     Assert.Null(protection.RequiredPullRequestReviews.DismissalRestrictions);
                     Assert.False(protection.RequiredPullRequestReviews.DismissStaleReviews);
                     Assert.False(protection.RequiredPullRequestReviews.RequireCodeOwnerReviews);
+                    Assert.False(protection.RequiredPullRequestReviews.RequireLastPushApproval);
                     Assert.Equal(2, protection.RequiredPullRequestReviews.RequiredApprovingReviewCount);
 
                     Assert.Empty(protection.Restrictions.Teams);
@@ -490,6 +497,7 @@ namespace Octokit.Tests.Integration.Clients
                     Assert.Null(protection.RequiredPullRequestReviews.DismissalRestrictions);
                     Assert.False(protection.RequiredPullRequestReviews.DismissStaleReviews);
                     Assert.False(protection.RequiredPullRequestReviews.RequireCodeOwnerReviews);
+                    Assert.False(protection.RequiredPullRequestReviews.RequireLastPushApproval);
                     Assert.Equal(2, protection.RequiredPullRequestReviews.RequiredApprovingReviewCount);
 
                     Assert.Empty(protection.Restrictions.Teams);
@@ -798,6 +806,7 @@ namespace Octokit.Tests.Integration.Clients
                     Assert.Null(requiredReviews.DismissalRestrictions);
                     Assert.True(requiredReviews.DismissStaleReviews);
                     Assert.True(requiredReviews.RequireCodeOwnerReviews);
+                    Assert.True(requiredReviews.RequireLastPushApproval);
                 }
             }
 
@@ -813,6 +822,7 @@ namespace Octokit.Tests.Integration.Clients
                     Assert.Null(requiredReviews.DismissalRestrictions);
                     Assert.True(requiredReviews.DismissStaleReviews);
                     Assert.True(requiredReviews.RequireCodeOwnerReviews);
+                    Assert.True(requiredReviews.RequireLastPushApproval);
                 }
             }
 
@@ -829,6 +839,7 @@ namespace Octokit.Tests.Integration.Clients
                     Assert.Equal(0, requiredReviews.DismissalRestrictions.Users.Count);
                     Assert.True(requiredReviews.DismissStaleReviews);
                     Assert.True(requiredReviews.RequireCodeOwnerReviews);
+                    Assert.True(requiredReviews.RequireLastPushApproval);
                 }
             }
 
@@ -845,6 +856,7 @@ namespace Octokit.Tests.Integration.Clients
                     Assert.Equal(0, requiredReviews.DismissalRestrictions.Users.Count);
                     Assert.True(requiredReviews.DismissStaleReviews);
                     Assert.True(requiredReviews.RequireCodeOwnerReviews);
+                    Assert.True(requiredReviews.RequireLastPushApproval);
                 }
             }
         }
@@ -865,6 +877,7 @@ namespace Octokit.Tests.Integration.Clients
                     Assert.Null(requiredReviews.DismissalRestrictions);
                     Assert.False(requiredReviews.DismissStaleReviews);
                     Assert.True(requiredReviews.RequireCodeOwnerReviews);
+                    Assert.True(requiredReviews.RequireLastPushApproval);
                     Assert.Equal(2, requiredReviews.RequiredApprovingReviewCount);
                 }
             }
@@ -883,6 +896,7 @@ namespace Octokit.Tests.Integration.Clients
                     Assert.Null(requiredReviews.DismissalRestrictions);
                     Assert.False(requiredReviews.DismissStaleReviews);
                     Assert.True(requiredReviews.RequireCodeOwnerReviews);
+                    Assert.True(requiredReviews.RequireLastPushApproval);
                     Assert.Equal(2, requiredReviews.RequiredApprovingReviewCount);
                 }
             }
@@ -905,6 +919,7 @@ namespace Octokit.Tests.Integration.Clients
                     Assert.Null(requiredReviews.DismissalRestrictions);
                     Assert.False(requiredReviews.DismissStaleReviews);
                     Assert.False(requiredReviews.RequireCodeOwnerReviews);
+                    Assert.False(requiredReviews.RequireLastPushApproval);
                     Assert.Equal(2, requiredReviews.RequiredApprovingReviewCount);
                 }
             }
@@ -927,6 +942,7 @@ namespace Octokit.Tests.Integration.Clients
                     Assert.Null(requiredReviews.DismissalRestrictions);
                     Assert.False(requiredReviews.DismissStaleReviews);
                     Assert.False(requiredReviews.RequireCodeOwnerReviews);
+                    Assert.False(requiredReviews.RequireLastPushApproval);
                     Assert.Equal(2, requiredReviews.RequiredApprovingReviewCount);
                 }
             }
@@ -950,6 +966,7 @@ namespace Octokit.Tests.Integration.Clients
                     Assert.Empty(requiredReviews.DismissalRestrictions.Users);
                     Assert.False(requiredReviews.DismissStaleReviews);
                     Assert.False(requiredReviews.RequireCodeOwnerReviews);
+                    Assert.False(requiredReviews.RequireLastPushApproval);
                     Assert.Equal(2, requiredReviews.RequiredApprovingReviewCount);
                 }
             }
@@ -973,6 +990,7 @@ namespace Octokit.Tests.Integration.Clients
                     Assert.Empty(requiredReviews.DismissalRestrictions.Users);
                     Assert.False(requiredReviews.DismissStaleReviews);
                     Assert.False(requiredReviews.RequireCodeOwnerReviews);
+                    Assert.False(requiredReviews.RequireLastPushApproval);
                     Assert.Equal(2, requiredReviews.RequiredApprovingReviewCount);
                 }
             }

--- a/Octokit.Tests.Integration/Helpers/OrganizationRepositoryWithTeamContext.cs
+++ b/Octokit.Tests.Integration/Helpers/OrganizationRepositoryWithTeamContext.cs
@@ -28,7 +28,7 @@ namespace Octokit.Tests.Integration.Helpers
             // Protect default branch
             var update = new BranchProtectionSettingsUpdate(
                 new BranchProtectionRequiredStatusChecksUpdate(true, new[] { "build", "test" }),
-                new BranchProtectionRequiredReviewsUpdate(true, true, 3),
+                new BranchProtectionRequiredReviewsUpdate(true, true, 3, true),
                 null,
                 true,
                 true,
@@ -78,7 +78,7 @@ namespace Octokit.Tests.Integration.Helpers
             // Protect default branch
             var protection = new BranchProtectionSettingsUpdate(
                 new BranchProtectionRequiredStatusChecksUpdate(true, new[] { "build", "test" }),
-                new BranchProtectionRequiredReviewsUpdate(new BranchProtectionRequiredReviewsDismissalRestrictionsUpdate(new BranchProtectionTeamCollection { team.TeamName }), true, true, 3),
+                new BranchProtectionRequiredReviewsUpdate(new BranchProtectionRequiredReviewsDismissalRestrictionsUpdate(new BranchProtectionTeamCollection { team.TeamName }), true, true, 3, true),
                 new BranchProtectionPushRestrictionsUpdate(new BranchProtectionTeamCollection { team.TeamName }),
                 true);
             await client.Repository.Branch.UpdateBranchProtection(repoContext.RepositoryOwner, repoContext.RepositoryName, repoContext.RepositoryDefaultBranch, protection);
@@ -105,7 +105,7 @@ namespace Octokit.Tests.Integration.Helpers
             // Protect default branch
             var protection = new BranchProtectionSettingsUpdate(
                 new BranchProtectionRequiredStatusChecksUpdate(true, new[] { "build", "test" }),
-                new BranchProtectionRequiredReviewsUpdate(new BranchProtectionRequiredReviewsDismissalRestrictionsUpdate(new BranchProtectionTeamCollection { contextOrgTeam.TeamName }), true, true, 3),
+                new BranchProtectionRequiredReviewsUpdate(new BranchProtectionRequiredReviewsDismissalRestrictionsUpdate(new BranchProtectionTeamCollection { contextOrgTeam.TeamName }), true, true, 3, true),
                 new BranchProtectionPushRestrictionsUpdate(new BranchProtectionTeamCollection { contextOrgTeam.TeamName }),
                 true);
             await client.Repository.Branch.UpdateBranchProtection(contextOrgRepo.RepositoryOwner, contextOrgRepo.RepositoryName, "main", protection);

--- a/Octokit/Models/Request/BranchProtectionUpdate.cs
+++ b/Octokit/Models/Request/BranchProtectionUpdate.cs
@@ -370,11 +370,13 @@ namespace Octokit
         /// <param name="dismissStaleReviews">Dismiss approved reviews automatically when a new commit is pushed.</param>
         /// <param name="requireCodeOwnerReviews">Blocks merge until code owners have reviewed.</param>
         /// <param name="requiredApprovingReviewCount">Specify the number of reviewers required to approve pull requests. Use a number between 1 and 6.</param>
-        public BranchProtectionRequiredReviewsUpdate(bool dismissStaleReviews, bool requireCodeOwnerReviews, int requiredApprovingReviewCount)
+        /// <param name="requireLastPushApproval">Whether the most recent push must be approved by someone other than the person who pushed it. Default: false.</param>
+        public BranchProtectionRequiredReviewsUpdate(bool dismissStaleReviews, bool requireCodeOwnerReviews, int requiredApprovingReviewCount, bool requireLastPushApproval = false)
         {
             DismissStaleReviews = dismissStaleReviews;
             RequireCodeOwnerReviews = requireCodeOwnerReviews;
             RequiredApprovingReviewCount = requiredApprovingReviewCount;
+            RequireLastPushApproval = requireLastPushApproval;
         }
 
         /// <summary>
@@ -384,7 +386,8 @@ namespace Octokit
         /// <param name="dismissStaleReviews">Dismiss approved reviews automatically when a new commit is pushed.</param>
         /// <param name="requireCodeOwnerReviews">Blocks merge until code owners have reviewed.</param>
         /// <param name="requiredApprovingReviewCount">Specify the number of reviewers required to approve pull requests. Use a number between 1 and 6.</param>
-        public BranchProtectionRequiredReviewsUpdate(BranchProtectionRequiredReviewsDismissalRestrictionsUpdate dismissalRestrictions, bool dismissStaleReviews, bool requireCodeOwnerReviews, int requiredApprovingReviewCount)
+        /// <param name="requireLastPushApproval">Whether the most recent push must be approved by someone other than the person who pushed it. Default: false.</param>
+        public BranchProtectionRequiredReviewsUpdate(BranchProtectionRequiredReviewsDismissalRestrictionsUpdate dismissalRestrictions, bool dismissStaleReviews, bool requireCodeOwnerReviews, int requiredApprovingReviewCount, bool requireLastPushApproval = false)
         {
             Ensure.ArgumentNotNull(dismissalRestrictions, nameof(dismissalRestrictions));
 
@@ -392,6 +395,7 @@ namespace Octokit
             DismissStaleReviews = dismissStaleReviews;
             RequireCodeOwnerReviews = requireCodeOwnerReviews;
             RequiredApprovingReviewCount = requiredApprovingReviewCount;
+            RequireLastPushApproval = requireLastPushApproval;
         }
 
         /// <summary>
@@ -413,16 +417,22 @@ namespace Octokit
         /// Specify the number of reviewers required to approve pull requests. Use a number between 1 and 6.
         /// </summary>
         public int RequiredApprovingReviewCount { get; protected set; }
+        
+        /// <summary>
+        /// Whether the most recent push must be approved by someone other than the person who pushed it. Default: false
+        /// </summary>
+        public bool RequireLastPushApproval { get; protected set; }
 
         internal string DebuggerDisplay
         {
             get
             {
-                return string.Format(CultureInfo.InvariantCulture, "DismissalRestrictions: {0} DismissStaleReviews: {1} RequireCodeOwnerReviews: {2} RequiredApprovingReviewCount: {3}",
+                return string.Format(CultureInfo.InvariantCulture, "DismissalRestrictions: {0} DismissStaleReviews: {1} RequireCodeOwnerReviews: {2} RequiredApprovingReviewCount: {3} RequireLastPushApproval: {4}",
                     DismissalRestrictions?.DebuggerDisplay ?? "disabled",
                     DismissStaleReviews,
                     RequireCodeOwnerReviews,
-                    RequiredApprovingReviewCount);
+                    RequiredApprovingReviewCount,
+                    RequireLastPushApproval);
             }
         }
     }

--- a/Octokit/Models/Response/BranchProtection.cs
+++ b/Octokit/Models/Response/BranchProtection.cs
@@ -236,12 +236,13 @@ namespace Octokit
     {
         public BranchProtectionRequiredReviews() { }
 
-        public BranchProtectionRequiredReviews(BranchProtectionRequiredReviewsDismissalRestrictions dismissalRestrictions, bool dismissStaleReviews, bool requireCodeOwnerReviews, int requiredApprovingReviewCount)
+        public BranchProtectionRequiredReviews(BranchProtectionRequiredReviewsDismissalRestrictions dismissalRestrictions, bool dismissStaleReviews, bool requireCodeOwnerReviews, int requiredApprovingReviewCount, bool requireLastPushApproval)
         {
             DismissalRestrictions = dismissalRestrictions;
             DismissStaleReviews = dismissStaleReviews;
             RequireCodeOwnerReviews = requireCodeOwnerReviews;
             RequiredApprovingReviewCount = requiredApprovingReviewCount;
+            RequireLastPushApproval = requireLastPushApproval;
         }
 
         /// <summary>
@@ -263,16 +264,22 @@ namespace Octokit
         /// Specify the number of reviewers required to approve pull requests. Use a number between 1 and 6.
         /// </summary>
         public int RequiredApprovingReviewCount { get; private set; }
+        
+        /// <summary>
+        /// Whether the most recent push must be approved by someone other than the person who pushed it. Default: false
+        /// </summary>
+        public bool RequireLastPushApproval { get; protected set; }
 
         internal string DebuggerDisplay
         {
             get
             {
-                return string.Format(CultureInfo.InvariantCulture, "DismissalRestrictions: {0} DismissStaleReviews: {1} RequireCodeOwnerReviews: {2} RequiredApprovingReviewCount: {3}",
+                return string.Format(CultureInfo.InvariantCulture, "DismissalRestrictions: {0} DismissStaleReviews: {1} RequireCodeOwnerReviews: {2} RequiredApprovingReviewCount: {3} RequireLastPushApproval: {4}",
                     DismissalRestrictions?.DebuggerDisplay ?? "disabled",
                     DismissStaleReviews,
                     RequireCodeOwnerReviews,
-                    RequiredApprovingReviewCount);
+                    RequiredApprovingReviewCount,
+                    RequireLastPushApproval);
             }
         }
     }


### PR DESCRIPTION
Resolves #2837

----

### Before the change?

It was not possible to set the Branch Protection option "Require approval of the most recent reviewable push".

### After the change?

We can now set, update and retrieve the Branch Protection option "Require approval of the most recent reviewable push".

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

No breaking change as made with defaulting to false, so keeping the current behaviour.

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

