### PR TITLE
Update Dockerfile to omit mkdocs so that pre-builds will complete successfully

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,7 +8,7 @@ FROM mcr.microsoft.com/vscode/devcontainers/dotnet
 COPY --from=mcr.microsoft.com/dotnet/sdk:6.0 /usr/share/dotnet/shared /usr/share/dotnet/shared
 
 # # Add mkdocs for doc generation
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive && apt-get -y install --no-install-recommends python3-pip
-RUN pip3 install mkdocs
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive && apt-get -y install --no-install-recommends python3-pip
+# RUN pip3 install mkdocs
 
 RUN apt-get install -y mono-complete


### PR DESCRIPTION
Currently prebuilds are failing and we might need to move from python3-pip to python3-full which will add build time and a few other variables into our pipeline.  Looking to put in a simple workaround for now (so that codespaces spin up does not cause a huge time delay as well as to fix create code spaces functionally from GitHub.com
