### PR TITLE
fix: "zip" Content-Type resulting in null Stream for Artifacts on Blob Storage

### DIFF
--- a/Octokit.Tests/Http/HttpClientAdapterTests.cs
+++ b/Octokit.Tests/Http/HttpClientAdapterTests.cs
@@ -177,6 +177,27 @@ namespace Octokit.Tests.Http
 
                 Assert.Equal("application/json", response.ContentType);
             }
+            
+            // See #2898 for why this is necessary
+            // Non standard MIME Content-Type coming from Blob Storage when downloading artifacts
+            [Fact]
+            public async Task SetsZipContentType()
+            {
+                var memoryStream = new MemoryStream();
+                var streamContent = new StreamContent(memoryStream);
+                streamContent.Headers.TryAddWithoutValidation("Content-Type", "zip");
+                
+                var responseMessage = new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = streamContent
+                };
+                var tester = new HttpClientAdapterTester();
+
+                var response = await tester.BuildResponseTester(responseMessage);
+
+                Assert.Equal("zip", response.ContentType);
+            }
         }
 
         sealed class HttpClientAdapterTester : HttpClientAdapter

--- a/Octokit.Tests/Http/HttpClientAdapterTests.cs
+++ b/Octokit.Tests/Http/HttpClientAdapterTests.cs
@@ -196,7 +196,7 @@ namespace Octokit.Tests.Http
 
                 var response = await tester.BuildResponseTester(responseMessage);
 
-                Assert.Equal("zip", response.ContentType);
+                Assert.Equal("application/zip", response.ContentType);
             }
         }
 

--- a/Octokit/Http/HttpClientAdapter.cs
+++ b/Octokit/Http/HttpClientAdapter.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -168,10 +169,18 @@ namespace Octokit.Internal
 
         static string GetContentMediaType(HttpContent httpContent)
         {
-            if (httpContent.Headers != null && httpContent.Headers.ContentType != null)
+            if (httpContent.Headers?.ContentType != null)
             {
                 return httpContent.Headers.ContentType.MediaType;
             }
+
+            // Issue #2898 - Bad "zip" Content-Type coming from Blob Storage for artifacts
+            if (httpContent.Headers?.TryGetValues("Content-Type", out var contentTypeValues) == true
+                && contentTypeValues.FirstOrDefault() == "zip")
+            {
+                return "application/zip";
+            }
+            
             return null;
         }
 

--- a/Octokit/Http/HttpClientAdapter.cs
+++ b/Octokit/Http/HttpClientAdapter.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -82,7 +81,6 @@ namespace Octokit.Internal
                 AcceptHeaders.RawContentMediaType,
                 "application/zip" ,
                 "application/x-gzip" ,
-                "zip" , // Not a standard MIME type but see issue #2898
                 "application/octet-stream"};
 
             var content = responseMessage.Content;


### PR DESCRIPTION
Fixes #2898 

Sorry, the last one didn't actually solve it because the Content-Type wasn't being set properly by the `System.Net` classes - Probably due to an invalid format.