### PR TITLE
bugfix #2870

### DIFF
--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -417,7 +417,7 @@ namespace Octokit
             TimeSpan timeout,
             CancellationToken cancellationToken,
             string twoFactorAuthenticationCode = null,
-            Uri baseAddress = null, 
+            Uri baseAddress = null,
             Func<object, object> preprocessResponseBody = null)
         {
             Ensure.ArgumentNotNull(uri, nameof(uri));
@@ -596,7 +596,8 @@ namespace Octokit
                 Method = HttpMethod.Delete,
                 Body = data,
                 BaseAddress = BaseAddress,
-                Endpoint = uri
+                Endpoint = uri,
+                ContentType = "application/json"
             };
             var response = await Run<object>(request, CancellationToken.None).ConfigureAwait(false);
             return response.HttpResponse.StatusCode;
@@ -722,12 +723,12 @@ namespace Octokit
 
             return new ApiResponse<byte[]>(response, response.Body as byte[]);
         }
-        
+
         async Task<IApiResponse<Stream>> GetRawStream(IRequest request)
         {
             request.Headers.Add("Accept", AcceptHeaders.RawContentMediaType);
             var response = await RunRequest(request, CancellationToken.None).ConfigureAwait(false);
-            
+
             return new ApiResponse<Stream>(response, response.Body as Stream);
         }
 
@@ -735,9 +736,9 @@ namespace Octokit
         {
             if (stream is MemoryStream memoryStream)
             {
-                return memoryStream.ToArray();                
+                return memoryStream.ToArray();
             }
-            
+
             using (var ms = new MemoryStream())
             {
                 await stream.CopyToAsync(ms);


### PR DESCRIPTION

Resolves #2870 

----

### Before the change?
When trying to delete a file an exception is raised stating `System.ArgumentException: The value cannot be null or empty. (Parameter 'mediaType')`. And the file is not deleted

### After the change?
No exception is raised and the file is deleted.

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->



----

