### PR TITLE
[DOCS]: Removed the Related Projects Section from the `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,6 @@ When creating an issue, clearly explain
 Also include any other information you think is relevant to reproduce the
 problem.
 
-## Related Projects
-
- - [ScriptCs.OctoKit](https://github.com/hnrkndrssn/ScriptCs.OctoKit) - a [script pack](https://github.com/scriptcs/scriptcs/wiki/Script-Packs) to use Octokit in scriptcs
- - [ScriptCs.OctokitLibrary](https://github.com/ryanrousseau/ScriptCs.OctokitLibrary) - a [script library](https://github.com/scriptcs/scriptcs/wiki/Script-Libraries) to use Octokit in scriptcs
-
 ## Copyright and License
 
 Copyright 2023 GitHub, Inc.


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2851

----

### Before the change?

* Outdated **Related Projects** were listed in the `Octokit.net` `README.md` file. 

### After the change?

* The 'Related Projects' section has been removed from the README, making it up-to-date.
* Fixes #2851

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [X] No

----

