### PR TITLE
Fix: Add `RequiredSignatures` to the `BranchProtectionSettingsUpdate` Type

### DIFF
--- a/Octokit.Tests.Integration/Helpers/OrganizationRepositoryWithTeamContext.cs
+++ b/Octokit.Tests.Integration/Helpers/OrganizationRepositoryWithTeamContext.cs
@@ -34,6 +34,7 @@ namespace Octokit.Tests.Integration.Helpers
                 true,
                 true,
                 true,
+                true,
                 false,
                 true);
 
@@ -51,6 +52,8 @@ namespace Octokit.Tests.Integration.Helpers
                 new BranchProtectionRequiredStatusChecksUpdate(true, new[] { "build", "test" }),
                 new BranchProtectionRequiredReviewsUpdate(true, true, 3),
                 null,
+                true,
+                true,
                 true,
                 true,
                 true,

--- a/Octokit.Tests.Integration/Reactive/ObservableRepositoryBranchesClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableRepositoryBranchesClientTests.cs
@@ -191,6 +191,7 @@ namespace Octokit.Tests.Integration.Reactive
                         new BranchProtectionRequiredStatusChecksUpdate(false, new[] { "new" }),
                         new BranchProtectionRequiredReviewsUpdate(new BranchProtectionRequiredReviewsDismissalRestrictionsUpdate(false), false, false, 2),
                         new BranchProtectionPushRestrictionsUpdate(),
+                        true,
                         false,
                         true,
                         true,
@@ -211,6 +212,7 @@ namespace Octokit.Tests.Integration.Reactive
                     Assert.Empty(protection.Restrictions.Teams);
                     Assert.Empty(protection.Restrictions.Users);
 
+                    Assert.True(protection.RequiredSignatures.Enabled);
                     Assert.False(protection.EnforceAdmins.Enabled);
                     Assert.True(protection.RequiredLinearHistory.Enabled);
                     Assert.True(protection.AllowForcePushes.Enabled);
@@ -230,6 +232,7 @@ namespace Octokit.Tests.Integration.Reactive
                         new BranchProtectionRequiredStatusChecksUpdate(false, new[] { "new" }),
                         new BranchProtectionRequiredReviewsUpdate(new BranchProtectionRequiredReviewsDismissalRestrictionsUpdate(false), false, false, 2),
                         new BranchProtectionPushRestrictionsUpdate(),
+                        true,
                         false,
                         true,
                         true,
@@ -250,6 +253,7 @@ namespace Octokit.Tests.Integration.Reactive
                     Assert.Empty(protection.Restrictions.Teams);
                     Assert.Empty(protection.Restrictions.Users);
 
+                    Assert.True(protection.RequiredSignatures.Enabled);
                     Assert.False(protection.EnforceAdmins.Enabled);
                     Assert.True(protection.RequiredLinearHistory.Enabled);
                     Assert.True(protection.AllowForcePushes.Enabled);

--- a/Octokit/Models/Request/BranchProtectionUpdate.cs
+++ b/Octokit/Models/Request/BranchProtectionUpdate.cs
@@ -112,6 +112,7 @@ namespace Octokit
         /// <param name="requiredStatusChecks">Specifies the requested status check settings. Pass null to disable status checks</param>
         /// <param name="requiredPullRequestReviews">Specifies if reviews are required to merge the pull request. Pass null to disable required reviews</param>
         /// <param name="restrictions">Specifies the requested push access restrictions (applies only to Organization owned repositories). Pass null to disable push access restrictions</param>
+        /// <param name="requiredSignatures">Specifies whether commits to a branch are required to be signed by gpg keys</param>
         /// <param name="enforceAdmins">Specifies whether the protections applied to this branch also apply to repository admins</param>
         /// <param name="requiredLinearHistory">Enforces a linear commit Git history</param>
         /// <param name="allowForcePushes">Permits force pushes to the protected branch</param>

--- a/Octokit/Models/Request/BranchProtectionUpdate.cs
+++ b/Octokit/Models/Request/BranchProtectionUpdate.cs
@@ -122,6 +122,7 @@ namespace Octokit
         public BranchProtectionSettingsUpdate(BranchProtectionRequiredStatusChecksUpdate requiredStatusChecks,
                                               BranchProtectionRequiredReviewsUpdate requiredPullRequestReviews,
                                               BranchProtectionPushRestrictionsUpdate restrictions,
+                                              bool requiredSignatures,
                                               bool enforceAdmins,
                                               bool requiredLinearHistory,
                                               bool? allowForcePushes,
@@ -133,6 +134,7 @@ namespace Octokit
             RequiredStatusChecks = requiredStatusChecks;
             RequiredPullRequestReviews = requiredPullRequestReviews;
             Restrictions = restrictions;
+            RequiredSignatures = requiredSignatures;
             EnforceAdmins = enforceAdmins;
             LockBranch = lockBranch;
             RequiredLinearHistory = requiredLinearHistory;
@@ -159,6 +161,11 @@ namespace Octokit
         /// </summary>
         [SerializeNull]
         public BranchProtectionPushRestrictionsUpdate Restrictions { get; protected set; }
+        
+        /// <summary>
+        /// Specifies whether the signed commits are required for this branch
+        /// </summary>
+        public bool RequiredSignatures { get; set; }
 
         /// <summary>
         /// Specifies whether the protections applied to this branch also apply to repository admins


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves  #2855

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* No `RequiredSignatures` property present for `BranchProtectionSettingsUpdate` type which is supported by GitHub's rest APIs.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Added `RequiredSignatures` property for the `BranchProtectionSettingsUpdate` type
* Updated all xUnnit tests for the `BranchProtectionSettingsUpdate` type to account for the new property (i.e `RequiredSignatures`)

### Pull request checklist
- [X] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

