### PR TITLE
Fix #2693 PageCount doesn't work if the query gets constructed with page number as the first query parameter 

### DIFF
--- a/Octokit.Tests/Http/PaginationTests.cs
+++ b/Octokit.Tests/Http/PaginationTests.cs
@@ -1,0 +1,46 @@
+using System;
+using Octokit.Models.Request.Enterprise;
+using Xunit;
+
+namespace Octokit.Tests.Http
+{
+    public class PaginationTests
+    {
+        public class TheShouldContinueMethod
+        {
+            [Fact]
+            public void HandlesMissingUri()
+            {
+                var result = Pagination.ShouldContinue(null, null);
+                Assert.False(result);
+            }
+            
+            [Fact]
+            public void HandlesIsDone()
+            {
+                var uri = new Uri("http://example.com");
+                var options = new ApiOptionsExtended { IsDone = true };
+                var result = Pagination.ShouldContinue(uri, options);
+                Assert.False(result);
+            }
+            
+            [Fact]
+            public void HandlesPageCountPageFirstParam()
+            {
+                var uri = new Uri("http://example.com?page=2");
+                var options = new ApiOptions { StartPage = 1, PageCount = 1 };
+                var result = Pagination.ShouldContinue(uri, options);
+                Assert.False(result);
+            }
+            
+            [Fact]
+            public void HandlesPageCountPageNotFirstParam()
+            {
+                var uri = new Uri("http://example.com?page_size=100&page=2");
+                var options = new ApiOptions { StartPage = 1, PageCount = 1 };
+                var result = Pagination.ShouldContinue(uri, options);
+                Assert.False(result);
+            }
+        }
+    }
+}

--- a/Octokit/Helpers/Pagination.cs
+++ b/Octokit/Helpers/Pagination.cs
@@ -41,8 +41,7 @@ namespace Octokit
             {
                 var allValues = ToQueryStringDictionary(uri);
 
-                string pageValue;
-                if (allValues.TryGetValue("page", out pageValue))
+                if (allValues.TryGetValue("page", out var pageValue))
                 {
                     var startPage = options.StartPage ?? 1;
                     var pageCount = options.PageCount.Value;
@@ -61,8 +60,14 @@ namespace Octokit
         static Dictionary<string, string> ToQueryStringDictionary(Uri uri)
         {
             return uri.Query.Split('&')
-                .Select(keyValue =>
+                .Select((keyValue, i) =>
                 {
+                    if (i == 0)
+                    {
+                        // Trim the leading '?' character from the first key-value pair
+                        keyValue = keyValue.Substring(1);
+                    }
+                    
                     var indexOf = keyValue.IndexOf('=');
                     if (indexOf > 0)
                     {


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2693

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* PageCount did not work if the query gets constructed with page number as the first query parameter

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* PageCount now works if the query gets constructed with page number as the first query parameter

### Pull request checklist
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes
- [X] No