### PR TITLE
 feat: added Missing APIOption overload for PackagesClient.GetAll* #2923

### DIFF
--- a/Octokit.Reactive/Clients/IObservablePackagesClient.cs
+++ b/Octokit.Reactive/Clients/IObservablePackagesClient.cs
@@ -15,8 +15,41 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="org">Required: Organisation Name</param>
         /// <param name="packageType">Required: The type of package</param>
+        IObservable<Package> GetAllForOrg(string org, PackageType packageType);
+
+        /// <summary>
+        /// List all packages for an organisations, readable by the current user
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-an-organization">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="org">Required: Organisation Name</param>
+        /// <param name="packageType">Required: The type of package</param>
+        /// <param name="options">Options for changing the API response</param>
+        IObservable<Package> GetAllForOrg(string org, PackageType packageType, ApiOptions options);
+
+        /// <summary>
+        /// List all packages for an organisations, readable by the current user
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-an-organization">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="org">Required: Organisation Name</param>
+        /// <param name="packageType">Required: The type of package</param>
         /// <param name="packageVisibility">Optional: The visibility of the package</param>
-        IObservable<Package> GetAllForOrg(string org, PackageType packageType, PackageVisibility? packageVisibility = null);
+        IObservable<Package> GetAllForOrg(string org, PackageType packageType, PackageVisibility? packageVisibility);
+
+        /// <summary>
+        /// List all packages for an organisations, readable by the current user
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-an-organization">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="org">Required: Organisation Name</param>
+        /// <param name="packageType">Required: The type of package</param>
+        /// <param name="packageVisibility">Optional: The visibility of the package</param>
+        /// <param name="options">Options for changing the API response</param>
+        IObservable<Package> GetAllForOrg(string org, PackageType packageType, PackageVisibility? packageVisibility, ApiOptions options);
 
         /// <summary>
         /// Get a specific package for an Organization.
@@ -58,8 +91,38 @@ namespace Octokit.Reactive
         /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-the-authenticated-users-namespace">API documentation</a> for more details
         /// </remarks>
         /// <param name="packageType">Required: The type of package</param>
+        IObservable<Package> GetAllForActiveUser(PackageType packageType);
+
+        /// <summary>
+        /// Lists packages owned by the authenticated user within the user's namespace
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-the-authenticated-users-namespace">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="packageType">Required: The type of package</param>
+        /// <param name="options">Options for changing the API response</param>
+        IObservable<Package> GetAllForActiveUser(PackageType packageType, ApiOptions options);
+
+        /// <summary>
+        /// Lists packages owned by the authenticated user within the user's namespace
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-the-authenticated-users-namespace">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="packageType">Required: The type of package</param>
         /// <param name="packageVisibility">Optional: The visibility of the package</param>
-        IObservable<Package> GetAllForActiveUser(PackageType packageType, PackageVisibility? packageVisibility = null);
+        IObservable<Package> GetAllForActiveUser(PackageType packageType, PackageVisibility? packageVisibility);
+
+        /// <summary>
+        /// Lists packages owned by the authenticated user within the user's namespace
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-the-authenticated-users-namespace">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="packageType">Required: The type of package</param>
+        /// <param name="packageVisibility">Optional: The visibility of the package</param>
+        /// <param name="options">Options for changing the API response</param>
+        IObservable<Package> GetAllForActiveUser(PackageType packageType, PackageVisibility? packageVisibility, ApiOptions options);
 
         /// <summary>
         /// Gets a specific package for a package owned by the authenticated user.
@@ -99,8 +162,41 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="username">Required: Username</param>
         /// <param name="packageType">Required: The type of package</param>
+        IObservable<Package> GetAllForUser(string username, PackageType packageType);
+
+        /// <summary>
+        /// Lists packages owned by the authenticated user within the user's namespace
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-the-authenticated-users-namespace">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="username">Required: Username</param>
+        /// <param name="packageType">Required: The type of package</param>
+        /// <param name="options">Options for changing the API response</param>
+        IObservable<Package> GetAllForUser(string username, PackageType packageType, ApiOptions options);
+
+        /// <summary>
+        /// Lists packages owned by the authenticated user within the user's namespace
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-the-authenticated-users-namespace">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="username">Required: Username</param>
+        /// <param name="packageType">Required: The type of package</param>
         /// <param name="packageVisibility">Optional: The visibility of the package</param>
