### PR TITLE
[feat] Introduce NewRelease.DiscussionCategoryName, Fixes #2746

### DIFF
--- a/Octokit/Models/Request/NewRelease.cs
+++ b/Octokit/Models/Request/NewRelease.cs
@@ -74,6 +74,15 @@ namespace Octokit
         public bool Prerelease { get; set; }
 
         /// <summary>
+        /// If specified, a discussion of the specified category is created and linked to the release.
+        /// The value must be a category that already exists in the repository.
+        /// <value>
+        /// The discussion category name.
+        /// </value>
+        /// </summary>
+        public string DiscussionCategoryName { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to automatically generate the name and body for this release.
         /// If <see cref="Name">name</see> is specified, the specified name will be used; otherwise, a name will
         /// be automatically generated. If <see cref="Body">body</see> is specified, the body will be pre-pended to the

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -55,6 +55,18 @@ newRelease.GenerateReleaseNotes = true; // Set for Name and Body to be generated
 newRelease.TargetCommitish = "main"; // Optional, can be a branch, tag, or SHA; defaults to the main branch.
 ```
 
+### Generate a discussion
+
+Using the `DiscussionCategoryName`, it's possible to create a discussion linked to the upcoming release.
+The value must be a category that already exists in the repository.
+For more information, see "[Managing categories for discussions in your repository](https://docs.github.com/discussions/managing-discussions-for-your-community/managing-categories-for-discussions-in-your-repository)."
+
+```csharp
+var newTag = "v1.5.7";
+var newRelease = new NewRelease(newTag);
+newRelease.DiscussionCategoryName = "Announcements";
+```
+
 #### Customizing generated notes
 ```csharp
 var newTag = "v1.5.7";


### PR DESCRIPTION
In this PR, we introduce the support of `discussion_category_name` for new releases:

> `discussion_category_name` `string`
> If specified, a discussion of the specified category is created and linked to the release. The value must be a category that already exists in the repository. For more information, see "[Managing categories for discussions in your repository](https://docs.github.com/discussions/managing-discussions-for-your-community/managing-categories-for-discussions-in-your-repository)."

This parameter was introduced in GitHub REST API 2022-11-28, see https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release

Resolves #2746