### PR TITLE
BREAKING CHANGE (behavior): Modify caching to only attempt to update the response cache if a 2xx response code is received from GitHub

### DIFF
--- a/Octokit/Caching/CachingHttpClient.cs
+++ b/Octokit/Caching/CachingHttpClient.cs
@@ -40,12 +40,12 @@ namespace Octokit.Caching
                     return cachedResponse;
                 }
 
-                TrySetCachedResponse(request, conditionalResponse);
+                _ = TrySetCachedResponse(request, conditionalResponse);
                 return conditionalResponse;
             }
 
             var response = await _httpClient.Send(request, cancellationToken);
-            TrySetCachedResponse(request, response);
+            _ = TrySetCachedResponse(request, response);
             return response;
         }
 
@@ -65,6 +65,10 @@ namespace Octokit.Caching
         {
             try
             {
+                if(!response.IsSuccessStatusCode())
+                {
+                    return;
+                }
                 await _responseCache.SetAsync(request, CachedResponse.V1.Create(response));
             }
             catch (Exception)

--- a/Octokit/Helpers/HttpExtensions.cs
+++ b/Octokit/Helpers/HttpExtensions.cs
@@ -4,7 +4,7 @@ using Octokit.Internal;
 
 namespace Octokit
 {
-    public static class HttpClientExtensions
+    public static class HttpExtensions
     {
         public static Task<IResponse> Send(this IHttpClient httpClient, IRequest request)
         {
@@ -12,6 +12,15 @@ namespace Octokit
             Ensure.ArgumentNotNull(request, nameof(request));
 
             return httpClient.Send(request, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Gets a value that indicates whether the HTTP response was successful.
+        /// </summary>
+        public static bool IsSuccessStatusCode(this IResponse response)
+        {
+            Ensure.ArgumentNotNull(response, nameof(response));
+            return (int) response.StatusCode >= 200 && (int) response.StatusCode <= 299;
         }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/octokit/octokit.net/issues/2876

Apologies if I've filed a bug when it should come under feature/enhancement!
I couldn't find any docs on response caching, but happy to update them if there are any.

----

### Before the change?

* If the `CachingHttpClient` received a non-200 and non-304 response from GitHub, it still attempts to update the underlying response cache, resulting in a higher number of subsequent cache misses if `IResponseCache` implementations don't guard for it themselves.

### After the change?

* Only attempts to update the response cache if a 2xx response code is received from GitHub.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

* I don't believe this is classed as a breaking change, but it is a change in behaviour that could impact users who rely on it calling the response cache for non-200 responses.

- [x] Yes
- [ ] No