-        IObservable<Package> GetAllForUser(string username, PackageType packageType, PackageVisibility? packageVisibility = null);
+        IObservable<Package> GetAllForUser(string username, PackageType packageType, PackageVisibility? packageVisibility);
+
+        /// <summary>
+        /// Lists packages owned by the authenticated user within the user's namespace
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-the-authenticated-users-namespace">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="username">Required: Username</param>
+        /// <param name="packageType">Required: The type of package</param>
+        /// <param name="packageVisibility">Optional: The visibility of the package</param>
+        /// <param name="options">Options for changing the API response</param>
+        IObservable<Package> GetAllForUser(string username, PackageType packageType, PackageVisibility? packageVisibility, ApiOptions options);
 
         /// <summary>
         /// Gets a specific package metadata for a public package owned by a user.

--- a/Octokit.Reactive/Clients/ObservablePackagesClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePackagesClient.cs
@@ -28,16 +28,69 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="org">Required: Organisation Name</param>
         /// <param name="packageType">Required: The type of package</param>
-        /// <param name="packageVisibility">Optional: The visibility of the package</param>
-        public IObservable<Package> GetAllForOrg(string org, PackageType packageType, PackageVisibility? packageVisibility = null)
+        public IObservable<Package> GetAllForOrg(string org, PackageType packageType)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
             Ensure.ArgumentNotNull(packageType, nameof(packageType));
 
