### PR TITLE
[Feat] Allow build version to be passed in to build.ps1 via command line

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -24,8 +24,9 @@ Param(
     [string]$Target = "Default",
     [ValidateSet("Release", "Debug")]
     [string]$Configuration = "Release",
+    [string]$ForceVersion = "0.0.0",
     [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
-    [string]$Verbosity = "Normal",
+    [string]$Verbosity = "Normal",	
     [switch]$WhatIf,
     [Parameter(Position=0,Mandatory=$false,ValueFromRemainingArguments=$true)]
     [string[]]$ScriptArgs
@@ -97,6 +98,7 @@ if (!(Test-Path $NugetPath)) {
 $Arguments = @{
     target=$Target;
     configuration=$Configuration;
+    forceVersion=$ForceVersion;
     verbosity=$Verbosity;
     dryrun=$WhatIf;
 }.GetEnumerator() | %{"--{0}=`"{1}`"" -f $_.key, $_.value };

--- a/build/Context.cs
+++ b/build/Context.cs
@@ -9,6 +9,7 @@ public class Context : FrostingContext
 {
     public string Target { get; set; }
     public new string Configuration { get; set; }
+    public string ForceVersion { get; set; }
     public bool FormatCode { get; set; }
     public BuildVersion Version { get; set; }
 

--- a/build/Lifetime.cs
+++ b/build/Lifetime.cs
@@ -12,6 +12,7 @@ public class Lifetime : FrostingLifetime<Context>
     {
         context.Target = context.Argument("target", "Default");
         context.Configuration = context.Argument("configuration", "Release");
+        context.ForceVersion = context.Argument<string>("forceVersion", "0.0.0");
         context.FormatCode = context.Argument("formatCode", false);
 
         context.Artifacts = "./packaging/";
@@ -46,7 +47,7 @@ public class Lifetime : FrostingLifetime<Context>
         ToolInstaller.DotNetToolInstall(context, "coverlet.console", "1.7.2", "coverlet");
 
         // Calculate semantic version.
-        context.Version = BuildVersion.Calculate(context);
+        context.Version = context.ForceVersion != "0.0.0" ? new BuildVersion(context.ForceVersion, null, null) : BuildVersion.Calculate(context);
         context.Version.Prefix = context.Argument<string>("version", context.Version.Prefix);
         context.Version.Suffix = context.Argument<string>("suffix", context.Version.Suffix);
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The build.ps1 script would require setup on the machine in order to parse a version number when building the nupkg file.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* A custom version can be forced in by specifying the -ForceVersion parameter

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

