### PR TITLE
[feat] Add Rocket & Eyes reactions to `ReactionSummary`

### DIFF
--- a/Octokit.Tests/Models/IssueTest.cs
+++ b/Octokit.Tests/Models/IssueTest.cs
@@ -122,7 +122,19 @@ public class IssueTest
 ""type"": ""User"",
 ""site_admin"": false,
 },
-""active_lock_reason"": null
+""active_lock_reason"": null,
+""reactions"": {
+""url"": ""https://api.github.com/repos/octocat/Hello-World/issues/1347/reactions"",
+""total_count"": 5,
+""+1"": 1,
+""-1"": 2,
+""laugh"": 0,
+""hooray"": 0,
+""confused"": 0,
+""heart"": 0,
+""rocket"": 1,
+""eyes"": 1
+}
 }";
         var serializer = new SimpleJsonSerializer();
 
@@ -132,6 +144,16 @@ public class IssueTest
         Assert.Equal("octocat", issue.User.Login);
         Assert.Equal("bug", issue.Labels.First().Name);
         Assert.Null(issue.ActiveLockReason);
+
+        Assert.Equal(5, issue.Reactions.TotalCount);
+        Assert.Equal(1, issue.Reactions.Plus1);
+        Assert.Equal(2, issue.Reactions.Minus1);
+        Assert.Equal(0, issue.Reactions.Laugh);
+        Assert.Equal(0, issue.Reactions.Hooray);
+        Assert.Equal(0, issue.Reactions.Confused);
+        Assert.Equal(0, issue.Reactions.Heart);
+        Assert.Equal(1, issue.Reactions.Rocket);
+        Assert.Equal(1, issue.Reactions.Eyes);
     }
 
     public class TheToUpdateMethod

--- a/Octokit/Models/Response/ReactionSummary.cs
+++ b/Octokit/Models/Response/ReactionSummary.cs
@@ -9,7 +9,7 @@ namespace Octokit
     {
         public ReactionSummary() { }
 
-        public ReactionSummary(int totalCount, int plus1, int minus1, int laugh, int confused, int heart, int hooray, string url)
+        public ReactionSummary(int totalCount, int plus1, int minus1, int laugh, int confused, int heart, int hooray, int eyes, int rocket, string url)
         {
             TotalCount = totalCount;
             Plus1 = plus1;
@@ -19,6 +19,8 @@ namespace Octokit
             Heart = heart;
             Hooray = hooray;
             Url = url;
+            Eyes = eyes;
+            Rocket = rocket;
         }
 
         public int TotalCount { get; private set; }
@@ -30,6 +32,8 @@ namespace Octokit
         public int Confused { get; private set; }
         public int Heart { get; private set; }
         public int Hooray { get; private set; }
+        public int Eyes { get; private set; }
+        public int Rocket { get; private set; }
         public string Url { get; private set; }
 
         internal string DebuggerDisplay
@@ -38,14 +42,16 @@ namespace Octokit
             {
                 return string.Format(
                     CultureInfo.InvariantCulture,
-                    "TotalCount: {0} +1: {1} -1: {2} Laugh: {3} Confused: {4} Heart: {5} Hooray: {6}",
+                    "TotalCount: {0} +1: {1} -1: {2} Laugh: {3} Confused: {4} Heart: {5} Hooray: {6} Eyes: {7} Rocket: {8}",
                     TotalCount,
                     Plus1,
                     Minus1,
                     Laugh,
                     Confused,
                     Heart,
-                    Hooray);
+                    Hooray, 
+					Eyes,
+					Rocket);
             }
         }
     }


### PR DESCRIPTION
Resolves #2838 

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->
It wasn't possible to get the count of eyes or rocket reactions from `ReactionSummary`
* 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->
`ReactionSummary` now has `Eyes` & `Rocket` properties
* 

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)