+            return GetAllForOrg(org, packageType, (PackageVisibility?)null);
+        }
+
+        /// <summary>
+        /// List all packages for an organisations, readable by the current user
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-an-organization">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="org">Required: Organisation Name</param>
+        /// <param name="packageType">Required: The type of package</param>
+        /// <param name="options">Options for changing the API response</param>
+        public IObservable<Package> GetAllForOrg(string org, PackageType packageType, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
+            Ensure.ArgumentNotNull(packageType, nameof(packageType));
+            Ensure.ArgumentNotNull(options, nameof(options));
+
+            return GetAllForOrg(org, packageType, null, options);
+        }
+
+        /// <summary>
+        /// List all packages for an organisations, readable by the current user
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-an-organization">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="org">Required: Organisation Name</param>
+        /// <param name="packageType">Required: The type of package</param>
+        /// <param name="packageVisibility">Optional: The visibility of the package</param>
+        public IObservable<Package> GetAllForOrg(string org, PackageType packageType, PackageVisibility? packageVisibility)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
+            Ensure.ArgumentNotNull(packageType, nameof(packageType));
+
+            return GetAllForOrg(org, packageType, packageVisibility, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List all packages for an organisations, readable by the current user
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-an-organization">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="org">Required: Organisation Name</param>
+        /// <param name="packageType">Required: The type of package</param>
+        /// <param name="packageVisibility">Optional: The visibility of the package</param>
+        /// <param name="options">Options for changing the API response</param>
+        public IObservable<Package> GetAllForOrg(string org, PackageType packageType, PackageVisibility? packageVisibility, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
+            Ensure.ArgumentNotNull(packageType, nameof(packageType));            
+            Ensure.ArgumentNotNull(options, nameof(options));
+
             var route = ApiUrls.PackagesOrg(org);
             var parameters = ParameterBuilder.AddParameter("package_type", packageType).AddOptionalParameter("visibility", packageVisibility);
 
-            return _connection.GetAndFlattenAllPages<Package>(route, parameters);
+            return _connection.GetAndFlattenAllPages<Package>(route, parameters, options);
         }
 
         /// <summary>
@@ -101,13 +154,62 @@ namespace Octokit.Reactive
         /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-the-authenticated-users-namespace">API documentation</a> for more details
         /// </remarks>
         /// <param name="packageType">Required: The type of package</param>
-        /// <param name="packageVisibility">Optional: The visibility of the package</param>
-        public IObservable<Package> GetAllForActiveUser(PackageType packageType, PackageVisibility? packageVisibility = null)
+        public IObservable<Package> GetAllForActiveUser(PackageType packageType)
         {
+            Ensure.ArgumentNotNull(packageType, nameof(packageType));
+            
+            return GetAllForActiveUser(packageType, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Lists packages owned by the authenticated user within the user's namespace
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-the-authenticated-users-namespace">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="packageType">Required: The type of package</param>
+        /// <param name="options">Options for changing the API response</param>
+        public IObservable<Package> GetAllForActiveUser(PackageType packageType, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(packageType, nameof(packageType));
+            Ensure.ArgumentNotNull(options, nameof(options));
+
+            return GetAllForActiveUser(packageType, null, options);
+        }
+
+        /// <summary>
+        /// Lists packages owned by the authenticated user within the user's namespace
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-the-authenticated-users-namespace">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="packageType">Required: The type of package</param>
+        /// <param name="packageVisibility">Optional: The visibility of the package</param>
+        public IObservable<Package> GetAllForActiveUser(PackageType packageType, PackageVisibility? packageVisibility)
+        {
+            Ensure.ArgumentNotNull(packageType, nameof(packageType));
+
+            return GetAllForActiveUser(packageType, packageVisibility, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Lists packages owned by the authenticated user within the user's namespace
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-the-authenticated-users-namespace">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="packageType">Required: The type of package</param>
+        /// <param name="packageVisibility">Optional: The visibility of the package</param>
+        /// <param name="options">Options for changing the API response</param>
+        public IObservable<Package> GetAllForActiveUser(PackageType packageType, PackageVisibility? packageVisibility, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(packageType, nameof(packageType));
+            Ensure.ArgumentNotNull(options, nameof(options));
+
             var route = ApiUrls.PackagesActiveUser();
             var parameters = ParameterBuilder.AddParameter("package_type", packageType).AddOptionalParameter("visibility", packageVisibility);
 
-            return _connection.GetAndFlattenAllPages<Package>(route, parameters);
+            return _connection.GetAndFlattenAllPages<Package>(route, parameters, options);
         }
 
         /// <summary>
@@ -166,16 +268,69 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="username">Required: Username</param>
         /// <param name="packageType">Required: The type of package</param>
-        /// <param name="packageVisibility">Optional: The visibility of the package</param>
-        public IObservable<Package> GetAllForUser(string username, PackageType packageType, PackageVisibility? packageVisibility = null)
+        public IObservable<Package> GetAllForUser(string username, PackageType packageType)
         {
             Ensure.ArgumentNotNullOrEmptyString(username, nameof(username));
             Ensure.ArgumentNotNull(packageType, nameof(packageType));
 
+            return GetAllForUser(username, packageType, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Lists packages owned by the authenticated user within the user's namespace
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-the-authenticated-users-namespace">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="username">Required: Username</param>
+        /// <param name="packageType">Required: The type of package</param>
+        /// <param name="options">Options for changing the API response</param>
+        public IObservable<Package> GetAllForUser(string username, PackageType packageType, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(username, nameof(username));
+            Ensure.ArgumentNotNull(packageType, nameof(packageType));
+            Ensure.ArgumentNotNull(options, nameof(options));
+
+            return GetAllForUser(username, packageType, null, options);
+        }
+
+        /// <summary>
+        /// Lists packages owned by the authenticated user within the user's namespace
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-the-authenticated-users-namespace">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="username">Required: Username</param>
+        /// <param name="packageType">Required: The type of package</param>
+        /// <param name="packageVisibility">Optional: The visibility of the package</param>
+        public IObservable<Package> GetAllForUser(string username, PackageType packageType, PackageVisibility? packageVisibility)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(username, nameof(username));
+            Ensure.ArgumentNotNull(packageType, nameof(packageType));
+
+            return GetAllForUser(username, packageType, packageVisibility, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Lists packages owned by the authenticated user within the user's namespace
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-the-authenticated-users-namespace">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="username">Required: Username</param>
+        /// <param name="packageType">Required: The type of package</param>
+        /// <param name="packageVisibility">Optional: The visibility of the package</param>
+        /// <param name="options">Options for changing the API response</param>
+        public IObservable<Package> GetAllForUser(string username, PackageType packageType, PackageVisibility? packageVisibility, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(username, nameof(username));
+            Ensure.ArgumentNotNull(packageType, nameof(packageType));
+            Ensure.ArgumentNotNull(options, nameof(options));
+
             var route = ApiUrls.PackagesUser(username);
             var parameters = ParameterBuilder.AddParameter("package_type", packageType).AddOptionalParameter("visibility", packageVisibility);
 
-            return _connection.GetAndFlattenAllPages<Package>(route, parameters);
+            return _connection.GetAndFlattenAllPages<Package>(route, parameters, options);
         }
 
         /// <summary>

--- a/Octokit.Tests/Clients/PackagesClientTests.cs
+++ b/Octokit.Tests/Clients/PackagesClientTests.cs
@@ -27,7 +27,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForOrg("fake", PackageType.RubyGems);
 
-                connection.Received().GetAll<Package>(Arg.Is<Uri>(u => u.ToString() == "orgs/fake/packages"), Arg.Is<Dictionary<string, string>>(d => d.ContainsKey("package_type")));
+                connection.Received().GetAll<Package>(Arg.Is<Uri>(u => u.ToString() == "orgs/fake/packages"), Arg.Is<Dictionary<string, string>>(d => d.ContainsKey("package_type")), Args.ApiOptions);
             }
 
             [Fact]
@@ -39,7 +39,7 @@ namespace Octokit.Tests.Clients
                 await client.GetAllForOrg("fake", PackageType.RubyGems, PackageVisibility.Public);
 
                 var calls = connection.ReceivedCalls();
-                connection.Received().GetAll<Package>(Arg.Is<Uri>(u => u.ToString() == "orgs/fake/packages"), Arg.Is<Dictionary<string, string>>(d => d.ContainsKey("package_type") && d.ContainsKey("visibility")));
+                connection.Received().GetAll<Package>(Arg.Is<Uri>(u => u.ToString() == "orgs/fake/packages"), Arg.Is<Dictionary<string, string>>(d => d.ContainsKey("package_type") && d.ContainsKey("visibility")), Args.ApiOptions);
             }
 
             [Fact]
@@ -141,7 +141,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForActiveUser(PackageType.RubyGems);
 
-                connection.Received().GetAll<Package>(Arg.Is<Uri>(u => u.ToString() == "user/packages"), Arg.Is<Dictionary<string, string>>(d => d.ContainsKey("package_type")));
+                connection.Received().GetAll<Package>(Arg.Is<Uri>(u => u.ToString() == "user/packages"), Arg.Is<Dictionary<string, string>>(d => d.ContainsKey("package_type")), Args.ApiOptions);
             }
 
             [Fact]
@@ -153,7 +153,7 @@ namespace Octokit.Tests.Clients
                 await client.GetAllForActiveUser(PackageType.RubyGems, PackageVisibility.Public);
 
                 var calls = connection.ReceivedCalls();
-                connection.Received().GetAll<Package>(Arg.Is<Uri>(u => u.ToString() == "user/packages"), Arg.Is<Dictionary<string, string>>(d => d.ContainsKey("package_type") && d.ContainsKey("visibility")));
+                connection.Received().GetAll<Package>(Arg.Is<Uri>(u => u.ToString() == "user/packages"), Arg.Is<Dictionary<string, string>>(d => d.ContainsKey("package_type") && d.ContainsKey("visibility")), Args.ApiOptions);
             }
         }
 
@@ -236,7 +236,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForUser("fake", PackageType.RubyGems);
 
-                connection.Received().GetAll<Package>(Arg.Is<Uri>(u => u.ToString() == "users/fake/packages"), Arg.Is<Dictionary<string, string>>(d => d.ContainsKey("package_type")));
+                connection.Received().GetAll<Package>(Arg.Is<Uri>(u => u.ToString() == "users/fake/packages"), Arg.Is<Dictionary<string, string>>(d => d.ContainsKey("package_type")), Args.ApiOptions);
             }
 
             [Fact]
@@ -248,7 +248,7 @@ namespace Octokit.Tests.Clients
                 await client.GetAllForUser("fake", PackageType.RubyGems, PackageVisibility.Public);
 
                 var calls = connection.ReceivedCalls();
-                connection.Received().GetAll<Package>(Arg.Is<Uri>(u => u.ToString() == "users/fake/packages"), Arg.Is<Dictionary<string, string>>(d => d.ContainsKey("package_type") && d.ContainsKey("visibility")));
+                connection.Received().GetAll<Package>(Arg.Is<Uri>(u => u.ToString() == "users/fake/packages"), Arg.Is<Dictionary<string, string>>(d => d.ContainsKey("package_type") && d.ContainsKey("visibility")), Args.ApiOptions);
             }
 
             [Fact]

--- a/Octokit/Clients/IPackagesClient.cs
+++ b/Octokit/Clients/IPackagesClient.cs
@@ -15,9 +15,42 @@ namespace Octokit
         /// </remarks>
         /// <param name="org">Required: Organisation Name</param>
         /// <param name="packageType">Required: The type of package</param>
+        Task<IReadOnlyList<Package>> GetAllForOrg(string org, PackageType packageType);
+
+        /// <summary>
+        /// List all packages for an organisations, readable by the current user
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-an-organization">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="org">Required: Organisation Name</param>
+        /// <param name="packageType">Required: The type of package</param>
+        /// <param name="options">Options for changing the API response</param>
+        Task<IReadOnlyList<Package>> GetAllForOrg(string org, PackageType packageType, ApiOptions options);
+
+        /// <summary>
+        /// List all packages for an organisations, readable by the current user
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-an-organization">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="org">Required: Organisation Name</param>
+        /// <param name="packageType">Required: The type of package</param>
         /// <param name="packageVisibility">Optional: The visibility of the package</param>
-        [ExcludeFromPaginationApiOptionsConventionTest("No api options available according to the documentation")]
-        Task<IReadOnlyList<Package>> GetAllForOrg(string org, PackageType packageType, PackageVisibility? packageVisibility = null);
+        Task<IReadOnlyList<Package>> GetAllForOrg(string org, PackageType packageType, PackageVisibility? packageVisibility);
+
+        /// <summary>
+        /// List all packages for an organisations, readable by the current user
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-an-organization">API documentation</a> for more details
+        /// The default page size on GitHub.com is 30.
+        /// </remarks>
+        /// <param name="org">Required: Organisation Name</param>
+        /// <param name="packageType">Required: The type of package</param>
+        /// <param name="packageVisibility">Optional: The visibility of the package</param>
+        /// <param name="options">Options for changing the API response</param>
+        Task<IReadOnlyList<Package>> GetAllForOrg(string org, PackageType packageType, PackageVisibility? packageVisibility, ApiOptions options);
 
         /// <summary>
         /// Get a specific package for an Organization.
@@ -59,9 +92,39 @@ namespace Octokit
         /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-the-authenticated-users-namespace">API documentation</a> for more details
         /// </remarks>
         /// <param name="packageType">Required: The type of package</param>
+        Task<IReadOnlyList<Package>> GetAllForActiveUser(PackageType packageType);
+
+        /// <summary>
+        /// Lists packages owned by the authenticated user within the user's namespace
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-the-authenticated-users-namespace">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="packageType">Required: The type of package</param>
+        /// <param name="options">Options for changing the API response</param>
+        Task<IReadOnlyList<Package>> GetAllForActiveUser(PackageType packageType, ApiOptions options);
+
+        /// <summary>
+        /// Lists packages owned by the authenticated user within the user's namespace
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-the-authenticated-users-namespace">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="packageType">Required: The type of package</param>
         /// <param name="packageVisibility">Optional: The visibility of the package</param>
-        [ExcludeFromPaginationApiOptionsConventionTest("No api options available according to the documentation")]
-        Task<IReadOnlyList<Package>> GetAllForActiveUser(PackageType packageType, PackageVisibility? packageVisibility = null);
+        Task<IReadOnlyList<Package>> GetAllForActiveUser(PackageType packageType, PackageVisibility? packageVisibility);
+
+        /// <summary>
+        /// Lists packages owned by the authenticated user within the user's namespace
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-the-authenticated-users-namespace">API documentation</a> for more details
+        /// The default page size on GitHub.com is 30.
+        /// </remarks>
+        /// <param name="packageType">Required: The type of package</param>
+        /// <param name="packageVisibility">Optional: The visibility of the package</param>
+        /// <param name="options">Options for changing the API response</param>
+        Task<IReadOnlyList<Package>> GetAllForActiveUser(PackageType packageType, PackageVisibility? packageVisibility, ApiOptions options);
 
         /// <summary>
         /// Gets a specific package for a package owned by the authenticated user.
@@ -101,9 +164,42 @@ namespace Octokit
         /// </remarks>
         /// <param name="username">Required: Username</param>
         /// <param name="packageType">Required: The type of package</param>
+        Task<IReadOnlyList<Package>> GetAllForUser(string username, PackageType packageType);
+
+        /// <summary>
+        /// Lists packages owned by the authenticated user within the user's namespace
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-the-authenticated-users-namespace">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="username">Required: Username</param>
+        /// <param name="packageType">Required: The type of package</param>
+        /// <param name="options">Options for changing the API response</param>
+        Task<IReadOnlyList<Package>> GetAllForUser(string username, PackageType packageType, ApiOptions options);
+
+        /// <summary>
+        /// Lists packages owned by the authenticated user within the user's namespace
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-the-authenticated-users-namespace">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="username">Required: Username</param>
+        /// <param name="packageType">Required: The type of package</param>
         /// <param name="packageVisibility">Optional: The visibility of the package</param>
-        [ExcludeFromPaginationApiOptionsConventionTest("No api options available according to the documentation")]
-        Task<IReadOnlyList<Package>> GetAllForUser(string username, PackageType packageType, PackageVisibility? packageVisibility = null);
+        Task<IReadOnlyList<Package>> GetAllForUser(string username, PackageType packageType, PackageVisibility? packageVisibility);
+
+        /// <summary>
+        /// Lists packages owned by the authenticated user within the user's namespace
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-the-authenticated-users-namespace">API documentation</a> for more details
+        /// The default page size on GitHub.com is 30.
+        /// </remarks>
+        /// <param name="username">Required: Username</param>
+        /// <param name="packageType">Required: The type of package</param>
+        /// <param name="packageVisibility">Optional: The visibility of the package</param>
+        /// <param name="options">Options for changing the API response</param>
+        Task<IReadOnlyList<Package>> GetAllForUser(string username, PackageType packageType, PackageVisibility? packageVisibility, ApiOptions options);
 
         /// <summary>
         /// Gets a specific package metadata for a public package owned by a user.

--- a/Octokit/Clients/PackagesClient.cs
+++ b/Octokit/Clients/PackagesClient.cs
@@ -27,16 +27,73 @@ namespace Octokit
         /// </remarks>
         /// <param name="org">Required: Organisation Name</param>
         /// <param name="packageType">Required: The type of package</param>
-        /// <param name="packageVisibility">Optional: The visibility of the package</param>
         [ManualRoute("GET", "/orgs/{org}/packages")]
-        public Task<IReadOnlyList<Package>> GetAllForOrg(string org, PackageType packageType, PackageVisibility? packageVisibility = null)
+        public Task<IReadOnlyList<Package>> GetAllForOrg(string org, PackageType packageType)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
+            Ensure.ArgumentNotNull(packageType, nameof(packageType));
+
+            return GetAllForOrg(org, packageType, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List all packages for an organisations, readable by the current user
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-an-organization">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="org">Required: Organisation Name</param>
+        /// <param name="packageType">Required: The type of package</param>
+        /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/orgs/{org}/packages")]
+        public Task<IReadOnlyList<Package>> GetAllForOrg(string org, PackageType packageType, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
+            Ensure.ArgumentNotNull(packageType, nameof(packageType));
+            Ensure.ArgumentNotNull(options, nameof(options));
+
+            return GetAllForOrg(org, packageType, null, options);
+        }
+
+        /// <summary>
+        /// List all packages for an organisations, readable by the current user
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-an-organization">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="org">Required: Organisation Name</param>
+        /// <param name="packageType">Required: The type of package</param>
+        /// <param name="packageVisibility">Optional: The visibility of the package</param>
+        [ManualRoute("GET", "/orgs/{org}/packages")]
+        public Task<IReadOnlyList<Package>> GetAllForOrg(string org, PackageType packageType, PackageVisibility? packageVisibility)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
+            Ensure.ArgumentNotNull(packageType, nameof(packageType));
+
+            return GetAllForOrg(org, packageType, packageVisibility, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List all packages for an organisations, readable by the current user
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-an-organization">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="org">Required: Organisation Name</param>
+        /// <param name="packageType">Required: The type of package</param>
+        /// <param name="packageVisibility">Optional: The visibility of the package</param>
+        /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/orgs/{org}/packages")]
+        public Task<IReadOnlyList<Package>> GetAllForOrg(string org, PackageType packageType, PackageVisibility? packageVisibility, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
+            Ensure.ArgumentNotNull(packageType, nameof(packageType));
+            Ensure.ArgumentNotNull(options, nameof(options));
 
             var route = ApiUrls.PackagesOrg(org);
             var parameters = ParameterBuilder.AddParameter("package_type", packageType).AddOptionalParameter("visibility", packageVisibility);
 
-            return ApiConnection.GetAll<Package>(route, parameters);
+            return ApiConnection.GetAll<Package>(route, parameters, options);
         }
 
         /// <summary>
@@ -73,6 +130,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
             Ensure.ArgumentNotNullOrEmptyString(packageName, nameof(packageName));
+            Ensure.ArgumentNotNull(packageType, nameof(packageType));
 
             var route = ApiUrls.PackageOrg(org, packageType, packageName);
 
@@ -108,14 +166,66 @@ namespace Octokit
         /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-the-authenticated-users-namespace">API documentation</a> for more details
         /// </remarks>
         /// <param name="packageType">Required: The type of package</param>
+        [ManualRoute("GET", "/user/packages")]
+        public Task<IReadOnlyList<Package>> GetAllForActiveUser(PackageType packageType)
+        {
+            Ensure.ArgumentNotNull(packageType, nameof(packageType));
+
+            return GetAllForActiveUser(packageType, (PackageVisibility?)null);
+        }
+
+        /// <summary>
+        /// Lists packages owned by the authenticated user within the user's namespace
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-the-authenticated-users-namespace">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="packageType">Required: The type of package</param>
+        /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/user/packages")]
+        public Task<IReadOnlyList<Package>> GetAllForActiveUser(PackageType packageType, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(packageType, nameof(packageType));
+            Ensure.ArgumentNotNull(options, nameof(options));
+
+            return GetAllForActiveUser(packageType, null, options);
+        }
+
+        /// <summary>
+        /// Lists packages owned by the authenticated user within the user's namespace
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-the-authenticated-users-namespace">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="packageType">Required: The type of package</param>
         /// <param name="packageVisibility">Optional: The visibility of the package</param>
         [ManualRoute("GET", "/user/packages")]
-        public Task<IReadOnlyList<Package>> GetAllForActiveUser(PackageType packageType, PackageVisibility? packageVisibility = null)
+        public Task<IReadOnlyList<Package>> GetAllForActiveUser(PackageType packageType, PackageVisibility? packageVisibility)
         {
+            Ensure.ArgumentNotNull(packageType, nameof(packageType));
+
+            return GetAllForActiveUser(packageType, packageVisibility, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Lists packages owned by the authenticated user within the user's namespace
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-the-authenticated-users-namespace">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="packageType">Required: The type of package</param>
+        /// <param name="packageVisibility">Optional: The visibility of the package</param>
+        /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/user/packages")]
+        public Task<IReadOnlyList<Package>> GetAllForActiveUser(PackageType packageType, PackageVisibility? packageVisibility, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(packageType, nameof(packageType));
+            Ensure.ArgumentNotNull(options, nameof(options));
+
             var route = ApiUrls.PackagesActiveUser();
             var parameters = ParameterBuilder.AddParameter("package_type", packageType).AddOptionalParameter("visibility", packageVisibility);
 
-            return ApiConnection.GetAll<Package>(route, parameters);
+            return ApiConnection.GetAll<Package>(route, parameters, options);
         }
 
         /// <summary>
@@ -182,16 +292,72 @@ namespace Octokit
         /// </remarks>
         /// <param name="username">Required: Username</param>
         /// <param name="packageType">Required: The type of package</param>
-        /// <param name="packageVisibility">Optional: The visibility of the package</param>
         [ManualRoute("GET", "/users/{username}/packages")]
-        public Task<IReadOnlyList<Package>> GetAllForUser(string username, PackageType packageType, PackageVisibility? packageVisibility = null)
+        public Task<IReadOnlyList<Package>> GetAllForUser(string username, PackageType packageType)
         {
             Ensure.ArgumentNotNullOrEmptyString(username, nameof(username));
+            Ensure.ArgumentNotNull(packageType, nameof(packageType));
+
+            return GetAllForUser(username, packageType, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Lists packages owned by the authenticated user within the user's namespace
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-the-authenticated-users-namespace">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="username">Required: Username</param>
+        /// <param name="packageType">Required: The type of package</param>
+        /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/users/{username}/packages")]
+        public Task<IReadOnlyList<Package>> GetAllForUser(string username, PackageType packageType, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(packageType, nameof(packageType));
+            Ensure.ArgumentNotNull(options, nameof(options));
+
+            return GetAllForUser(username, packageType, null, options);
+        }
+
+        /// <summary>
+        /// Lists packages owned by the authenticated user within the user's namespace
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-the-authenticated-users-namespace">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="username">Required: Username</param>
+        /// <param name="packageType">Required: The type of package</param>
+        /// <param name="packageVisibility">Optional: The visibility of the package</param>
+        [ManualRoute("GET", "/users/{username}/packages")]
+        public Task<IReadOnlyList<Package>> GetAllForUser(string username, PackageType packageType, PackageVisibility? packageVisibility)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(username, nameof(username));
+            Ensure.ArgumentNotNull(packageType, nameof(packageType));
+
+            return GetAllForUser(username, packageType, packageVisibility, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Lists packages owned by the authenticated user within the user's namespace
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://docs.github.com/rest/packages#list-packages-for-the-authenticated-users-namespace">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="username">Required: Username</param>
+        /// <param name="packageType">Required: The type of package</param>
+        /// <param name="packageVisibility">Optional: The visibility of the package</param>
+        /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/users/{username}/packages")]
+        public Task<IReadOnlyList<Package>> GetAllForUser(string username, PackageType packageType, PackageVisibility? packageVisibility, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(username, nameof(username));
+            Ensure.ArgumentNotNull(packageType, nameof(packageType));
+            Ensure.ArgumentNotNull(options, nameof(options));
 
             var route = ApiUrls.PackagesUser(username);
             var parameters = ParameterBuilder.AddParameter("package_type", packageType).AddOptionalParameter("visibility", packageVisibility);
 
-            return ApiConnection.GetAll<Package>(route, parameters);
+            return ApiConnection.GetAll<Package>(route, parameters, options);
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2923

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->
`PackagesClient.GetAll*` were not able to paginate and the results capped at 30 results


### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Overload parameter `APIOptions` for `PackagesClient.GetAll*`  
Methods. Extended the Tests for `PackagesClient.GetAll*` to behave the same as `RepositoriesClient.GetAll*`.


### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
