### PR TITLE
Add 'Pending' member to WorkflowJobStatus enum

### DIFF
--- a/Octokit/Models/Response/WorkflowJobStatus.cs
+++ b/Octokit/Models/Response/WorkflowJobStatus.cs
@@ -12,5 +12,7 @@ namespace Octokit
         Completed,
         [Parameter(Value = "waiting")]
         Waiting,
+        [Parameter(Value = "pending")]
+        Pending,
     }
 }


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2882

----

### Before the change?
* The 'pending' value on the `WorkflowJobStep.Status` would not deserialize properly.

### After the change?
* The 'pending' value on the `WorkflowJobStep.Status` should deserialize properly.

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

_I didn't see any tests/docs relating to this enum, so I didn't create any for this PR, let me know if I missed something and should add them._

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
