### PR TITLE
[BREAKING CHANGES]: int to long Ids for PreReceiveHook, Deployment Environments, Repository, Org Team, Repo Invitations, Public Key, Project Cards, Organization Invitation, Migrations, GpgKey, Deployment, Authorizations, Accounts / Profiles, Codespace / Workspaces

### DIFF
--- a/Octokit.AsyncPaginationExtension/Extensions.cs
+++ b/Octokit.AsyncPaginationExtension/Extensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Octokit.Models.Request.Enterprise;
 
 namespace Octokit.AsyncPaginationExtension
 {
@@ -13,818 +14,922 @@ namespace Octokit.AsyncPaginationExtension
   public static class Extensions
   {
     private const int DEFAULT_PAGE_SIZE = 30;
-  
-    /// <inheritdoc cref="IAssigneesClient.GetAllForRepository(string, string, ApiOptions)"/>
-    public static IPaginatedList<User> GetAllForRepositoryAsync(this IAssigneesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IAssigneesClient.GetAllForRepository(long, ApiOptions)"/>
-    public static IPaginatedList<User> GetAllForRepositoryAsync(this IAssigneesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IAuthorizationsClient.GetAll(ApiOptions)"/>
-    public static IPaginatedList<Authorization> GetAllAsync(this IAuthorizationsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Authorization>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="ICheckRunsClient.GetAllAnnotations(string, string, long, ApiOptions)"/>
-    public static IPaginatedList<CheckRunAnnotation> GetAllAnnotationsAsync(this ICheckRunsClient t, string owner, string name, long checkRunId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<CheckRunAnnotation>(options => t.GetAllAnnotations(owner, name, checkRunId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="ICheckRunsClient.GetAllAnnotations(long, long, ApiOptions)"/>
-    public static IPaginatedList<CheckRunAnnotation> GetAllAnnotationsAsync(this ICheckRunsClient t, long repositoryId, long checkRunId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<CheckRunAnnotation>(options => t.GetAllAnnotations(repositoryId, checkRunId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="ICommitCommentReactionsClient.GetAll(string, string, int, ApiOptions)"/>
-    public static IPaginatedList<Reaction> GetAllAsync(this ICommitCommentReactionsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="ICommitCommentReactionsClient.GetAll(long, int, ApiOptions)"/>
-    public static IPaginatedList<Reaction> GetAllAsync(this ICommitCommentReactionsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="ICommitStatusClient.GetAll(string, string, string, ApiOptions)"/>
-    public static IPaginatedList<CommitStatus> GetAllAsync(this ICommitStatusClient t, string owner, string name, string reference, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<CommitStatus>(options => t.GetAll(owner, name, reference, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="ICommitStatusClient.GetAll(long, string, ApiOptions)"/>
-    public static IPaginatedList<CommitStatus> GetAllAsync(this ICommitStatusClient t, long repositoryId, string reference, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<CommitStatus>(options => t.GetAll(repositoryId, reference, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IDeploymentsClient.GetAll(string, string, ApiOptions)"/>
-    public static IPaginatedList<Deployment> GetAllAsync(this IDeploymentsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Deployment>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IDeploymentsClient.GetAll(long, ApiOptions)"/>
-    public static IPaginatedList<Deployment> GetAllAsync(this IDeploymentsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Deployment>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IDeploymentStatusClient.GetAll(string, string, int, ApiOptions)"/>
-    public static IPaginatedList<DeploymentStatus> GetAllAsync(this IDeploymentStatusClient t, string owner, string name, int deploymentId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<DeploymentStatus>(options => t.GetAll(owner, name, deploymentId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IDeploymentStatusClient.GetAll(long, int, ApiOptions)"/>
-    public static IPaginatedList<DeploymentStatus> GetAllAsync(this IDeploymentStatusClient t, long repositoryId, int deploymentId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<DeploymentStatus>(options => t.GetAll(repositoryId, deploymentId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IEventsClient.GetAll(ApiOptions)"/>
-    public static IPaginatedList<Activity> GetAllAsync(this IEventsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Activity>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IEventsClient.GetAllForRepository(string, string, ApiOptions)"/>
-    public static IPaginatedList<Activity> GetAllForRepositoryAsync(this IEventsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IEventsClient.GetAllForRepository(long, ApiOptions)"/>
-    public static IPaginatedList<Activity> GetAllForRepositoryAsync(this IEventsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IEventsClient.GetAllIssuesForRepository(string, string, ApiOptions)"/>
-    public static IPaginatedList<IssueEvent> GetAllIssuesForRepositoryAsync(this IEventsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllIssuesForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IEventsClient.GetAllIssuesForRepository(long, ApiOptions)"/>
-    public static IPaginatedList<IssueEvent> GetAllIssuesForRepositoryAsync(this IEventsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllIssuesForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IEventsClient.GetAllForRepositoryNetwork(string, string, ApiOptions)"/>
-    public static IPaginatedList<Activity> GetAllForRepositoryNetworkAsync(this IEventsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllForRepositoryNetwork(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IEventsClient.GetAllForOrganization(string, ApiOptions)"/>
-    public static IPaginatedList<Activity> GetAllForOrganizationAsync(this IEventsClient t, string organization, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllForOrganization(organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IEventsClient.GetAllUserReceived(string, ApiOptions)"/>
-    public static IPaginatedList<Activity> GetAllUserReceivedAsync(this IEventsClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllUserReceived(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IEventsClient.GetAllUserReceivedPublic(string, ApiOptions)"/>
-    public static IPaginatedList<Activity> GetAllUserReceivedPublicAsync(this IEventsClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllUserReceivedPublic(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IEventsClient.GetAllUserPerformed(string, ApiOptions)"/>
-    public static IPaginatedList<Activity> GetAllUserPerformedAsync(this IEventsClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllUserPerformed(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IEventsClient.GetAllUserPerformedPublic(string, ApiOptions)"/>
-    public static IPaginatedList<Activity> GetAllUserPerformedPublicAsync(this IEventsClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllUserPerformedPublic(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IEventsClient.GetAllForAnOrganization(string, string, ApiOptions)"/>
-    public static IPaginatedList<Activity> GetAllForAnOrganizationAsync(this IEventsClient t, string user, string organization, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllForAnOrganization(user, organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IFollowersClient.GetAllForCurrent(ApiOptions)"/>
-    public static IPaginatedList<User> GetAllForCurrentAsync(this IFollowersClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<User>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IFollowersClient.GetAll(string, ApiOptions)"/>
-    public static IPaginatedList<User> GetAllAsync(this IFollowersClient t, string login, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(login, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IFollowersClient.GetAllFollowingForCurrent(ApiOptions)"/>
-    public static IPaginatedList<User> GetAllFollowingForCurrentAsync(this IFollowersClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<User>(t.GetAllFollowingForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IFollowersClient.GetAllFollowing(string, ApiOptions)"/>
-    public static IPaginatedList<User> GetAllFollowingAsync(this IFollowersClient t, string login, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllFollowing(login, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IGistCommentsClient.GetAllForGist(string, ApiOptions)"/>
-    public static IPaginatedList<GistComment> GetAllForGistAsync(this IGistCommentsClient t, string gistId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<GistComment>(options => t.GetAllForGist(gistId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IGistsClient.GetAll(ApiOptions)"/>
-    public static IPaginatedList<Gist> GetAllAsync(this IGistsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Gist>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IGistsClient.GetAll(DateTimeOffset, ApiOptions)"/>
-    public static IPaginatedList<Gist> GetAllAsync(this IGistsClient t, DateTimeOffset since, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Gist>(options => t.GetAll(since, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IGistsClient.GetAllPublic(ApiOptions)"/>
-    public static IPaginatedList<Gist> GetAllPublicAsync(this IGistsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Gist>(t.GetAllPublic, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IGistsClient.GetAllPublic(DateTimeOffset, ApiOptions)"/>
-    public static IPaginatedList<Gist> GetAllPublicAsync(this IGistsClient t, DateTimeOffset since, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Gist>(options => t.GetAllPublic(since, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IGistsClient.GetAllStarred(ApiOptions)"/>
-    public static IPaginatedList<Gist> GetAllStarredAsync(this IGistsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Gist>(t.GetAllStarred, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IGistsClient.GetAllStarred(DateTimeOffset, ApiOptions)"/>
-    public static IPaginatedList<Gist> GetAllStarredAsync(this IGistsClient t, DateTimeOffset since, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Gist>(options => t.GetAllStarred(since, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IGistsClient.GetAllForUser(string, ApiOptions)"/>
-    public static IPaginatedList<Gist> GetAllForUserAsync(this IGistsClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Gist>(options => t.GetAllForUser(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IGistsClient.GetAllForUser(string, DateTimeOffset, ApiOptions)"/>
-    public static IPaginatedList<Gist> GetAllForUserAsync(this IGistsClient t, string user, DateTimeOffset since, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Gist>(options => t.GetAllForUser(user, since, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IGistsClient.GetAllCommits(string, ApiOptions)"/>
-    public static IPaginatedList<GistHistory> GetAllCommitsAsync(this IGistsClient t, string id, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<GistHistory>(options => t.GetAllCommits(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IGistsClient.GetAllForks(string, ApiOptions)"/>
-    public static IPaginatedList<GistFork> GetAllForksAsync(this IGistsClient t, string id, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<GistFork>(options => t.GetAllForks(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IGitHubAppsClient.GetAllInstallationsForCurrent(ApiOptions)"/>
-    public static IPaginatedList<Installation> GetAllInstallationsForCurrentAsync(this IGitHubAppsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Installation>(t.GetAllInstallationsForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssueCommentReactionsClient.GetAll(string, string, int, ApiOptions)"/>
-    public static IPaginatedList<Reaction> GetAllAsync(this IIssueCommentReactionsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssueCommentReactionsClient.GetAll(long, int, ApiOptions)"/>
-    public static IPaginatedList<Reaction> GetAllAsync(this IIssueCommentReactionsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssueCommentsClient.GetAllForRepository(string, string, ApiOptions)"/>
-    public static IPaginatedList<IssueComment> GetAllForRepositoryAsync(this IIssueCommentsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssueCommentsClient.GetAllForRepository(long, ApiOptions)"/>
-    public static IPaginatedList<IssueComment> GetAllForRepositoryAsync(this IIssueCommentsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssueCommentsClient.GetAllForRepository(string, string, IssueCommentRequest, ApiOptions)"/>
-    public static IPaginatedList<IssueComment> GetAllForRepositoryAsync(this IIssueCommentsClient t, string owner, string name, IssueCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssueCommentsClient.GetAllForRepository(long, IssueCommentRequest, ApiOptions)"/>
-    public static IPaginatedList<IssueComment> GetAllForRepositoryAsync(this IIssueCommentsClient t, long repositoryId, IssueCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssueCommentsClient.GetAllForIssue(string, string, int, ApiOptions)"/>
-    public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForIssue(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssueCommentsClient.GetAllForIssue(long, int, ApiOptions)"/>
-    public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForIssue(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssueCommentsClient.GetAllForIssue(string, string, int, IssueCommentRequest, ApiOptions)"/>
-    public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, string owner, string name, int number, IssueCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForIssue(owner, name, number, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssueCommentsClient.GetAllForIssue(long, int, IssueCommentRequest, ApiOptions)"/>
-    public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, long repositoryId, int number, IssueCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForIssue(repositoryId, number, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssueReactionsClient.GetAll(string, string, int, ApiOptions)"/>
-    public static IPaginatedList<Reaction> GetAllAsync(this IIssueReactionsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssueReactionsClient.GetAll(long, int, ApiOptions)"/>
-    public static IPaginatedList<Reaction> GetAllAsync(this IIssueReactionsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssuesClient.GetAllForCurrent(ApiOptions)"/>
-    public static IPaginatedList<Issue> GetAllForCurrentAsync(this IIssuesClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Issue>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssuesClient.GetAllForCurrent(IssueRequest, ApiOptions)"/>
-    public static IPaginatedList<Issue> GetAllForCurrentAsync(this IIssuesClient t, IssueRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForCurrent(request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssuesClient.GetAllForOwnedAndMemberRepositories(ApiOptions)"/>
-    public static IPaginatedList<Issue> GetAllForOwnedAndMemberRepositoriesAsync(this IIssuesClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Issue>(t.GetAllForOwnedAndMemberRepositories, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssuesClient.GetAllForOwnedAndMemberRepositories(IssueRequest, ApiOptions)"/>
-    public static IPaginatedList<Issue> GetAllForOwnedAndMemberRepositoriesAsync(this IIssuesClient t, IssueRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForOwnedAndMemberRepositories(request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssuesClient.GetAllForOrganization(string, ApiOptions)"/>
-    public static IPaginatedList<Issue> GetAllForOrganizationAsync(this IIssuesClient t, string organization, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForOrganization(organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssuesClient.GetAllForOrganization(string, IssueRequest, ApiOptions)"/>
-    public static IPaginatedList<Issue> GetAllForOrganizationAsync(this IIssuesClient t, string organization, IssueRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForOrganization(organization, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssuesClient.GetAllForRepository(string, string, ApiOptions)"/>
-    public static IPaginatedList<Issue> GetAllForRepositoryAsync(this IIssuesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssuesClient.GetAllForRepository(long, ApiOptions)"/>
-    public static IPaginatedList<Issue> GetAllForRepositoryAsync(this IIssuesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssuesClient.GetAllForRepository(string, string, RepositoryIssueRequest, ApiOptions)"/>
-    public static IPaginatedList<Issue> GetAllForRepositoryAsync(this IIssuesClient t, string owner, string name, RepositoryIssueRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssuesClient.GetAllForRepository(long, RepositoryIssueRequest, ApiOptions)"/>
-    public static IPaginatedList<Issue> GetAllForRepositoryAsync(this IIssuesClient t, long repositoryId, RepositoryIssueRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssuesEventsClient.GetAllForIssue(string, string, int, ApiOptions)"/>
-    public static IPaginatedList<IssueEvent> GetAllForIssueAsync(this IIssuesEventsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllForIssue(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssuesEventsClient.GetAllForIssue(long, int, ApiOptions)"/>
-    public static IPaginatedList<IssueEvent> GetAllForIssueAsync(this IIssuesEventsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllForIssue(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssuesEventsClient.GetAllForRepository(string, string, ApiOptions)"/>
-    public static IPaginatedList<IssueEvent> GetAllForRepositoryAsync(this IIssuesEventsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssuesEventsClient.GetAllForRepository(long, ApiOptions)"/>
-    public static IPaginatedList<IssueEvent> GetAllForRepositoryAsync(this IIssuesEventsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForIssue(string, string, int, ApiOptions)"/>
-    public static IPaginatedList<Label> GetAllForIssueAsync(this IIssuesLabelsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForIssue(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForIssue(long, int, ApiOptions)"/>
-    public static IPaginatedList<Label> GetAllForIssueAsync(this IIssuesLabelsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForIssue(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForRepository(string, string, ApiOptions)"/>
-    public static IPaginatedList<Label> GetAllForRepositoryAsync(this IIssuesLabelsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForRepository(long, ApiOptions)"/>
-    public static IPaginatedList<Label> GetAllForRepositoryAsync(this IIssuesLabelsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForMilestone(string, string, int, ApiOptions)"/>
-    public static IPaginatedList<Label> GetAllForMilestoneAsync(this IIssuesLabelsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForMilestone(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForMilestone(long, int, ApiOptions)"/>
-    public static IPaginatedList<Label> GetAllForMilestoneAsync(this IIssuesLabelsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForMilestone(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssueTimelineClient.GetAllForIssue(string, string, int, ApiOptions)"/>
-    public static IPaginatedList<TimelineEventInfo> GetAllForIssueAsync(this IIssueTimelineClient t, string owner, string repo, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<TimelineEventInfo>(options => t.GetAllForIssue(owner, repo, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IIssueTimelineClient.GetAllForIssue(long, int, ApiOptions)"/>
-    public static IPaginatedList<TimelineEventInfo> GetAllForIssueAsync(this IIssueTimelineClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<TimelineEventInfo>(options => t.GetAllForIssue(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IMilestonesClient.GetAllForRepository(string, string, ApiOptions)"/>
-    public static IPaginatedList<Milestone> GetAllForRepositoryAsync(this IMilestonesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Milestone>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IMilestonesClient.GetAllForRepository(long, ApiOptions)"/>
-    public static IPaginatedList<Milestone> GetAllForRepositoryAsync(this IMilestonesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Milestone>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IMilestonesClient.GetAllForRepository(string, string, MilestoneRequest, ApiOptions)"/>
-    public static IPaginatedList<Milestone> GetAllForRepositoryAsync(this IMilestonesClient t, string owner, string name, MilestoneRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Milestone>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IMilestonesClient.GetAllForRepository(long, MilestoneRequest, ApiOptions)"/>
-    public static IPaginatedList<Milestone> GetAllForRepositoryAsync(this IMilestonesClient t, long repositoryId, MilestoneRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Milestone>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IMiscellaneousClient.GetAllLicenses(ApiOptions)"/>
-    public static IPaginatedList<LicenseMetadata> GetAllLicensesAsync(this IMiscellaneousClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<LicenseMetadata>(t.GetAllLicenses, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="INotificationsClient.GetAllForCurrent(ApiOptions)"/>
-    public static IPaginatedList<Notification> GetAllForCurrentAsync(this INotificationsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Notification>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="INotificationsClient.GetAllForCurrent(NotificationsRequest, ApiOptions)"/>
-    public static IPaginatedList<Notification> GetAllForCurrentAsync(this INotificationsClient t, NotificationsRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Notification>(options => t.GetAllForCurrent(request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="INotificationsClient.GetAllForRepository(string, string, ApiOptions)"/>
-    public static IPaginatedList<Notification> GetAllForRepositoryAsync(this INotificationsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Notification>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="INotificationsClient.GetAllForRepository(long, ApiOptions)"/>
-    public static IPaginatedList<Notification> GetAllForRepositoryAsync(this INotificationsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Notification>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="INotificationsClient.GetAllForRepository(string, string, NotificationsRequest, ApiOptions)"/>
-    public static IPaginatedList<Notification> GetAllForRepositoryAsync(this INotificationsClient t, string owner, string name, NotificationsRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Notification>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="INotificationsClient.GetAllForRepository(long, NotificationsRequest, ApiOptions)"/>
-    public static IPaginatedList<Notification> GetAllForRepositoryAsync(this INotificationsClient t, long repositoryId, NotificationsRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Notification>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IOrganizationHooksClient.GetAll(string, ApiOptions)"/>
-    public static IPaginatedList<OrganizationHook> GetAllAsync(this IOrganizationHooksClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<OrganizationHook>(options => t.GetAll(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IOrganizationMembersClient.GetAll(string, ApiOptions)"/>
-    public static IPaginatedList<User> GetAllAsync(this IOrganizationMembersClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IOrganizationMembersClient.GetAll(string, OrganizationMembersFilter, ApiOptions)"/>
-    public static IPaginatedList<User> GetAllAsync(this IOrganizationMembersClient t, string org, OrganizationMembersFilter filter, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, filter, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IOrganizationMembersClient.GetAll(string, OrganizationMembersRole, ApiOptions)"/>
-    public static IPaginatedList<User> GetAllAsync(this IOrganizationMembersClient t, string org, OrganizationMembersRole role, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, role, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IOrganizationMembersClient.GetAll(string, OrganizationMembersFilter, OrganizationMembersRole, ApiOptions)"/>
-    public static IPaginatedList<User> GetAllAsync(this IOrganizationMembersClient t, string org, OrganizationMembersFilter filter, OrganizationMembersRole role, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, filter, role, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IOrganizationMembersClient.GetAllPublic(string, ApiOptions)"/>
-    public static IPaginatedList<User> GetAllPublicAsync(this IOrganizationMembersClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllPublic(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IOrganizationMembersClient.GetAllPendingInvitations(string, ApiOptions)"/>
-    public static IPaginatedList<OrganizationMembershipInvitation> GetAllPendingInvitationsAsync(this IOrganizationMembersClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<OrganizationMembershipInvitation>(options => t.GetAllPendingInvitations(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IOrganizationMembersClient.GetAllFailedInvitations(string, ApiOptions)"/>
-    public static IPaginatedList<OrganizationMembershipInvitation> GetAllFailedInvitationsAsync(this IOrganizationMembersClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<OrganizationMembershipInvitation>(options => t.GetAllFailedInvitations(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IOrganizationOutsideCollaboratorsClient.GetAll(string, ApiOptions)"/>
-    public static IPaginatedList<User> GetAllAsync(this IOrganizationOutsideCollaboratorsClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IOrganizationOutsideCollaboratorsClient.GetAll(string, OrganizationMembersFilter, ApiOptions)"/>
-    public static IPaginatedList<User> GetAllAsync(this IOrganizationOutsideCollaboratorsClient t, string org, OrganizationMembersFilter filter, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, filter, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IOrganizationsClient.GetAllForCurrent(ApiOptions)"/>
-    public static IPaginatedList<Organization> GetAllForCurrentAsync(this IOrganizationsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Organization>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IOrganizationsClient.GetAllForUser(string, ApiOptions)"/>
-    public static IPaginatedList<Organization> GetAllForUserAsync(this IOrganizationsClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Organization>(options => t.GetAllForUser(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IOrganizationsClient.GetAllAuthorizations(string, ApiOptions)"/>
-    public static IPaginatedList<OrganizationCredential> GetAllAuthorizationsAsync(this IOrganizationsClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<OrganizationCredential>(options => t.GetAllAuthorizations(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IOrganizationsClient.GetAllAuthorizations(string, string, ApiOptions)"/>
-    public static IPaginatedList<OrganizationCredential> GetAllAuthorizationsAsync(this IOrganizationsClient t, string org, string login, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<OrganizationCredential>(options => t.GetAllAuthorizations(org, login, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IProjectCardsClient.GetAll(int, ApiOptions)"/>
-    public static IPaginatedList<ProjectCard> GetAllAsync(this IProjectCardsClient t, int columnId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<ProjectCard>(options => t.GetAll(columnId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IProjectCardsClient.GetAll(int, ProjectCardRequest, ApiOptions)"/>
-    public static IPaginatedList<ProjectCard> GetAllAsync(this IProjectCardsClient t, int columnId, ProjectCardRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<ProjectCard>(options => t.GetAll(columnId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IProjectColumnsClient.GetAll(int, ApiOptions)"/>
-    public static IPaginatedList<ProjectColumn> GetAllAsync(this IProjectColumnsClient t, int projectId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<ProjectColumn>(options => t.GetAll(projectId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IProjectsClient.GetAllForRepository(string, string, ApiOptions)"/>
-    public static IPaginatedList<Project> GetAllForRepositoryAsync(this IProjectsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IProjectsClient.GetAllForRepository(string, string, ProjectRequest, ApiOptions)"/>
-    public static IPaginatedList<Project> GetAllForRepositoryAsync(this IProjectsClient t, string owner, string name, ProjectRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IProjectsClient.GetAllForRepository(long, ApiOptions)"/>
-    public static IPaginatedList<Project> GetAllForRepositoryAsync(this IProjectsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IProjectsClient.GetAllForRepository(long, ProjectRequest, ApiOptions)"/>
-    public static IPaginatedList<Project> GetAllForRepositoryAsync(this IProjectsClient t, long repositoryId, ProjectRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IProjectsClient.GetAllForOrganization(string, ApiOptions)"/>
-    public static IPaginatedList<Project> GetAllForOrganizationAsync(this IProjectsClient t, string organization, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForOrganization(organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IProjectsClient.GetAllForOrganization(string, ProjectRequest, ApiOptions)"/>
-    public static IPaginatedList<Project> GetAllForOrganizationAsync(this IProjectsClient t, string organization, ProjectRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForOrganization(organization, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IPullRequestReviewCommentReactionsClient.GetAll(string, string, int, ApiOptions)"/>
-    public static IPaginatedList<Reaction> GetAllAsync(this IPullRequestReviewCommentReactionsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IPullRequestReviewCommentReactionsClient.GetAll(long, int, ApiOptions)"/>
-    public static IPaginatedList<Reaction> GetAllAsync(this IPullRequestReviewCommentReactionsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
+
     /// <inheritdoc cref="IPullRequestReviewCommentsClient.GetAll(string, string, int, ApiOptions)"/>
     public static IPaginatedList<PullRequestReviewComment> GetAllAsync(this IPullRequestReviewCommentsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAll(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
+
     /// <inheritdoc cref="IPullRequestReviewCommentsClient.GetAll(long, int, ApiOptions)"/>
     public static IPaginatedList<PullRequestReviewComment> GetAllAsync(this IPullRequestReviewCommentsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAll(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
+
     /// <inheritdoc cref="IPullRequestReviewCommentsClient.GetAllForRepository(string, string, ApiOptions)"/>
     public static IPaginatedList<PullRequestReviewComment> GetAllForRepositoryAsync(this IPullRequestReviewCommentsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
+
     /// <inheritdoc cref="IPullRequestReviewCommentsClient.GetAllForRepository(long, ApiOptions)"/>
     public static IPaginatedList<PullRequestReviewComment> GetAllForRepositoryAsync(this IPullRequestReviewCommentsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
+
     /// <inheritdoc cref="IPullRequestReviewCommentsClient.GetAllForRepository(string, string, PullRequestReviewCommentRequest, ApiOptions)"/>
     public static IPaginatedList<PullRequestReviewComment> GetAllForRepositoryAsync(this IPullRequestReviewCommentsClient t, string owner, string name, PullRequestReviewCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
+
     /// <inheritdoc cref="IPullRequestReviewCommentsClient.GetAllForRepository(long, PullRequestReviewCommentRequest, ApiOptions)"/>
     public static IPaginatedList<PullRequestReviewComment> GetAllForRepositoryAsync(this IPullRequestReviewCommentsClient t, long repositoryId, PullRequestReviewCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IPullRequestReviewsClient.GetAll(string, string, int, ApiOptions)"/>
-    public static IPaginatedList<PullRequestReview> GetAllAsync(this IPullRequestReviewsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PullRequestReview>(options => t.GetAll(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IPullRequestReviewsClient.GetAll(long, int, ApiOptions)"/>
-    public static IPaginatedList<PullRequestReview> GetAllAsync(this IPullRequestReviewsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PullRequestReview>(options => t.GetAll(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IPullRequestReviewsClient.GetAllComments(string, string, int, long, ApiOptions)"/>
-    public static IPaginatedList<PullRequestReviewComment> GetAllCommentsAsync(this IPullRequestReviewsClient t, string owner, string name, int number, long reviewId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllComments(owner, name, number, reviewId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IPullRequestReviewsClient.GetAllComments(long, int, long, ApiOptions)"/>
-    public static IPaginatedList<PullRequestReviewComment> GetAllCommentsAsync(this IPullRequestReviewsClient t, long repositoryId, int number, long reviewId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllComments(repositoryId, number, reviewId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IPullRequestsClient.GetAllForRepository(string, string, ApiOptions)"/>
-    public static IPaginatedList<PullRequest> GetAllForRepositoryAsync(this IPullRequestsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PullRequest>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IPullRequestsClient.GetAllForRepository(long, ApiOptions)"/>
-    public static IPaginatedList<PullRequest> GetAllForRepositoryAsync(this IPullRequestsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PullRequest>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IPullRequestsClient.GetAllForRepository(string, string, PullRequestRequest, ApiOptions)"/>
-    public static IPaginatedList<PullRequest> GetAllForRepositoryAsync(this IPullRequestsClient t, string owner, string name, PullRequestRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PullRequest>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IPullRequestsClient.GetAllForRepository(long, PullRequestRequest, ApiOptions)"/>
-    public static IPaginatedList<PullRequest> GetAllForRepositoryAsync(this IPullRequestsClient t, long repositoryId, PullRequestRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PullRequest>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IReferencesClient.GetAll(string, string, ApiOptions)"/>
-    public static IPaginatedList<Reference> GetAllAsync(this IReferencesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Reference>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IReferencesClient.GetAll(long, ApiOptions)"/>
-    public static IPaginatedList<Reference> GetAllAsync(this IReferencesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Reference>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IReferencesClient.GetAllForSubNamespace(string, string, string, ApiOptions)"/>
-    public static IPaginatedList<Reference> GetAllForSubNamespaceAsync(this IReferencesClient t, string owner, string name, string subNamespace, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Reference>(options => t.GetAllForSubNamespace(owner, name, subNamespace, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IReferencesClient.GetAllForSubNamespace(long, string, ApiOptions)"/>
-    public static IPaginatedList<Reference> GetAllForSubNamespaceAsync(this IReferencesClient t, long repositoryId, string subNamespace, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Reference>(options => t.GetAllForSubNamespace(repositoryId, subNamespace, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
+
     /// <inheritdoc cref="IReleasesClient.GetAll(string, string, ApiOptions)"/>
     public static IPaginatedList<Release> GetAllAsync(this IReleasesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<Release>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
+
     /// <inheritdoc cref="IReleasesClient.GetAll(long, ApiOptions)"/>
     public static IPaginatedList<Release> GetAllAsync(this IReleasesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<Release>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IReleasesClient.GetAllAssets(string, string, int, ApiOptions)"/>
-    public static IPaginatedList<ReleaseAsset> GetAllAssetsAsync(this IReleasesClient t, string owner, string name, int id, int pageSize = DEFAULT_PAGE_SIZE)
+
+    /// <inheritdoc cref="IReleasesClient.GetAllAssets(string, string, long, ApiOptions)"/>
+    public static IPaginatedList<ReleaseAsset> GetAllAssetsAsync(this IReleasesClient t, string owner, string name, long id, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<ReleaseAsset>(options => t.GetAllAssets(owner, name, id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IReleasesClient.GetAllAssets(long, int, ApiOptions)"/>
-    public static IPaginatedList<ReleaseAsset> GetAllAssetsAsync(this IReleasesClient t, long repositoryId, int id, int pageSize = DEFAULT_PAGE_SIZE)
+
+    /// <inheritdoc cref="IReleasesClient.GetAllAssets(long, long, ApiOptions)"/>
+    public static IPaginatedList<ReleaseAsset> GetAllAssetsAsync(this IReleasesClient t, long repositoryId, long id, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<ReleaseAsset>(options => t.GetAllAssets(repositoryId, id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepoCollaboratorsClient.GetAll(string, string, ApiOptions)"/>
-    public static IPaginatedList<Collaborator> GetAllAsync(this IRepoCollaboratorsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Collaborator>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepoCollaboratorsClient.GetAll(long, ApiOptions)"/>
-    public static IPaginatedList<Collaborator> GetAllAsync(this IRepoCollaboratorsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Collaborator>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepoCollaboratorsClient.GetAll(string, string, RepositoryCollaboratorListRequest, ApiOptions)"/>
-    public static IPaginatedList<Collaborator> GetAllAsync(this IRepoCollaboratorsClient t, string owner, string name, RepositoryCollaboratorListRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Collaborator>(options => t.GetAll(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepoCollaboratorsClient.GetAll(long, RepositoryCollaboratorListRequest, ApiOptions)"/>
-    public static IPaginatedList<Collaborator> GetAllAsync(this IRepoCollaboratorsClient t, long repositoryId, RepositoryCollaboratorListRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Collaborator>(options => t.GetAll(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoriesClient.GetAllForCurrent(ApiOptions)"/>
-    public static IPaginatedList<Repository> GetAllForCurrentAsync(this IRepositoriesClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Repository>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoriesClient.GetAllForCurrent(RepositoryRequest, ApiOptions)"/>
-    public static IPaginatedList<Repository> GetAllForCurrentAsync(this IRepositoriesClient t, RepositoryRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForCurrent(request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoriesClient.GetAllForUser(string, ApiOptions)"/>
-    public static IPaginatedList<Repository> GetAllForUserAsync(this IRepositoriesClient t, string login, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForUser(login, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoriesClient.GetAllForOrg(string, ApiOptions)"/>
-    public static IPaginatedList<Repository> GetAllForOrgAsync(this IRepositoriesClient t, string organization, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForOrg(organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoriesClient.GetAllContributors(string, string, ApiOptions)"/>
-    public static IPaginatedList<RepositoryContributor> GetAllContributorsAsync(this IRepositoriesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<RepositoryContributor>(options => t.GetAllContributors(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoriesClient.GetAllContributors(long, ApiOptions)"/>
-    public static IPaginatedList<RepositoryContributor> GetAllContributorsAsync(this IRepositoriesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<RepositoryContributor>(options => t.GetAllContributors(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoriesClient.GetAllContributors(string, string, bool, ApiOptions)"/>
-    public static IPaginatedList<RepositoryContributor> GetAllContributorsAsync(this IRepositoriesClient t, string owner, string name, bool includeAnonymous, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<RepositoryContributor>(options => t.GetAllContributors(owner, name, includeAnonymous, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoriesClient.GetAllContributors(long, bool, ApiOptions)"/>
-    public static IPaginatedList<RepositoryContributor> GetAllContributorsAsync(this IRepositoriesClient t, long repositoryId, bool includeAnonymous, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<RepositoryContributor>(options => t.GetAllContributors(repositoryId, includeAnonymous, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoriesClient.GetAllTeams(string, string, ApiOptions)"/>
-    public static IPaginatedList<Team> GetAllTeamsAsync(this IRepositoriesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Team>(options => t.GetAllTeams(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoriesClient.GetAllTeams(long, ApiOptions)"/>
-    public static IPaginatedList<Team> GetAllTeamsAsync(this IRepositoriesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Team>(options => t.GetAllTeams(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoriesClient.GetAllTags(string, string, ApiOptions)"/>
-    public static IPaginatedList<RepositoryTag> GetAllTagsAsync(this IRepositoriesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<RepositoryTag>(options => t.GetAllTags(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoriesClient.GetAllTags(long, ApiOptions)"/>
-    public static IPaginatedList<RepositoryTag> GetAllTagsAsync(this IRepositoriesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<RepositoryTag>(options => t.GetAllTags(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoryBranchesClient.GetAll(string, string, ApiOptions)"/>
-    public static IPaginatedList<Branch> GetAllAsync(this IRepositoryBranchesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Branch>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoryBranchesClient.GetAll(long, ApiOptions)"/>
-    public static IPaginatedList<Branch> GetAllAsync(this IRepositoryBranchesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Branch>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoryCommentsClient.GetAllForRepository(string, string, ApiOptions)"/>
-    public static IPaginatedList<CommitComment> GetAllForRepositoryAsync(this IRepositoryCommentsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<CommitComment>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoryCommentsClient.GetAllForRepository(long, ApiOptions)"/>
-    public static IPaginatedList<CommitComment> GetAllForRepositoryAsync(this IRepositoryCommentsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<CommitComment>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoryCommentsClient.GetAllForCommit(string, string, string, ApiOptions)"/>
-    public static IPaginatedList<CommitComment> GetAllForCommitAsync(this IRepositoryCommentsClient t, string owner, string name, string sha, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<CommitComment>(options => t.GetAllForCommit(owner, name, sha, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoryCommentsClient.GetAllForCommit(long, string, ApiOptions)"/>
-    public static IPaginatedList<CommitComment> GetAllForCommitAsync(this IRepositoryCommentsClient t, long repositoryId, string sha, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<CommitComment>(options => t.GetAllForCommit(repositoryId, sha, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoryCommitsClient.GetAll(string, string, ApiOptions)"/>
-    public static IPaginatedList<GitHubCommit> GetAllAsync(this IRepositoryCommitsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<GitHubCommit>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoryCommitsClient.GetAll(long, ApiOptions)"/>
-    public static IPaginatedList<GitHubCommit> GetAllAsync(this IRepositoryCommitsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<GitHubCommit>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoryCommitsClient.GetAll(string, string, CommitRequest, ApiOptions)"/>
-    public static IPaginatedList<GitHubCommit> GetAllAsync(this IRepositoryCommitsClient t, string owner, string name, CommitRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<GitHubCommit>(options => t.GetAll(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoryCommitsClient.GetAll(long, CommitRequest, ApiOptions)"/>
-    public static IPaginatedList<GitHubCommit> GetAllAsync(this IRepositoryCommitsClient t, long repositoryId, CommitRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<GitHubCommit>(options => t.GetAll(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoryDeployKeysClient.GetAll(string, string, ApiOptions)"/>
-    public static IPaginatedList<DeployKey> GetAllAsync(this IRepositoryDeployKeysClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<DeployKey>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoryDeployKeysClient.GetAll(long, ApiOptions)"/>
-    public static IPaginatedList<DeployKey> GetAllAsync(this IRepositoryDeployKeysClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<DeployKey>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoryForksClient.GetAll(string, string, ApiOptions)"/>
-    public static IPaginatedList<Repository> GetAllAsync(this IRepositoryForksClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoryForksClient.GetAll(long, ApiOptions)"/>
-    public static IPaginatedList<Repository> GetAllAsync(this IRepositoryForksClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoryForksClient.GetAll(string, string, RepositoryForksListRequest, ApiOptions)"/>
-    public static IPaginatedList<Repository> GetAllAsync(this IRepositoryForksClient t, string owner, string name, RepositoryForksListRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAll(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoryForksClient.GetAll(long, RepositoryForksListRequest, ApiOptions)"/>
-    public static IPaginatedList<Repository> GetAllAsync(this IRepositoryForksClient t, long repositoryId, RepositoryForksListRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAll(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoryHooksClient.GetAll(string, string, ApiOptions)"/>
-    public static IPaginatedList<RepositoryHook> GetAllAsync(this IRepositoryHooksClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<RepositoryHook>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoryHooksClient.GetAll(long, ApiOptions)"/>
-    public static IPaginatedList<RepositoryHook> GetAllAsync(this IRepositoryHooksClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<RepositoryHook>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoryInvitationsClient.GetAllForCurrent(ApiOptions)"/>
-    public static IPaginatedList<RepositoryInvitation> GetAllForCurrentAsync(this IRepositoryInvitationsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<RepositoryInvitation>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoryInvitationsClient.GetAllForRepository(long, ApiOptions)"/>
-    public static IPaginatedList<RepositoryInvitation> GetAllForRepositoryAsync(this IRepositoryInvitationsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<RepositoryInvitation>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoryPagesClient.GetAll(string, string, ApiOptions)"/>
-    public static IPaginatedList<PagesBuild> GetAllAsync(this IRepositoryPagesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PagesBuild>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IRepositoryPagesClient.GetAll(long, ApiOptions)"/>
-    public static IPaginatedList<PagesBuild> GetAllAsync(this IRepositoryPagesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PagesBuild>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
+
+    /// <inheritdoc cref="IProjectsClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<Project> GetAllForRepositoryAsync(this IProjectsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IProjectsClient.GetAllForRepository(string, string, ProjectRequest, ApiOptions)"/>
+    public static IPaginatedList<Project> GetAllForRepositoryAsync(this IProjectsClient t, string owner, string name, ProjectRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IProjectsClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<Project> GetAllForRepositoryAsync(this IProjectsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IProjectsClient.GetAllForRepository(long, ProjectRequest, ApiOptions)"/>
+    public static IPaginatedList<Project> GetAllForRepositoryAsync(this IProjectsClient t, long repositoryId, ProjectRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IProjectsClient.GetAllForOrganization(string, ApiOptions)"/>
+    public static IPaginatedList<Project> GetAllForOrganizationAsync(this IProjectsClient t, string organization, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForOrganization(organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IProjectsClient.GetAllForOrganization(string, ProjectRequest, ApiOptions)"/>
+    public static IPaginatedList<Project> GetAllForOrganizationAsync(this IProjectsClient t, string organization, ProjectRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForOrganization(organization, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IGistsClient.GetAll(ApiOptions)"/>
+    public static IPaginatedList<Gist> GetAllAsync(this IGistsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Gist>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IGistsClient.GetAll(DateTimeOffset, ApiOptions)"/>
+    public static IPaginatedList<Gist> GetAllAsync(this IGistsClient t, DateTimeOffset since, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Gist>(options => t.GetAll(since, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IGistsClient.GetAllPublic(ApiOptions)"/>
+    public static IPaginatedList<Gist> GetAllPublicAsync(this IGistsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Gist>(t.GetAllPublic, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IGistsClient.GetAllPublic(DateTimeOffset, ApiOptions)"/>
+    public static IPaginatedList<Gist> GetAllPublicAsync(this IGistsClient t, DateTimeOffset since, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Gist>(options => t.GetAllPublic(since, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IGistsClient.GetAllStarred(ApiOptions)"/>
+    public static IPaginatedList<Gist> GetAllStarredAsync(this IGistsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Gist>(t.GetAllStarred, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IGistsClient.GetAllStarred(DateTimeOffset, ApiOptions)"/>
+    public static IPaginatedList<Gist> GetAllStarredAsync(this IGistsClient t, DateTimeOffset since, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Gist>(options => t.GetAllStarred(since, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IGistsClient.GetAllForUser(string, ApiOptions)"/>
+    public static IPaginatedList<Gist> GetAllForUserAsync(this IGistsClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Gist>(options => t.GetAllForUser(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IGistsClient.GetAllForUser(string, DateTimeOffset, ApiOptions)"/>
+    public static IPaginatedList<Gist> GetAllForUserAsync(this IGistsClient t, string user, DateTimeOffset since, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Gist>(options => t.GetAllForUser(user, since, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IGistsClient.GetAllCommits(string, ApiOptions)"/>
+    public static IPaginatedList<GistHistory> GetAllCommitsAsync(this IGistsClient t, string id, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<GistHistory>(options => t.GetAllCommits(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IGistsClient.GetAllForks(string, ApiOptions)"/>
+    public static IPaginatedList<GistFork> GetAllForksAsync(this IGistsClient t, string id, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<GistFork>(options => t.GetAllForks(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
     /// <inheritdoc cref="IStarredClient.GetAllStargazers(string, string, ApiOptions)"/>
     public static IPaginatedList<User> GetAllStargazersAsync(this IStarredClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllStargazers(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
+
     /// <inheritdoc cref="IStarredClient.GetAllStargazers(long, ApiOptions)"/>
     public static IPaginatedList<User> GetAllStargazersAsync(this IStarredClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllStargazers(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
+
     /// <inheritdoc cref="IStarredClient.GetAllStargazersWithTimestamps(string, string, ApiOptions)"/>
     public static IPaginatedList<UserStar> GetAllStargazersWithTimestampsAsync(this IStarredClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<UserStar>(options => t.GetAllStargazersWithTimestamps(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
+
     /// <inheritdoc cref="IStarredClient.GetAllStargazersWithTimestamps(long, ApiOptions)"/>
     public static IPaginatedList<UserStar> GetAllStargazersWithTimestampsAsync(this IStarredClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<UserStar>(options => t.GetAllStargazersWithTimestamps(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
+
     /// <inheritdoc cref="IStarredClient.GetAllForCurrent(ApiOptions)"/>
     public static IPaginatedList<Repository> GetAllForCurrentAsync(this IStarredClient t, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<Repository>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
+
     /// <inheritdoc cref="IStarredClient.GetAllForCurrentWithTimestamps(ApiOptions)"/>
     public static IPaginatedList<RepositoryStar> GetAllForCurrentWithTimestampsAsync(this IStarredClient t, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<RepositoryStar>(t.GetAllForCurrentWithTimestamps, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
+
     /// <inheritdoc cref="IStarredClient.GetAllForCurrent(StarredRequest, ApiOptions)"/>
     public static IPaginatedList<Repository> GetAllForCurrentAsync(this IStarredClient t, StarredRequest request, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForCurrent(request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
+
     /// <inheritdoc cref="IStarredClient.GetAllForCurrentWithTimestamps(StarredRequest, ApiOptions)"/>
     public static IPaginatedList<RepositoryStar> GetAllForCurrentWithTimestampsAsync(this IStarredClient t, StarredRequest request, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<RepositoryStar>(options => t.GetAllForCurrentWithTimestamps(request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
+
     /// <inheritdoc cref="IStarredClient.GetAllForUser(string, ApiOptions)"/>
     public static IPaginatedList<Repository> GetAllForUserAsync(this IStarredClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForUser(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
+
     /// <inheritdoc cref="IStarredClient.GetAllForUserWithTimestamps(string, ApiOptions)"/>
     public static IPaginatedList<RepositoryStar> GetAllForUserWithTimestampsAsync(this IStarredClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<RepositoryStar>(options => t.GetAllForUserWithTimestamps(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
+
     /// <inheritdoc cref="IStarredClient.GetAllForUser(string, StarredRequest, ApiOptions)"/>
     public static IPaginatedList<Repository> GetAllForUserAsync(this IStarredClient t, string user, StarredRequest request, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForUser(user, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
+
     /// <inheritdoc cref="IStarredClient.GetAllForUserWithTimestamps(string, StarredRequest, ApiOptions)"/>
     public static IPaginatedList<RepositoryStar> GetAllForUserWithTimestampsAsync(this IStarredClient t, string user, StarredRequest request, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<RepositoryStar>(options => t.GetAllForUserWithTimestamps(user, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="ITeamsClient.GetAll(string, ApiOptions)"/>
-    public static IPaginatedList<Team> GetAllAsync(this ITeamsClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Team>(options => t.GetAll(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="ITeamsClient.GetAllForCurrent(ApiOptions)"/>
-    public static IPaginatedList<Team> GetAllForCurrentAsync(this ITeamsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Team>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="ITeamsClient.GetAllChildTeams(int, ApiOptions)"/>
-    public static IPaginatedList<Team> GetAllChildTeamsAsync(this ITeamsClient t, int id, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Team>(options => t.GetAllChildTeams(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="ITeamsClient.GetAllMembers(int, ApiOptions)"/>
-    public static IPaginatedList<User> GetAllMembersAsync(this ITeamsClient t, int id, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllMembers(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="ITeamsClient.GetAllMembers(int, TeamMembersRequest, ApiOptions)"/>
-    public static IPaginatedList<User> GetAllMembersAsync(this ITeamsClient t, int id, TeamMembersRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllMembers(id, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="ITeamsClient.GetAllRepositories(int, ApiOptions)"/>
-    public static IPaginatedList<Repository> GetAllRepositoriesAsync(this ITeamsClient t, int id, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllRepositories(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="ITeamsClient.GetAllPendingInvitations(int, ApiOptions)"/>
-    public static IPaginatedList<OrganizationMembershipInvitation> GetAllPendingInvitationsAsync(this ITeamsClient t, int id, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<OrganizationMembershipInvitation>(options => t.GetAllPendingInvitations(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IUserEmailsClient.GetAll(ApiOptions)"/>
-    public static IPaginatedList<EmailAddress> GetAllAsync(this IUserEmailsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<EmailAddress>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
+
+    /// <inheritdoc cref="ILicensesClient.GetAllLicenses(ApiOptions)"/>
+    public static IPaginatedList<LicenseMetadata> GetAllLicensesAsync(this ILicensesClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<LicenseMetadata>(t.GetAllLicenses, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="ICommitCommentReactionsClient.GetAll(string, string, long, ApiOptions)"/>
+    public static IPaginatedList<Reaction> GetAllAsync(this ICommitCommentReactionsClient t, string owner, string name, long commentId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(owner, name, commentId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="ICommitCommentReactionsClient.GetAll(long, long, ApiOptions)"/>
+    public static IPaginatedList<Reaction> GetAllAsync(this ICommitCommentReactionsClient t, long repositoryId, long commentId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(repositoryId, commentId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IPullRequestReviewsClient.GetAll(string, string, int, ApiOptions)"/>
+    public static IPaginatedList<PullRequestReview> GetAllAsync(this IPullRequestReviewsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequestReview>(options => t.GetAll(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IPullRequestReviewsClient.GetAll(long, int, ApiOptions)"/>
+    public static IPaginatedList<PullRequestReview> GetAllAsync(this IPullRequestReviewsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequestReview>(options => t.GetAll(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IPullRequestReviewsClient.GetAllComments(string, string, int, long, ApiOptions)"/>
+    public static IPaginatedList<PullRequestReviewComment> GetAllCommentsAsync(this IPullRequestReviewsClient t, string owner, string name, int number, long reviewId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllComments(owner, name, number, reviewId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IPullRequestReviewsClient.GetAllComments(long, int, long, ApiOptions)"/>
+    public static IPaginatedList<PullRequestReviewComment> GetAllCommentsAsync(this IPullRequestReviewsClient t, long repositoryId, int number, long reviewId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllComments(repositoryId, number, reviewId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IActionsSelfHostedRunnerGroupsClient.ListAllRunnerGroupOrganizationsForEnterprise(string, long, ApiOptions)"/>
+    public static IPaginatedList<Organization> ListAllRunnerGroupOrganizationsForEnterpriseAsync(this IActionsSelfHostedRunnerGroupsClient t, string enterprise, long runnerGroupId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Organization>(options => t.ListAllRunnerGroupOrganizationsForEnterprise(enterprise, runnerGroupId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IActionsSelfHostedRunnerGroupsClient.ListAllRunnerGroupRepositoriesForOrganization(string, long, ApiOptions)"/>
+    public static IPaginatedList<Repository> ListAllRunnerGroupRepositoriesForOrganizationAsync(this IActionsSelfHostedRunnerGroupsClient t, string org, long runnerGroupId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(options => t.ListAllRunnerGroupRepositoriesForOrganization(org, runnerGroupId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryDeployKeysClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<DeployKey> GetAllAsync(this IRepositoryDeployKeysClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<DeployKey>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryDeployKeysClient.GetAll(long, ApiOptions)"/>
+    public static IPaginatedList<DeployKey> GetAllAsync(this IRepositoryDeployKeysClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<DeployKey>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryForksClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllAsync(this IRepositoryForksClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryForksClient.GetAll(long, ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllAsync(this IRepositoryForksClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryForksClient.GetAll(string, string, RepositoryForksListRequest, ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllAsync(this IRepositoryForksClient t, string owner, string name, RepositoryForksListRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAll(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryForksClient.GetAll(long, RepositoryForksListRequest, ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllAsync(this IRepositoryForksClient t, long repositoryId, RepositoryForksListRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAll(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssueCommentReactionsClient.GetAll(string, string, long, ApiOptions)"/>
+    public static IPaginatedList<Reaction> GetAllAsync(this IIssueCommentReactionsClient t, string owner, string name, long commentId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(owner, name, commentId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssueCommentReactionsClient.GetAll(long, long, ApiOptions)"/>
+    public static IPaginatedList<Reaction> GetAllAsync(this IIssueCommentReactionsClient t, long repositoryId, long commentId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(repositoryId, commentId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryInvitationsClient.GetAllForCurrent(ApiOptions)"/>
+    public static IPaginatedList<RepositoryInvitation> GetAllForCurrentAsync(this IRepositoryInvitationsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryInvitation>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryInvitationsClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<RepositoryInvitation> GetAllForRepositoryAsync(this IRepositoryInvitationsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryInvitation>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationHooksClient.GetAll(string, ApiOptions)"/>
+    public static IPaginatedList<OrganizationHook> GetAllAsync(this IOrganizationHooksClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<OrganizationHook>(options => t.GetAll(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryCommentsClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<CommitComment> GetAllForRepositoryAsync(this IRepositoryCommentsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<CommitComment>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryCommentsClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<CommitComment> GetAllForRepositoryAsync(this IRepositoryCommentsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<CommitComment>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryCommentsClient.GetAllForCommit(string, string, string, ApiOptions)"/>
+    public static IPaginatedList<CommitComment> GetAllForCommitAsync(this IRepositoryCommentsClient t, string owner, string name, string sha, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<CommitComment>(options => t.GetAllForCommit(owner, name, sha, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryCommentsClient.GetAllForCommit(long, string, ApiOptions)"/>
+    public static IPaginatedList<CommitComment> GetAllForCommitAsync(this IRepositoryCommentsClient t, long repositoryId, string sha, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<CommitComment>(options => t.GetAllForCommit(repositoryId, sha, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepoCollaboratorsClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<Collaborator> GetAllAsync(this IRepoCollaboratorsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Collaborator>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepoCollaboratorsClient.GetAll(long, ApiOptions)"/>
+    public static IPaginatedList<Collaborator> GetAllAsync(this IRepoCollaboratorsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Collaborator>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepoCollaboratorsClient.GetAll(string, string, RepositoryCollaboratorListRequest, ApiOptions)"/>
+    public static IPaginatedList<Collaborator> GetAllAsync(this IRepoCollaboratorsClient t, string owner, string name, RepositoryCollaboratorListRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Collaborator>(options => t.GetAll(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepoCollaboratorsClient.GetAll(long, RepositoryCollaboratorListRequest, ApiOptions)"/>
+    public static IPaginatedList<Collaborator> GetAllAsync(this IRepoCollaboratorsClient t, long repositoryId, RepositoryCollaboratorListRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Collaborator>(options => t.GetAll(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
     /// <inheritdoc cref="IUserGpgKeysClient.GetAllForCurrent(ApiOptions)"/>
     public static IPaginatedList<GpgKey> GetAllForCurrentAsync(this IUserGpgKeysClient t, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<GpgKey>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IUserKeysClient.GetAll(string, ApiOptions)"/>
-    public static IPaginatedList<PublicKey> GetAllAsync(this IUserKeysClient t, string userName, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PublicKey>(options => t.GetAll(userName, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IUserKeysClient.GetAllForCurrent(ApiOptions)"/>
-    public static IPaginatedList<PublicKey> GetAllForCurrentAsync(this IUserKeysClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PublicKey>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
+
+    /// <inheritdoc cref="IActionsSelfHostedRunnersClient.ListAllRunnerApplicationsForEnterprise(string, ApiOptions)"/>
+    public static IPaginatedList<RunnerApplication> ListAllRunnerApplicationsForEnterpriseAsync(this IActionsSelfHostedRunnersClient t, string enterprise, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RunnerApplication>(options => t.ListAllRunnerApplicationsForEnterprise(enterprise, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IActionsSelfHostedRunnersClient.ListAllRunnerApplicationsForOrganization(string, ApiOptions)"/>
+    public static IPaginatedList<RunnerApplication> ListAllRunnerApplicationsForOrganizationAsync(this IActionsSelfHostedRunnersClient t, string organization, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RunnerApplication>(options => t.ListAllRunnerApplicationsForOrganization(organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IActionsSelfHostedRunnersClient.ListAllRunnerApplicationsForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<RunnerApplication> ListAllRunnerApplicationsForRepositoryAsync(this IActionsSelfHostedRunnersClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RunnerApplication>(options => t.ListAllRunnerApplicationsForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IAutolinksClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<Autolink> GetAllAsync(this IAutolinksClient t, string owner, string repo, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Autolink>(options => t.GetAll(owner, repo, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssueCommentsClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<IssueComment> GetAllForRepositoryAsync(this IIssueCommentsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssueCommentsClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<IssueComment> GetAllForRepositoryAsync(this IIssueCommentsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssueCommentsClient.GetAllForRepository(string, string, IssueCommentRequest, ApiOptions)"/>
+    public static IPaginatedList<IssueComment> GetAllForRepositoryAsync(this IIssueCommentsClient t, string owner, string name, IssueCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssueCommentsClient.GetAllForRepository(long, IssueCommentRequest, ApiOptions)"/>
+    public static IPaginatedList<IssueComment> GetAllForRepositoryAsync(this IIssueCommentsClient t, long repositoryId, IssueCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssueCommentsClient.GetAllForIssue(string, string, int, ApiOptions)"/>
+    public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForIssue(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssueCommentsClient.GetAllForIssue(long, int, ApiOptions)"/>
+    public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForIssue(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssueCommentsClient.GetAllForIssue(string, string, int, IssueCommentRequest, ApiOptions)"/>
+    public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, string owner, string name, int number, IssueCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForIssue(owner, name, number, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssueCommentsClient.GetAllForIssue(long, int, IssueCommentRequest, ApiOptions)"/>
+    public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, long repositoryId, int number, IssueCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForIssue(repositoryId, number, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
     /// <inheritdoc cref="IWatchedClient.GetAllWatchers(string, string, ApiOptions)"/>
     public static IPaginatedList<User> GetAllWatchersAsync(this IWatchedClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllWatchers(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
+
     /// <inheritdoc cref="IWatchedClient.GetAllWatchers(long, ApiOptions)"/>
     public static IPaginatedList<User> GetAllWatchersAsync(this IWatchedClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllWatchers(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
+
     /// <inheritdoc cref="IWatchedClient.GetAllForCurrent(ApiOptions)"/>
     public static IPaginatedList<Repository> GetAllForCurrentAsync(this IWatchedClient t, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<Repository>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
+
     /// <inheritdoc cref="IWatchedClient.GetAllForUser(string, ApiOptions)"/>
     public static IPaginatedList<Repository> GetAllForUserAsync(this IWatchedClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForUser(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
+
+    /// <inheritdoc cref="IIssuesEventsClient.GetAllForIssue(string, string, int, ApiOptions)"/>
+    public static IPaginatedList<IssueEvent> GetAllForIssueAsync(this IIssuesEventsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllForIssue(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesEventsClient.GetAllForIssue(long, int, ApiOptions)"/>
+    public static IPaginatedList<IssueEvent> GetAllForIssueAsync(this IIssuesEventsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllForIssue(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesEventsClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<IssueEvent> GetAllForRepositoryAsync(this IIssuesEventsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesEventsClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<IssueEvent> GetAllForRepositoryAsync(this IIssuesEventsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IMiscellaneousClient.GetAllLicenses(ApiOptions)"/>
+    public static IPaginatedList<LicenseMetadata> GetAllLicensesAsync(this IMiscellaneousClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<LicenseMetadata>(t.GetAllLicenses, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssueTimelineClient.GetAllForIssue(string, string, int, ApiOptions)"/>
+    public static IPaginatedList<TimelineEventInfo> GetAllForIssueAsync(this IIssueTimelineClient t, string owner, string repo, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<TimelineEventInfo>(options => t.GetAllForIssue(owner, repo, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssueTimelineClient.GetAllForIssue(long, int, ApiOptions)"/>
+    public static IPaginatedList<TimelineEventInfo> GetAllForIssueAsync(this IIssueTimelineClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<TimelineEventInfo>(options => t.GetAllForIssue(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IProjectCardsClient.GetAll(int, ApiOptions)"/>
+    public static IPaginatedList<ProjectCard> GetAllAsync(this IProjectCardsClient t, int columnId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<ProjectCard>(options => t.GetAll(columnId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IProjectCardsClient.GetAll(int, ProjectCardRequest, ApiOptions)"/>
+    public static IPaginatedList<ProjectCard> GetAllAsync(this IProjectCardsClient t, int columnId, ProjectCardRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<ProjectCard>(options => t.GetAll(columnId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryCommitsClient.BranchesWhereHead(long, string, ApiOptions)"/>
+    public static IPaginatedList<Branch> BranchesWhereHeadAsync(this IRepositoryCommitsClient t, long repositoryId, string sha1, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Branch>(options => t.BranchesWhereHead(repositoryId, sha1, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryCommitsClient.BranchesWhereHead(string, string, string, ApiOptions)"/>
+    public static IPaginatedList<Branch> BranchesWhereHeadAsync(this IRepositoryCommitsClient t, string owner, string name, string sha1, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Branch>(options => t.BranchesWhereHead(owner, name, sha1, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryCommitsClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<GitHubCommit> GetAllAsync(this IRepositoryCommitsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<GitHubCommit>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryCommitsClient.GetAll(long, ApiOptions)"/>
+    public static IPaginatedList<GitHubCommit> GetAllAsync(this IRepositoryCommitsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<GitHubCommit>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryCommitsClient.GetAll(string, string, CommitRequest, ApiOptions)"/>
+    public static IPaginatedList<GitHubCommit> GetAllAsync(this IRepositoryCommitsClient t, string owner, string name, CommitRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<GitHubCommit>(options => t.GetAll(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryCommitsClient.GetAll(long, CommitRequest, ApiOptions)"/>
+    public static IPaginatedList<GitHubCommit> GetAllAsync(this IRepositoryCommitsClient t, long repositoryId, CommitRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<GitHubCommit>(options => t.GetAll(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryCommitsClient.PullRequests(long, string, ApiOptions)"/>
+    public static IPaginatedList<CommitPullRequest> PullRequestsAsync(this IRepositoryCommitsClient t, long repositoryId, string sha1, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<CommitPullRequest>(options => t.PullRequests(repositoryId, sha1, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryCommitsClient.PullRequests(string, string, string, ApiOptions)"/>
+    public static IPaginatedList<CommitPullRequest> PullRequestsAsync(this IRepositoryCommitsClient t, string owner, string name, string sha1, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<CommitPullRequest>(options => t.PullRequests(owner, name, sha1, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IDeploymentsClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<Deployment> GetAllAsync(this IDeploymentsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Deployment>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IDeploymentsClient.GetAll(long, ApiOptions)"/>
+    public static IPaginatedList<Deployment> GetAllAsync(this IDeploymentsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Deployment>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IAssigneesClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllForRepositoryAsync(this IAssigneesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IAssigneesClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllForRepositoryAsync(this IAssigneesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesClient.GetAllForCurrent(ApiOptions)"/>
+    public static IPaginatedList<Issue> GetAllForCurrentAsync(this IIssuesClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Issue>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesClient.GetAllForCurrent(IssueRequest, ApiOptions)"/>
+    public static IPaginatedList<Issue> GetAllForCurrentAsync(this IIssuesClient t, IssueRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForCurrent(request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesClient.GetAllForOwnedAndMemberRepositories(ApiOptions)"/>
+    public static IPaginatedList<Issue> GetAllForOwnedAndMemberRepositoriesAsync(this IIssuesClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Issue>(t.GetAllForOwnedAndMemberRepositories, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesClient.GetAllForOwnedAndMemberRepositories(IssueRequest, ApiOptions)"/>
+    public static IPaginatedList<Issue> GetAllForOwnedAndMemberRepositoriesAsync(this IIssuesClient t, IssueRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForOwnedAndMemberRepositories(request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesClient.GetAllForOrganization(string, ApiOptions)"/>
+    public static IPaginatedList<Issue> GetAllForOrganizationAsync(this IIssuesClient t, string organization, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForOrganization(organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesClient.GetAllForOrganization(string, IssueRequest, ApiOptions)"/>
+    public static IPaginatedList<Issue> GetAllForOrganizationAsync(this IIssuesClient t, string organization, IssueRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForOrganization(organization, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<Issue> GetAllForRepositoryAsync(this IIssuesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<Issue> GetAllForRepositoryAsync(this IIssuesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesClient.GetAllForRepository(string, string, RepositoryIssueRequest, ApiOptions)"/>
+    public static IPaginatedList<Issue> GetAllForRepositoryAsync(this IIssuesClient t, string owner, string name, RepositoryIssueRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesClient.GetAllForRepository(long, RepositoryIssueRequest, ApiOptions)"/>
+    public static IPaginatedList<Issue> GetAllForRepositoryAsync(this IIssuesClient t, long repositoryId, RepositoryIssueRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IPullRequestsClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<PullRequest> GetAllForRepositoryAsync(this IPullRequestsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequest>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IPullRequestsClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<PullRequest> GetAllForRepositoryAsync(this IPullRequestsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequest>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IPullRequestsClient.GetAllForRepository(string, string, PullRequestRequest, ApiOptions)"/>
+    public static IPaginatedList<PullRequest> GetAllForRepositoryAsync(this IPullRequestsClient t, string owner, string name, PullRequestRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequest>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IPullRequestsClient.GetAllForRepository(long, PullRequestRequest, ApiOptions)"/>
+    public static IPaginatedList<PullRequest> GetAllForRepositoryAsync(this IPullRequestsClient t, long repositoryId, PullRequestRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequest>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IPullRequestsClient.Files(string, string, int, ApiOptions)"/>
+    public static IPaginatedList<PullRequestFile> FilesAsync(this IPullRequestsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequestFile>(options => t.Files(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IPullRequestsClient.Files(long, int, ApiOptions)"/>
+    public static IPaginatedList<PullRequestFile> FilesAsync(this IPullRequestsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequestFile>(options => t.Files(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IMilestonesClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<Milestone> GetAllForRepositoryAsync(this IMilestonesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Milestone>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IMilestonesClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<Milestone> GetAllForRepositoryAsync(this IMilestonesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Milestone>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IMilestonesClient.GetAllForRepository(string, string, MilestoneRequest, ApiOptions)"/>
+    public static IPaginatedList<Milestone> GetAllForRepositoryAsync(this IMilestonesClient t, string owner, string name, MilestoneRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Milestone>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IMilestonesClient.GetAllForRepository(long, MilestoneRequest, ApiOptions)"/>
+    public static IPaginatedList<Milestone> GetAllForRepositoryAsync(this IMilestonesClient t, long repositoryId, MilestoneRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Milestone>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryHooksClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<RepositoryHook> GetAllAsync(this IRepositoryHooksClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryHook>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryHooksClient.GetAll(long, ApiOptions)"/>
+    public static IPaginatedList<RepositoryHook> GetAllAsync(this IRepositoryHooksClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryHook>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryPagesClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<PagesBuild> GetAllAsync(this IRepositoryPagesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PagesBuild>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryPagesClient.GetAll(long, ApiOptions)"/>
+    public static IPaginatedList<PagesBuild> GetAllAsync(this IRepositoryPagesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PagesBuild>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IUserKeysClient.GetAll(string, ApiOptions)"/>
+    public static IPaginatedList<PublicKey> GetAllAsync(this IUserKeysClient t, string userName, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PublicKey>(options => t.GetAll(userName, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IUserKeysClient.GetAllForCurrent(ApiOptions)"/>
+    public static IPaginatedList<PublicKey> GetAllForCurrentAsync(this IUserKeysClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PublicKey>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="ITeamsClient.GetAll(string, ApiOptions)"/>
+    public static IPaginatedList<Team> GetAllAsync(this ITeamsClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Team>(options => t.GetAll(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="ITeamsClient.GetAllForCurrent(ApiOptions)"/>
+    public static IPaginatedList<Team> GetAllForCurrentAsync(this ITeamsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Team>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="ITeamsClient.GetAllChildTeams(long, ApiOptions)"/>
+    public static IPaginatedList<Team> GetAllChildTeamsAsync(this ITeamsClient t, long id, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Team>(options => t.GetAllChildTeams(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="ITeamsClient.GetAllMembers(long, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllMembersAsync(this ITeamsClient t, long id, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllMembers(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="ITeamsClient.GetAllMembers(long, TeamMembersRequest, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllMembersAsync(this ITeamsClient t, long id, TeamMembersRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllMembers(id, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="ITeamsClient.GetAllRepositories(long, ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllRepositoriesAsync(this ITeamsClient t, long id, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllRepositories(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="ITeamsClient.GetAllPendingInvitations(long, ApiOptions)"/>
+    public static IPaginatedList<OrganizationMembershipInvitation> GetAllPendingInvitationsAsync(this ITeamsClient t, long id, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<OrganizationMembershipInvitation>(options => t.GetAllPendingInvitations(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="ICheckRunsClient.GetAllAnnotations(string, string, long, ApiOptions)"/>
+    public static IPaginatedList<CheckRunAnnotation> GetAllAnnotationsAsync(this ICheckRunsClient t, string owner, string name, long checkRunId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<CheckRunAnnotation>(options => t.GetAllAnnotations(owner, name, checkRunId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="ICheckRunsClient.GetAllAnnotations(long, long, ApiOptions)"/>
+    public static IPaginatedList<CheckRunAnnotation> GetAllAnnotationsAsync(this ICheckRunsClient t, long repositoryId, long checkRunId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<CheckRunAnnotation>(options => t.GetAllAnnotations(repositoryId, checkRunId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationOutsideCollaboratorsClient.GetAll(string, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllAsync(this IOrganizationOutsideCollaboratorsClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationOutsideCollaboratorsClient.GetAll(string, OrganizationMembersFilter, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllAsync(this IOrganizationOutsideCollaboratorsClient t, string org, OrganizationMembersFilter filter, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, filter, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IPullRequestReviewCommentReactionsClient.GetAll(string, string, long, ApiOptions)"/>
+    public static IPaginatedList<Reaction> GetAllAsync(this IPullRequestReviewCommentReactionsClient t, string owner, string name, long commentId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(owner, name, commentId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IPullRequestReviewCommentReactionsClient.GetAll(long, long, ApiOptions)"/>
+    public static IPaginatedList<Reaction> GetAllAsync(this IPullRequestReviewCommentReactionsClient t, long repositoryId, long commentId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(repositoryId, commentId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="INotificationsClient.GetAllForCurrent(ApiOptions)"/>
+    public static IPaginatedList<Notification> GetAllForCurrentAsync(this INotificationsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Notification>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="INotificationsClient.GetAllForCurrent(NotificationsRequest, ApiOptions)"/>
+    public static IPaginatedList<Notification> GetAllForCurrentAsync(this INotificationsClient t, NotificationsRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Notification>(options => t.GetAllForCurrent(request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="INotificationsClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<Notification> GetAllForRepositoryAsync(this INotificationsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Notification>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="INotificationsClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<Notification> GetAllForRepositoryAsync(this INotificationsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Notification>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="INotificationsClient.GetAllForRepository(string, string, NotificationsRequest, ApiOptions)"/>
+    public static IPaginatedList<Notification> GetAllForRepositoryAsync(this INotificationsClient t, string owner, string name, NotificationsRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Notification>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="INotificationsClient.GetAllForRepository(long, NotificationsRequest, ApiOptions)"/>
+    public static IPaginatedList<Notification> GetAllForRepositoryAsync(this INotificationsClient t, long repositoryId, NotificationsRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Notification>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationsClient.GetAllForCurrent(ApiOptions)"/>
+    public static IPaginatedList<Organization> GetAllForCurrentAsync(this IOrganizationsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Organization>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationsClient.GetAllForUser(string, ApiOptions)"/>
+    public static IPaginatedList<Organization> GetAllForUserAsync(this IOrganizationsClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Organization>(options => t.GetAllForUser(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationsClient.GetAllAuthorizations(string, ApiOptions)"/>
+    public static IPaginatedList<OrganizationCredential> GetAllAuthorizationsAsync(this IOrganizationsClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<OrganizationCredential>(options => t.GetAllAuthorizations(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationsClient.GetAllAuthorizations(string, string, ApiOptions)"/>
+    public static IPaginatedList<OrganizationCredential> GetAllAuthorizationsAsync(this IOrganizationsClient t, string org, string login, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<OrganizationCredential>(options => t.GetAllAuthorizations(org, login, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IEventsClient.GetAll(ApiOptions)"/>
+    public static IPaginatedList<Activity> GetAllAsync(this IEventsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Activity>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IEventsClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<Activity> GetAllForRepositoryAsync(this IEventsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IEventsClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<Activity> GetAllForRepositoryAsync(this IEventsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IEventsClient.GetAllIssuesForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<IssueEvent> GetAllIssuesForRepositoryAsync(this IEventsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllIssuesForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IEventsClient.GetAllIssuesForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<IssueEvent> GetAllIssuesForRepositoryAsync(this IEventsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllIssuesForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IEventsClient.GetAllForRepositoryNetwork(string, string, ApiOptions)"/>
+    public static IPaginatedList<Activity> GetAllForRepositoryNetworkAsync(this IEventsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllForRepositoryNetwork(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IEventsClient.GetAllForOrganization(string, ApiOptions)"/>
+    public static IPaginatedList<Activity> GetAllForOrganizationAsync(this IEventsClient t, string organization, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllForOrganization(organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IEventsClient.GetAllUserReceived(string, ApiOptions)"/>
+    public static IPaginatedList<Activity> GetAllUserReceivedAsync(this IEventsClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllUserReceived(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IEventsClient.GetAllUserReceivedPublic(string, ApiOptions)"/>
+    public static IPaginatedList<Activity> GetAllUserReceivedPublicAsync(this IEventsClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllUserReceivedPublic(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IEventsClient.GetAllUserPerformed(string, ApiOptions)"/>
+    public static IPaginatedList<Activity> GetAllUserPerformedAsync(this IEventsClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllUserPerformed(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IEventsClient.GetAllUserPerformedPublic(string, ApiOptions)"/>
+    public static IPaginatedList<Activity> GetAllUserPerformedPublicAsync(this IEventsClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllUserPerformedPublic(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IEventsClient.GetAllForAnOrganization(string, string, ApiOptions)"/>
+    public static IPaginatedList<Activity> GetAllForAnOrganizationAsync(this IEventsClient t, string user, string organization, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllForAnOrganization(user, organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForIssue(string, string, int, ApiOptions)"/>
+    public static IPaginatedList<Label> GetAllForIssueAsync(this IIssuesLabelsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForIssue(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForIssue(long, int, ApiOptions)"/>
+    public static IPaginatedList<Label> GetAllForIssueAsync(this IIssuesLabelsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForIssue(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<Label> GetAllForRepositoryAsync(this IIssuesLabelsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<Label> GetAllForRepositoryAsync(this IIssuesLabelsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForMilestone(string, string, int, ApiOptions)"/>
+    public static IPaginatedList<Label> GetAllForMilestoneAsync(this IIssuesLabelsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForMilestone(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForMilestone(long, int, ApiOptions)"/>
+    public static IPaginatedList<Label> GetAllForMilestoneAsync(this IIssuesLabelsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForMilestone(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IDeploymentStatusClient.GetAll(string, string, long, ApiOptions)"/>
+    public static IPaginatedList<DeploymentStatus> GetAllAsync(this IDeploymentStatusClient t, string owner, string name, long deploymentId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<DeploymentStatus>(options => t.GetAll(owner, name, deploymentId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IDeploymentStatusClient.GetAll(long, long, ApiOptions)"/>
+    public static IPaginatedList<DeploymentStatus> GetAllAsync(this IDeploymentStatusClient t, long repositoryId, long deploymentId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<DeploymentStatus>(options => t.GetAll(repositoryId, deploymentId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssueReactionsClient.GetAll(string, string, int, ApiOptions)"/>
+    public static IPaginatedList<Reaction> GetAllAsync(this IIssueReactionsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssueReactionsClient.GetAll(long, int, ApiOptions)"/>
+    public static IPaginatedList<Reaction> GetAllAsync(this IIssueReactionsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IReferencesClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<Reference> GetAllAsync(this IReferencesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reference>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IReferencesClient.GetAll(long, ApiOptions)"/>
+    public static IPaginatedList<Reference> GetAllAsync(this IReferencesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reference>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IReferencesClient.GetAllForSubNamespace(string, string, string, ApiOptions)"/>
+    public static IPaginatedList<Reference> GetAllForSubNamespaceAsync(this IReferencesClient t, string owner, string name, string subNamespace, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reference>(options => t.GetAllForSubNamespace(owner, name, subNamespace, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IReferencesClient.GetAllForSubNamespace(long, string, ApiOptions)"/>
+    public static IPaginatedList<Reference> GetAllForSubNamespaceAsync(this IReferencesClient t, long repositoryId, string subNamespace, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reference>(options => t.GetAllForSubNamespace(repositoryId, subNamespace, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IUserEmailsClient.GetAll(ApiOptions)"/>
+    public static IPaginatedList<EmailAddress> GetAllAsync(this IUserEmailsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<EmailAddress>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="ICommitStatusClient.GetAll(string, string, string, ApiOptions)"/>
+    public static IPaginatedList<CommitStatus> GetAllAsync(this ICommitStatusClient t, string owner, string name, string reference, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<CommitStatus>(options => t.GetAll(owner, name, reference, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="ICommitStatusClient.GetAll(long, string, ApiOptions)"/>
+    public static IPaginatedList<CommitStatus> GetAllAsync(this ICommitStatusClient t, long repositoryId, string reference, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<CommitStatus>(options => t.GetAll(repositoryId, reference, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IGistCommentsClient.GetAllForGist(string, ApiOptions)"/>
+    public static IPaginatedList<GistComment> GetAllForGistAsync(this IGistCommentsClient t, string gistId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<GistComment>(options => t.GetAllForGist(gistId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IProjectColumnsClient.GetAll(int, ApiOptions)"/>
+    public static IPaginatedList<ProjectColumn> GetAllAsync(this IProjectColumnsClient t, int projectId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<ProjectColumn>(options => t.GetAll(projectId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IFollowersClient.GetAllForCurrent(ApiOptions)"/>
+    public static IPaginatedList<User> GetAllForCurrentAsync(this IFollowersClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IFollowersClient.GetAll(string, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllAsync(this IFollowersClient t, string login, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(login, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IFollowersClient.GetAllFollowingForCurrent(ApiOptions)"/>
+    public static IPaginatedList<User> GetAllFollowingForCurrentAsync(this IFollowersClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(t.GetAllFollowingForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IFollowersClient.GetAllFollowing(string, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllFollowingAsync(this IFollowersClient t, string login, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllFollowing(login, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoriesClient.GetAllForCurrent(ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllForCurrentAsync(this IRepositoriesClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoriesClient.GetAllForCurrent(RepositoryRequest, ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllForCurrentAsync(this IRepositoriesClient t, RepositoryRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForCurrent(request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoriesClient.GetAllForUser(string, ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllForUserAsync(this IRepositoriesClient t, string login, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForUser(login, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoriesClient.GetAllForOrg(string, ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllForOrgAsync(this IRepositoriesClient t, string organization, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForOrg(organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoriesClient.GetAllContributors(string, string, ApiOptions)"/>
+    public static IPaginatedList<RepositoryContributor> GetAllContributorsAsync(this IRepositoriesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryContributor>(options => t.GetAllContributors(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoriesClient.GetAllContributors(long, ApiOptions)"/>
+    public static IPaginatedList<RepositoryContributor> GetAllContributorsAsync(this IRepositoriesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryContributor>(options => t.GetAllContributors(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoriesClient.GetAllContributors(string, string, bool, ApiOptions)"/>
+    public static IPaginatedList<RepositoryContributor> GetAllContributorsAsync(this IRepositoriesClient t, string owner, string name, bool includeAnonymous, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryContributor>(options => t.GetAllContributors(owner, name, includeAnonymous, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoriesClient.GetAllContributors(long, bool, ApiOptions)"/>
+    public static IPaginatedList<RepositoryContributor> GetAllContributorsAsync(this IRepositoriesClient t, long repositoryId, bool includeAnonymous, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryContributor>(options => t.GetAllContributors(repositoryId, includeAnonymous, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoriesClient.GetAllTeams(string, string, ApiOptions)"/>
+    public static IPaginatedList<Team> GetAllTeamsAsync(this IRepositoriesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Team>(options => t.GetAllTeams(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoriesClient.GetAllTeams(long, ApiOptions)"/>
+    public static IPaginatedList<Team> GetAllTeamsAsync(this IRepositoriesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Team>(options => t.GetAllTeams(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoriesClient.GetAllTags(string, string, ApiOptions)"/>
+    public static IPaginatedList<RepositoryTag> GetAllTagsAsync(this IRepositoriesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryTag>(options => t.GetAllTags(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoriesClient.GetAllTags(long, ApiOptions)"/>
+    public static IPaginatedList<RepositoryTag> GetAllTagsAsync(this IRepositoriesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryTag>(options => t.GetAllTags(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryBranchesClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<Branch> GetAllAsync(this IRepositoryBranchesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Branch>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryBranchesClient.GetAll(long, ApiOptions)"/>
+    public static IPaginatedList<Branch> GetAllAsync(this IRepositoryBranchesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Branch>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationMembersClient.GetAll(string, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllAsync(this IOrganizationMembersClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationMembersClient.GetAll(string, OrganizationMembersFilter, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllAsync(this IOrganizationMembersClient t, string org, OrganizationMembersFilter filter, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, filter, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationMembersClient.GetAll(string, OrganizationMembersRole, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllAsync(this IOrganizationMembersClient t, string org, OrganizationMembersRole role, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, role, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationMembersClient.GetAll(string, OrganizationMembersFilter, OrganizationMembersRole, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllAsync(this IOrganizationMembersClient t, string org, OrganizationMembersFilter filter, OrganizationMembersRole role, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, filter, role, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationMembersClient.GetAllPublic(string, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllPublicAsync(this IOrganizationMembersClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllPublic(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationMembersClient.GetAllPendingInvitations(string, ApiOptions)"/>
+    public static IPaginatedList<OrganizationMembershipInvitation> GetAllPendingInvitationsAsync(this IOrganizationMembersClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<OrganizationMembershipInvitation>(options => t.GetAllPendingInvitations(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationMembersClient.GetAllFailedInvitations(string, ApiOptions)"/>
+    public static IPaginatedList<OrganizationMembershipInvitation> GetAllFailedInvitationsAsync(this IOrganizationMembersClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<OrganizationMembershipInvitation>(options => t.GetAllFailedInvitations(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationMembersClient.GetAllOrganizationMembershipsForCurrent(ApiOptions)"/>
+    public static IPaginatedList<OrganizationMembership> GetAllOrganizationMembershipsForCurrentAsync(this IOrganizationMembersClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<OrganizationMembership>(t.GetAllOrganizationMembershipsForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationCustomPropertyValuesClient.GetAll(string, ApiOptions)"/>
+    public static IPaginatedList<OrganizationCustomPropertyValues> GetAllAsync(this IOrganizationCustomPropertyValuesClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<OrganizationCustomPropertyValues>(options => t.GetAll(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IPackagesClient.GetAllForOrg(string, PackageType, ApiOptions)"/>
+    public static IPaginatedList<Package> GetAllForOrgAsync(this IPackagesClient t, string org, PackageType packageType, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Package>(options => t.GetAllForOrg(org, packageType, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IPackagesClient.GetAllForOrg(string, PackageType, PackageVisibility?, ApiOptions)"/>
+    public static IPaginatedList<Package> GetAllForOrgAsync(this IPackagesClient t, string org, PackageType packageType, PackageVisibility? packageVisibility, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Package>(options => t.GetAllForOrg(org, packageType, packageVisibility, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IPackagesClient.GetAllForActiveUser(PackageType, ApiOptions)"/>
+    public static IPaginatedList<Package> GetAllForActiveUserAsync(this IPackagesClient t, PackageType packageType, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Package>(options => t.GetAllForActiveUser(packageType, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IPackagesClient.GetAllForActiveUser(PackageType, PackageVisibility?, ApiOptions)"/>
+    public static IPaginatedList<Package> GetAllForActiveUserAsync(this IPackagesClient t, PackageType packageType, PackageVisibility? packageVisibility, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Package>(options => t.GetAllForActiveUser(packageType, packageVisibility, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IPackagesClient.GetAllForUser(string, PackageType, ApiOptions)"/>
+    public static IPaginatedList<Package> GetAllForUserAsync(this IPackagesClient t, string username, PackageType packageType, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Package>(options => t.GetAllForUser(username, packageType, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IPackagesClient.GetAllForUser(string, PackageType, PackageVisibility?, ApiOptions)"/>
+    public static IPaginatedList<Package> GetAllForUserAsync(this IPackagesClient t, string username, PackageType packageType, PackageVisibility? packageVisibility, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Package>(options => t.GetAllForUser(username, packageType, packageVisibility, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IGitHubAppsClient.GetAllInstallationsForCurrent(ApiOptions)"/>
+    public static IPaginatedList<Installation> GetAllInstallationsForCurrentAsync(this IGitHubAppsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Installation>(t.GetAllInstallationsForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IAuthorizationsClient.GetAll(ApiOptions)"/>
+    public static IPaginatedList<Authorization> GetAllAsync(this IAuthorizationsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Authorization>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
     /// <inheritdoc cref="IApiConnection.GetAll(Uri, ApiOptions)"/>
     public static IPaginatedList<T> GetAllAsync<T>(this IApiConnection t, Uri uri, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<T>(options => t.GetAll<T>(uri, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
+
     /// <inheritdoc cref="IApiConnection.GetAll(Uri, IDictionary{string, string}, ApiOptions)"/>
     public static IPaginatedList<T> GetAllAsync<T>(this IApiConnection t, Uri uri, IDictionary<string, string> parameters, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<T>(options => t.GetAll<T>(uri, parameters, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
+
     /// <inheritdoc cref="IApiConnection.GetAll(Uri, IDictionary{string, string}, string, ApiOptions)"/>
     public static IPaginatedList<T> GetAllAsync<T>(this IApiConnection t, Uri uri, IDictionary<string, string> parameters, string accepts, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<T>(options => t.GetAll<T>(uri, parameters, accepts, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
-    /// <inheritdoc cref="IEnterprisePreReceiveEnvironmentsClient.GetAll(ApiOptions)"/>
-    public static IPaginatedList<PreReceiveEnvironment> GetAllAsync(this IEnterprisePreReceiveEnvironmentsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PreReceiveEnvironment>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
+
     /// <inheritdoc cref="IEnterprisePreReceiveHooksClient.GetAll(ApiOptions)"/>
     public static IPaginatedList<PreReceiveHook> GetAllAsync(this IEnterprisePreReceiveHooksClient t, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<PreReceiveHook>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-    
+
+    /// <inheritdoc cref="IEnterpriseAuditLogClient.GetAll(string, AuditLogApiOptions)"/>
+    public static IPaginatedList<AuditLogEvent> GetAllAsync(this IEnterpriseAuditLogClient t, string enterprise, AuditLogApiOptions auditLog, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<AuditLogEvent>(options => t.GetAll(enterprise, auditLog), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IEnterpriseAuditLogClient.GetAll(string, AuditLogRequest, AuditLogApiOptions)"/>
+    public static IPaginatedList<AuditLogEvent> GetAllAsync(this IEnterpriseAuditLogClient t, string enterprise, AuditLogRequest request, AuditLogApiOptions auditLog, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<AuditLogEvent>(options => t.GetAll(enterprise, request, auditLog), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IEnterpriseAuditLogClient.GetAllJson(string, AuditLogApiOptions)"/>
+    public static IPaginatedList<object> GetAllJsonAsync(this IEnterpriseAuditLogClient t, string enterprise, AuditLogApiOptions auditLog, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<object>(options => t.GetAllJson(enterprise, auditLog), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IEnterpriseAuditLogClient.GetAllJson(string, AuditLogRequest, AuditLogApiOptions)"/>
+    public static IPaginatedList<object> GetAllJsonAsync(this IEnterpriseAuditLogClient t, string enterprise, AuditLogRequest request, AuditLogApiOptions auditLog, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<object>(options => t.GetAllJson(enterprise, request, auditLog), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IEnterprisePreReceiveEnvironmentsClient.GetAll(ApiOptions)"/>
+    public static IPaginatedList<PreReceiveEnvironment> GetAllAsync(this IEnterprisePreReceiveEnvironmentsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PreReceiveEnvironment>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="ICopilotLicenseClient.GetAll(string, ApiOptions)"/>
+    public static IPaginatedList<CopilotSeats> GetAllAsync(this ICopilotLicenseClient t, string organization, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<CopilotSeats>(options => t.GetAll(organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
   }
 }

--- a/Octokit.Reactive/Clients/Enterprise/IObservableEnterpriseLdapClient.cs
+++ b/Octokit.Reactive/Clients/Enterprise/IObservableEnterpriseLdapClient.cs
@@ -43,7 +43,7 @@ namespace Octokit.Reactive
         /// <param name="teamId">The teamId to update LDAP mapping</param>
         /// <param name="newLdapMapping">The <see cref="NewLdapMapping"/></param>
         /// <returns>The <see cref="Team"/> object.</returns>
-        IObservable<Team> UpdateTeamMapping(int teamId, NewLdapMapping newLdapMapping);
+        IObservable<Team> UpdateTeamMapping(long teamId, NewLdapMapping newLdapMapping);
 
         /// <summary>
         /// Queue an LDAP Sync job for a team on a GitHub Enterprise appliance (must be Site Admin user).
@@ -53,6 +53,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="teamId">The teamId to update LDAP mapping</param>
         /// <returns>The <see cref="LdapSyncResponse"/> of the queue request.</returns>
-        IObservable<LdapSyncResponse> QueueSyncTeamMapping(int teamId);
+        IObservable<LdapSyncResponse> QueueSyncTeamMapping(long teamId);
     }
 }

--- a/Octokit.Reactive/Clients/Enterprise/ObservableEnterpriseLdapClient.cs
+++ b/Octokit.Reactive/Clients/Enterprise/ObservableEnterpriseLdapClient.cs
@@ -58,7 +58,7 @@ namespace Octokit.Reactive
         /// <param name="teamId">The teamId to update LDAP mapping</param>
         /// <param name="newLdapMapping">The <see cref="NewLdapMapping"/></param>
         /// <returns>The <see cref="Team"/> object.</returns>
-        public IObservable<Team> UpdateTeamMapping(int teamId, NewLdapMapping newLdapMapping)
+        public IObservable<Team> UpdateTeamMapping(long teamId, NewLdapMapping newLdapMapping)
         {
             return _client.UpdateTeamMapping(teamId, newLdapMapping).ToObservable();
         }
@@ -71,7 +71,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="teamId">The teamId to update LDAP mapping</param>
         /// <returns>The <see cref="LdapSyncResponse"/> of the queue request.</returns>
-        public IObservable<LdapSyncResponse> QueueSyncTeamMapping(int teamId)
+        public IObservable<LdapSyncResponse> QueueSyncTeamMapping(long teamId)
         {
             return _client.QueueSyncTeamMapping(teamId).ToObservable();
         }

--- a/Octokit.Reactive/Clients/IObservableAuthorizationsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableAuthorizationsClient.cs
@@ -42,7 +42,7 @@ namespace Octokit.Reactive
         /// <returns>An <see cref="Authorization"/></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "It's fiiiine. It's fine. Trust us.")]
-        IObservable<Authorization> Get(int id);
+        IObservable<Authorization> Get(long  id);
 
         /// <summary>
         /// Creates a new personal token for the authenticated user.
@@ -132,7 +132,7 @@ namespace Octokit.Reactive
             string twoFactorAuthenticationCode);
 
         /// <summary>
-        /// This method will create a new authorization for the specified OAuth application, only if an authorization 
+        /// This method will create a new authorization for the specified OAuth application, only if an authorization
         /// for that application doesn’t already exist for the user. It returns the user’s token for the application
         /// if one exists. Otherwise, it creates one.
         /// </summary>
@@ -143,7 +143,7 @@ namespace Octokit.Reactive
         /// <param name="clientId">Client Id for the OAuth application that is requesting the token</param>
         /// <param name="clientSecret">The client secret</param>
         /// <param name="newAuthorization">Defines the scopes and metadata for the token</param>
-        /// <exception cref="AuthorizationException">Thrown when the user does not have permission to make 
+        /// <exception cref="AuthorizationException">Thrown when the user does not have permission to make
         /// this request. Check </exception>
         /// <exception cref="TwoFactorRequiredException">Thrown when the current account has two-factor
         /// authentication enabled.</exception>
@@ -154,19 +154,19 @@ namespace Octokit.Reactive
             NewAuthorization newAuthorization);
 
         /// <summary>
-        /// This method will create a new authorization for the specified OAuth application, only if an authorization 
+        /// This method will create a new authorization for the specified OAuth application, only if an authorization
         /// for that application doesn’t already exist for the user. It returns the user’s token for the application
         /// if one exists. Otherwise, it creates one.
         /// </summary>
         /// <remarks>
-        /// See <a href="http://developer.github.com/v3/oauth/#get-or-create-an-authorization-for-a-specific-app">API 
+        /// See <a href="http://developer.github.com/v3/oauth/#get-or-create-an-authorization-for-a-specific-app">API
         /// documentation</a> for more details.
         /// </remarks>
         /// <param name="clientId">Client Id for the OAuth application that is requesting the token</param>
         /// <param name="clientSecret">The client secret</param>
         /// <param name="newAuthorization">Defines the scopes and metadata for the token</param>
         /// <param name="twoFactorAuthenticationCode">The two-factor authentication code provided by the user</param>
-        /// <exception cref="AuthorizationException">Thrown when the user does not have permission to make 
+        /// <exception cref="AuthorizationException">Thrown when the user does not have permission to make
         /// this request. Check </exception>
         /// <exception cref="TwoFactorChallengeFailedException">Thrown when the two-factor code is not
         /// valid.</exception>
@@ -219,14 +219,14 @@ namespace Octokit.Reactive
         /// <param name="id">The id of the <see cref="Authorization"/></param>
         /// <param name="authorizationUpdate">The changes to make to the authorization</param>
         /// <returns></returns>
-        IObservable<Authorization> Update(int id, AuthorizationUpdate authorizationUpdate);
+        IObservable<Authorization> Update(long id, AuthorizationUpdate authorizationUpdate);
 
         /// <summary>
         /// Deletes the specified <see cref="Authorization"/>.
         /// </summary>
         /// <remarks>
         /// This method requires authentication.
-        /// See the <a href="http://developer.github.com/v3/oauth/#delete-an-authorization">API 
+        /// See the <a href="http://developer.github.com/v3/oauth/#delete-an-authorization">API
         /// documentation</a> for more details.
         /// </remarks>
         /// <param name="id">The system-wide Id of the authorization to delete</param>
@@ -234,14 +234,14 @@ namespace Octokit.Reactive
         /// Thrown when the current user does not have permission to make the request.
         /// </exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<Unit> Delete(int id);
+        IObservable<Unit> Delete(long id);
 
         /// <summary>
         /// Deletes the specified <see cref="Authorization"/>.
         /// </summary>
         /// <remarks>
         /// This method requires authentication.
-        /// See the <a href="http://developer.github.com/v3/oauth/#delete-an-authorization">API 
+        /// See the <a href="http://developer.github.com/v3/oauth/#delete-an-authorization">API
         /// documentation</a> for more details.
         /// </remarks>
         /// <param name="id">The system-wide Id of the authorization to delete</param>
@@ -250,6 +250,6 @@ namespace Octokit.Reactive
         /// Thrown when the current user does not have permission to make the request.
         /// </exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<Unit> Delete(int id, string twoFactorAuthenticationCode);
+        IObservable<Unit> Delete(long id, string twoFactorAuthenticationCode);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableDeploymentStatusClient.cs
+++ b/Octokit.Reactive/Clients/IObservableDeploymentStatusClient.cs
@@ -21,7 +21,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
-        IObservable<DeploymentStatus> GetAll(string owner, string name, int deploymentId);
+        IObservable<DeploymentStatus> GetAll(string owner, string name, long deploymentId);
 
         /// <summary>
         /// Gets all the statuses for the given deployment. Any user with pull access to a repository can
@@ -32,7 +32,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
-        IObservable<DeploymentStatus> GetAll(long repositoryId, int deploymentId);
+        IObservable<DeploymentStatus> GetAll(long repositoryId, long deploymentId);
 
         /// <summary>
         /// Gets all the statuses for the given deployment. Any user with pull access to a repository can
@@ -45,7 +45,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<DeploymentStatus> GetAll(string owner, string name, int deploymentId, ApiOptions options);
+        IObservable<DeploymentStatus> GetAll(string owner, string name, long deploymentId, ApiOptions options);
 
         /// <summary>
         /// Gets all the statuses for the given deployment. Any user with pull access to a repository can
@@ -57,7 +57,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<DeploymentStatus> GetAll(long repositoryId, int deploymentId, ApiOptions options);
+        IObservable<DeploymentStatus> GetAll(long repositoryId, long deploymentId, ApiOptions options);
 
         /// <summary>
         /// Creates a new status for the given deployment. Users with push access can create deployment
@@ -70,7 +70,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus">The new deployment status to create.</param>
-        IObservable<DeploymentStatus> Create(string owner, string name, int deploymentId, NewDeploymentStatus newDeploymentStatus);
+        IObservable<DeploymentStatus> Create(string owner, string name, long deploymentId, NewDeploymentStatus newDeploymentStatus);
 
         /// <summary>
         /// Creates a new status for the given deployment. Users with push access can create deployment
@@ -82,6 +82,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus">The new deployment status to create.</param>
-        IObservable<DeploymentStatus> Create(long repositoryId, int deploymentId, NewDeploymentStatus newDeploymentStatus);
+        IObservable<DeploymentStatus> Create(long repositoryId, long deploymentId, NewDeploymentStatus newDeploymentStatus);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableMigrationsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableMigrationsClient.cs
@@ -21,7 +21,7 @@ namespace Octokit.Reactive
         /// https://developer.github.com/v3/migration/migrations/#start-a-migration
         /// </remarks>
         /// <param name="org">The organization for which to start a migration.</param>
-        /// <param name="migration">Specifies parameters for the migration in a 
+        /// <param name="migration">Specifies parameters for the migration in a
         /// <see cref="StartMigrationRequest"/> object.</param>
         /// <returns>The started migration.</returns>
         IObservable<Migration> Start(
@@ -64,7 +64,7 @@ namespace Octokit.Reactive
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         IObservable<Migration> Get(
            string org,
-           int id);
+           long id);
 
         /// <summary>
         /// Get the migration archive.
@@ -77,7 +77,7 @@ namespace Octokit.Reactive
         /// <returns>The binary contents of the archive as a byte array.</returns>
         IObservable<byte[]> GetArchive(
             string org,
-            int id);
+            long id);
 
         /// <summary>
         /// Deletes a previous migration archive.
@@ -90,7 +90,7 @@ namespace Octokit.Reactive
         /// <returns></returns>
         IObservable<Unit> DeleteArchive(
             string org,
-            int id);
+            long id);
 
         /// <summary>
         /// Unlocks a repository that was locked for migration.
@@ -104,7 +104,7 @@ namespace Octokit.Reactive
         /// <returns></returns>
         IObservable<Unit> UnlockRepository(
             string org,
-            int id,
+            long id,
             string repo);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableOrganizationMembersClient.cs
+++ b/Octokit.Reactive/Clients/IObservableOrganizationMembersClient.cs
@@ -318,7 +318,7 @@ namespace Octokit.Reactive
         /// details of the organization invitation</param>
         /// <returns></returns>
         IObservable<OrganizationMembershipInvitation> CreateOrganizationInvitation(string org, OrganizationInvitationRequest invitationRequest);
-        
+
         /// <summary>
         /// Remove a user's membership with an organization.
         /// </summary>
@@ -389,7 +389,7 @@ namespace Octokit.Reactive
         /// <param name="org">The login for the organization</param>
         /// <param name="invitationId">The unique identifier of the invitation</param>
         /// <returns></returns>
-        IObservable<Unit> CancelOrganizationInvitation(string org, int invitationId);
+        IObservable<Unit> CancelOrganizationInvitation(string org, long invitationId);
 
         /// <summary>
         /// Returns all <see cref="OrganizationMembership" />s for the current user.

--- a/Octokit.Reactive/Clients/IObservableProjectCardsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableProjectCardsClient.cs
@@ -59,7 +59,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="id">The id of the card</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        IObservable<ProjectCard> Get(int id);
+        IObservable<ProjectCard> Get(long id);
 
         /// <summary>
         /// Creates a card.
@@ -79,7 +79,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="id">The id of the card</param>
         /// <param name="projectCardUpdate">New values to update the card with</param>
-        IObservable<ProjectCard> Update(int id, ProjectCardUpdate projectCardUpdate);
+        IObservable<ProjectCard> Update(long id, ProjectCardUpdate projectCardUpdate);
 
         /// <summary>
         /// Deletes a card.
@@ -88,7 +88,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/repos/projects/#delete-a-project-card">API documentation</a> for more information.
         /// </remarks>
         /// <param name="id">The id of the card</param>
-        IObservable<bool> Delete(int id);
+        IObservable<bool> Delete(long id);
 
         /// <summary>
         /// Moves a card.
@@ -98,6 +98,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="id">The id of the card</param>
         /// <param name="position">The position to move the card</param>
-        IObservable<bool> Move(int id, ProjectCardMove position);
+        IObservable<bool> Move(long id, ProjectCardMove position);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableReleasesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableReleasesClient.cs
@@ -90,7 +90,7 @@ namespace Octokit.Reactive
         /// <param name="name">The repository's name</param>
         /// <param name="id">The id of the release</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<Release> Get(string owner, string name, int id);
+        IObservable<Release> Get(string owner, string name, long id);
 
         /// <summary>
         /// Gets a single <see cref="Release"/> for the specified repository.
@@ -113,7 +113,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the release</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<Release> Get(long repositoryId, int id);
+        IObservable<Release> Get(long repositoryId, long id);
 
         /// <summary>
         /// Gets a single <see cref="Release"/> for the specified repository.
@@ -181,7 +181,7 @@ namespace Octokit.Reactive
         /// <param name="id">The id of the release</param>
         /// <param name="data">A description of the release to edit</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<Release> Edit(string owner, string name, int id, ReleaseUpdate data);
+        IObservable<Release> Edit(string owner, string name, long id, ReleaseUpdate data);
 
         /// <summary>
         /// Edits an existing <see cref="Release"/> for the specified repository.
@@ -193,7 +193,7 @@ namespace Octokit.Reactive
         /// <param name="id">The id of the release</param>
         /// <param name="data">A description of the release to edit</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<Release> Edit(long repositoryId, int id, ReleaseUpdate data);
+        IObservable<Release> Edit(long repositoryId, long id, ReleaseUpdate data);
 
         /// <summary>
         /// Deletes an existing <see cref="Release"/> for the specified repository.
@@ -205,7 +205,7 @@ namespace Octokit.Reactive
         /// <param name="name">The repository's name</param>
         /// <param name="id">The id of the release to delete</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<Unit> Delete(string owner, string name, int id);
+        IObservable<Unit> Delete(string owner, string name, long id);
 
         /// <summary>
         /// Deletes an existing <see cref="Release"/> for the specified repository.
@@ -216,7 +216,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the release to delete</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<Unit> Delete(long repositoryId, int id);
+        IObservable<Unit> Delete(long repositoryId, long id);
 
         /// <summary>
         /// Gets all <see cref="ReleaseAsset"/> for the specified release of the specified repository.
@@ -228,7 +228,7 @@ namespace Octokit.Reactive
         /// <param name="name">The repository's name</param>
         /// <param name="id">The id of the <see cref="Release"/>.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<ReleaseAsset> GetAllAssets(string owner, string name, int id);
+        IObservable<ReleaseAsset> GetAllAssets(string owner, string name, long id);
 
         /// <summary>
         /// Gets all <see cref="ReleaseAsset"/> for the specified release of the specified repository.
@@ -239,7 +239,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the <see cref="Release"/>.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<ReleaseAsset> GetAllAssets(long repositoryId, int id);
+        IObservable<ReleaseAsset> GetAllAssets(long repositoryId, long id);
 
         /// <summary>
         /// Gets all <see cref="ReleaseAsset"/> for the specified release of the specified repository.
@@ -252,7 +252,7 @@ namespace Octokit.Reactive
         /// <param name="id">The id of the <see cref="Release"/>.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<ReleaseAsset> GetAllAssets(string owner, string name, int id, ApiOptions options);
+        IObservable<ReleaseAsset> GetAllAssets(string owner, string name, long id, ApiOptions options);
 
         /// <summary>
         /// Gets all <see cref="ReleaseAsset"/> for the specified release of the specified repository.
@@ -264,7 +264,7 @@ namespace Octokit.Reactive
         /// <param name="id">The id of the <see cref="Release"/>.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<ReleaseAsset> GetAllAssets(long repositoryId, int id, ApiOptions options);
+        IObservable<ReleaseAsset> GetAllAssets(long repositoryId, long id, ApiOptions options);
 
         /// <summary>
         /// Uploads a <see cref="ReleaseAsset"/> for the specified release.

--- a/Octokit.Reactive/Clients/IObservableRepositoryInvitationsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryInvitationsClient.cs
@@ -11,18 +11,18 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/invitations/#accept-a-repository-invitation">API documentation</a> for more information.
-        /// </remarks>        
-        /// <param name="invitationId">The id of the invitation.</param>        
-        IObservable<bool> Accept(int invitationId);
+        /// </remarks>
+        /// <param name="invitationId">The id of the invitation.</param>
+        IObservable<bool> Accept(long invitationId);
 
         /// <summary>
         /// Decline a repository invitation.
         /// </summary>
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/invitations/#decline-a-repository-invitation">API documentation</a> for more information.
-        /// </remarks>        
-        /// <param name="invitationId">The id of the invitation.</param>        
-        IObservable<bool> Decline(int invitationId);
+        /// </remarks>
+        /// <param name="invitationId">The id of the invitation.</param>
+        IObservable<bool> Decline(long invitationId);
 
         /// <summary>
         /// Deletes a repository invitation.
@@ -31,15 +31,15 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/repos/invitations/#delete-a-repository-invitation">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The id of the repository.</param>
-        /// <param name="invitationId">The id of the invitation.</param>        
-        IObservable<bool> Delete(long repositoryId, int invitationId);
+        /// <param name="invitationId">The id of the invitation.</param>
+        IObservable<bool> Delete(long repositoryId, long invitationId);
 
         /// <summary>
         /// Gets all invitations for the current user.
         /// </summary>
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/invitations/#list-a-users-repository-invitations">API documentation</a> for more information.
-        /// </remarks>        
+        /// </remarks>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         IObservable<RepositoryInvitation> GetAllForCurrent();
 
@@ -49,7 +49,7 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/invitations/#list-a-users-repository-invitations">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="options">Options for changing the API response</param>        
+        /// <param name="options">Options for changing the API response</param>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         IObservable<RepositoryInvitation> GetAllForCurrent(ApiOptions options);
 
@@ -58,8 +58,8 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/invitations/#list-invitations-for-a-repository">API documentation</a> for more information.
-        /// </remarks>        
-        /// <param name="repositoryId">The id of the repository</param>         
+        /// </remarks>
+        /// <param name="repositoryId">The id of the repository</param>
         IObservable<RepositoryInvitation> GetAllForRepository(long repositoryId);
 
         /// <summary>
@@ -67,9 +67,9 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/invitations/#list-invitations-for-a-repository">API documentation</a> for more information.
-        /// </remarks>        
+        /// </remarks>
         /// <param name="repositoryId">The id of the repository</param>
-        /// /// <param name="options">Options for changing the API response</param>        
+        /// /// <param name="options">Options for changing the API response</param>
         IObservable<RepositoryInvitation> GetAllForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
@@ -79,9 +79,9 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/repos/invitations/#update-a-repository-invitation">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The id of the repository.</param>
-        /// <param name="invitationId">The id of the invitation.</param>   
+        /// <param name="invitationId">The id of the invitation.</param>
         /// <param name="permissions">The permission to set.</param>
         /// <returns><see cref="RepositoryInvitation"/></returns>
-        IObservable<RepositoryInvitation> Edit(long repositoryId, int invitationId, InvitationUpdate permissions);
+        IObservable<RepositoryInvitation> Edit(long repositoryId, long invitationId, InvitationUpdate permissions);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableTeamsClient.cs
@@ -22,7 +22,7 @@ namespace Octokit.Reactive
         /// <returns>The <see cref="Team"/> with the given identifier.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
-        IObservable<Team> Get(int id);
+        IObservable<Team> Get(long id);
 
         /// <summary>
         /// Returns all <see cref="Team" />s for the current org.
@@ -65,7 +65,7 @@ namespace Octokit.Reactive
         /// https://developer.github.com/v3/orgs/teams/#list-child-teams
         /// </remarks>
         /// <param name="id">The team identifier</param>
-        IObservable<Team> GetAllChildTeams(int id);
+        IObservable<Team> GetAllChildTeams(long id);
 
         /// <summary>
         /// Returns all child teams of the given team.
@@ -75,26 +75,26 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="id">The team identifier</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<Team> GetAllChildTeams(int id, ApiOptions options);
+        IObservable<Team> GetAllChildTeams(long id, ApiOptions options);
 
         /// <summary>
-        /// Returns all members of the given team. 
+        /// Returns all members of the given team.
         /// </summary>
         /// <remarks>
         /// https://developer.github.com/v3/orgs/teams/#list-team-members
         /// </remarks>
         /// <param name="id">The team identifier</param>
-        IObservable<User> GetAllMembers(int id);
+        IObservable<User> GetAllMembers(long id);
 
         /// <summary>
-        /// Returns all members of the given team. 
+        /// Returns all members of the given team.
         /// </summary>
         /// <remarks>
         /// https://developer.github.com/v3/orgs/teams/#list-team-members
         /// </remarks>
         /// <param name="id">The team identifier</param>
         /// <param name="options">Options to change API behaviour.</param>
-        IObservable<User> GetAllMembers(int id, ApiOptions options);
+        IObservable<User> GetAllMembers(long id, ApiOptions options);
 
         /// <summary>
         /// Returns all members with the specified role in the given team of the given role.
@@ -104,7 +104,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="id">The team identifier</param>
         /// <param name="request">The request filter</param>
-        IObservable<User> GetAllMembers(int id, TeamMembersRequest request);
+        IObservable<User> GetAllMembers(long id, TeamMembersRequest request);
 
         /// <summary>
         /// Returns all members with the specified role in the given team of the given role.
@@ -115,7 +115,7 @@ namespace Octokit.Reactive
         /// <param name="id">The team identifier</param>
         /// <param name="request">The request filter</param>
         /// <param name="options">Options to change API behaviour.</param>
-        IObservable<User> GetAllMembers(int id, TeamMembersRequest request, ApiOptions options);
+        IObservable<User> GetAllMembers(long id, TeamMembersRequest request, ApiOptions options);
 
         /// <summary>
         /// Returns newly created <see cref="Team" /> for the current org.
@@ -129,7 +129,7 @@ namespace Octokit.Reactive
         /// To edit a team, the authenticated user must either be an organization owner or a team maintainer
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#update-a-team">API documentation</a> 
+        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#update-a-team">API documentation</a>
         /// for more information.
         /// </remarks>
         /// <returns>updated <see cref="Team" /> for the current org</returns>
@@ -139,22 +139,22 @@ namespace Octokit.Reactive
         /// Returns updated <see cref="Team" /> for the current org.
         /// This endpoint route is deprecated and will be removed from the Teams API.
         /// We recommend migrating your existing code to use the new Update a team endpoint.
-        /// <see cref="Update(string, string, UpdateTeam)"/>
+        /// <see cref="Update(long, UpdateTeam)"/>
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#update-a-team-legacy">API documentation</a> 
+        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#update-a-team-legacy">API documentation</a>
         /// for more information.
         /// </remarks>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>Updated <see cref="Team"/></returns>
-        IObservable<Team> Update(int id, UpdateTeam team);
+        IObservable<Team> Update(long id, UpdateTeam team);
 
         /// <summary>
         /// To delete a team, the authenticated user must be an organization owner or team maintainer.
         /// If you are an organization owner, deleting a parent team will delete all of its child teams as well.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#delete-a-team">API documentation</a> 
+        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#delete-a-team">API documentation</a>
         /// </remarks>
         /// <param name="org">The organization name. The name is not case sensitive.</param>
         /// <param name="teamSlug">The slug of the team name.</param>
@@ -169,12 +169,12 @@ namespace Octokit.Reactive
         /// <see cref="Delete(string, string)"/>.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#delete-a-team-legacy">API documentation</a> 
+        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#delete-a-team-legacy">API documentation</a>
         /// </remarks>
         /// <param name="id">The unique identifier of the team.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns></returns>
-        IObservable<Unit> Delete(int id);
+        IObservable<Unit> Delete(long id);
 
         /// <summary>
         /// Adds a <see cref="User"/> to a <see cref="Team"/>.
@@ -185,7 +185,7 @@ namespace Octokit.Reactive
         /// <param name="id">The team identifier.</param>
         /// <param name="login">The user to add to the team.</param>
         /// <param name="request">Additional parameters for the request</param>
-        IObservable<TeamMembershipDetails> AddOrEditMembership(int id, string login, UpdateTeamMembership request);
+        IObservable<TeamMembershipDetails> AddOrEditMembership(long id, string login, UpdateTeamMembership request);
 
         /// <summary>
         /// Removes a <see cref="User"/> from a <see cref="Team"/>.
@@ -196,10 +196,10 @@ namespace Octokit.Reactive
         /// <param name="id">The team identifier.</param>
         /// <param name="login">The user to remove from the team.</param>
         /// <returns><see langword="true"/> if the user was removed from the team; <see langword="false"/> otherwise.</returns>
-        IObservable<bool> RemoveMembership(int id, string login);
+        IObservable<bool> RemoveMembership(long id, string login);
 
         /// <summary>
-        /// Gets whether the user with the given <paramref name="login"/> 
+        /// Gets whether the user with the given <paramref name="login"/>
         /// is a member of the team with the given <paramref name="id"/>.
         /// A <see cref="NotFoundException"/> is thrown if the user is not a member.
         /// </summary>
@@ -208,7 +208,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="id">The team to check.</param>
         /// <param name="login">The user to check.</param>
-        IObservable<TeamMembershipDetails> GetMembershipDetails(int id, string login);
+        IObservable<TeamMembershipDetails> GetMembershipDetails(long id, string login);
 
         /// <summary>
         /// Returns all team's repositories.
@@ -216,7 +216,7 @@ namespace Octokit.Reactive
         /// <param name="id">Team Id.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The team's repositories</returns>
-        IObservable<Repository> GetAllRepositories(int id);
+        IObservable<Repository> GetAllRepositories(long id);
 
         /// <summary>
         /// Returns all team's repositories.
@@ -225,14 +225,14 @@ namespace Octokit.Reactive
         /// <param name="options">Options to change API behaviour.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The team's repositories</returns>
-        IObservable<Repository> GetAllRepositories(int id, ApiOptions options);
+        IObservable<Repository> GetAllRepositories(long id, ApiOptions options);
 
         /// <summary>
         /// Remove a repository from the team
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns></returns>
-        IObservable<bool> RemoveRepository(int id, string organization, string repoName);
+        IObservable<bool> RemoveRepository(long id, string organization, string repoName);
 
         /// <summary>
         /// Adds a <see cref="Repository"/> to a <see cref="Team"/>.
@@ -245,7 +245,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/orgs/teams/#add-team-repo">API documentation</a> for more information.
         /// </remarks>
         /// <returns><see langword="true"/> if the repository was added to the team; <see langword="false"/> otherwise.</returns>
-        IObservable<bool> AddRepository(int id, string organization, string repoName);
+        IObservable<bool> AddRepository(long id, string organization, string repoName);
 
         /// <summary>
         /// Adds a <see cref="Repository"/> to a <see cref="Team"/>.
@@ -259,7 +259,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/orgs/teams/#add-team-repo">API documentation</a> for more information.
         /// </remarks>
         /// <returns><see langword="true"/> if the repository was added to the team; <see langword="false"/> otherwise.</returns>
-        IObservable<bool> AddRepository(int id, string organization, string repoName, RepositoryPermissionRequest permission);
+        IObservable<bool> AddRepository(long id, string organization, string repoName, RepositoryPermissionRequest permission);
 
         /// <summary>
         /// Gets whether or not the given repository is managed by the given team.
@@ -271,7 +271,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/orgs/teams/#get-team-repo">API documentation</a> for more information.
         /// </remarks>
         /// <returns><see langword="true"/> if the repository is managed by the given team; <see langword="false"/> otherwise.</returns>
-        IObservable<bool> IsRepositoryManagedByTeam(int id, string owner, string repo);
+        IObservable<bool> IsRepositoryManagedByTeam(long id, string owner, string repo);
 
         /// <summary>
         /// List all pending invitations for the given team.
@@ -282,7 +282,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="id">The team identifier</param>
         /// <returns></returns>
-        IObservable<OrganizationMembershipInvitation> GetAllPendingInvitations(int id);
+        IObservable<OrganizationMembershipInvitation> GetAllPendingInvitations(long id);
 
         /// <summary>
         /// List all pending invitations for the given team.
@@ -294,7 +294,7 @@ namespace Octokit.Reactive
         /// <param name="id">The team identifier</param>
         /// <param name="options">Options to change API behaviour.</param>
         /// <returns></returns>
-        IObservable<OrganizationMembershipInvitation> GetAllPendingInvitations(int id, ApiOptions options);
+        IObservable<OrganizationMembershipInvitation> GetAllPendingInvitations(long id, ApiOptions options);
 
         /// <summary>
         /// Checks whether a team has admin, push, maintain, triage, or pull permission for a repository.
@@ -339,9 +339,9 @@ namespace Octokit.Reactive
         /// <param name="owner">The account owner of the repository. The name is not case sensitive.</param>
         /// <param name="repo">The name of the repository. The name is not case sensitive.</param>
         /// <param name="permission">
-        /// The permission to grant the team on this repository. We accept the following permissions to be set: 
-        /// pull, triage, push, maintain, admin and you can also specify a custom repository role name, if the 
-        /// owning organization has defined any. If no permission is specified, the team's permission attribute 
+        /// The permission to grant the team on this repository. We accept the following permissions to be set:
+        /// pull, triage, push, maintain, admin and you can also specify a custom repository role name, if the
+        /// owning organization has defined any. If no permission is specified, the team's permission attribute
         /// will be used to determine what permission to grant the team on this repository
         /// </param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
@@ -362,7 +362,7 @@ namespace Octokit.Reactive
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns></returns>
         IObservable<Unit> RemoveRepositoryFromATeam(string org, string teamSlug, string owner, string repo);
-        
+
         /// <summary>
         /// Get a team by slug name
         /// </summary>

--- a/Octokit.Reactive/Clients/IObservableUserGpgKeysClient.cs
+++ b/Octokit.Reactive/Clients/IObservableUserGpgKeysClient.cs
@@ -45,7 +45,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <returns>The <see cref="GpgKey"/> for the specified Id.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        IObservable<GpgKey> Get(int id);
+        IObservable<GpgKey> Get(long id);
 
         /// <summary>
         /// Creates a new <see cref="GpgKey"/> for the authenticated user.
@@ -66,6 +66,6 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/users/gpg_keys/#delete-a-gpg-key">API documentation</a> for more information.
         /// </remarks>
         /// <returns></returns>
-        IObservable<Unit> Delete(int id);
+        IObservable<Unit> Delete(long id);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableUserKeysClient.cs
+++ b/Octokit.Reactive/Clients/IObservableUserKeysClient.cs
@@ -63,7 +63,7 @@ namespace Octokit.Reactive
         /// <param name="id">The Id of the SSH key</param>
         /// <returns>View extended details for a single public key.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        IObservable<PublicKey> Get(int id);
+        IObservable<PublicKey> Get(long id);
 
         /// <summary>
         /// Create a public key <see cref="NewPublicKey"/>.
@@ -83,6 +83,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="id">The id of the key to delete</param>
         /// <returns>Removes a public key.</returns>
-        IObservable<Unit> Delete(int id);
+        IObservable<Unit> Delete(long id);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableAuthorizationsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableAuthorizationsClient.cs
@@ -56,7 +56,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="id">The id of the <see cref="Authorization"/></param>
         /// <returns>An <see cref="Authorization"/></returns>
-        public IObservable<Authorization> Get(int id)
+        public IObservable<Authorization> Get(long id)
         {
             return _client.Get(id).ToObservable();
         }
@@ -177,7 +177,7 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
-        /// This method will create a new authorization for the specified OAuth application, only if an authorization 
+        /// This method will create a new authorization for the specified OAuth application, only if an authorization
         /// for that application doesn’t already exist for the user. It returns the user’s token for the application
         /// if one exists. Otherwise, it creates one.
         /// </summary>
@@ -188,7 +188,7 @@ namespace Octokit.Reactive
         /// <param name="clientId">Client Id for the OAuth application that is requesting the token</param>
         /// <param name="clientSecret">The client secret</param>
         /// <param name="newAuthorization">Defines the scopes and metadata for the token</param>
-        /// <exception cref="AuthorizationException">Thrown when the user does not have permission to make 
+        /// <exception cref="AuthorizationException">Thrown when the user does not have permission to make
         /// this request. Check </exception>
         /// <exception cref="TwoFactorRequiredException">Thrown when the current account has two-factor
         /// authentication enabled.</exception>
@@ -207,19 +207,19 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
-        /// This method will create a new authorization for the specified OAuth application, only if an authorization 
+        /// This method will create a new authorization for the specified OAuth application, only if an authorization
         /// for that application doesn’t already exist for the user. It returns the user’s token for the application
         /// if one exists. Otherwise, it creates one.
         /// </summary>
         /// <remarks>
-        /// See <a href="http://developer.github.com/v3/oauth/#get-or-create-an-authorization-for-a-specific-app">API 
+        /// See <a href="http://developer.github.com/v3/oauth/#get-or-create-an-authorization-for-a-specific-app">API
         /// documentation</a> for more details.
         /// </remarks>
         /// <param name="clientId">Client Id for the OAuth application that is requesting the token</param>
         /// <param name="clientSecret">The client secret</param>
         /// <param name="newAuthorization">Defines the scopes and metadata for the token</param>
         /// <param name="twoFactorAuthenticationCode">The two-factor authentication code provided by the user</param>
-        /// <exception cref="AuthorizationException">Thrown when the user does not have permission to make 
+        /// <exception cref="AuthorizationException">Thrown when the user does not have permission to make
         /// this request. Check </exception>
         /// <exception cref="TwoFactorChallengeFailedException">Thrown when the two-factor code is not
         /// valid.</exception>
@@ -307,7 +307,7 @@ namespace Octokit.Reactive
         /// <param name="id">The id of the <see cref="Authorization"/></param>
         /// <param name="authorizationUpdate">The changes to make to the authorization</param>
         /// <returns></returns>
-        public IObservable<Authorization> Update(int id, AuthorizationUpdate authorizationUpdate)
+        public IObservable<Authorization> Update(long id, AuthorizationUpdate authorizationUpdate)
         {
             Ensure.ArgumentNotNull(authorizationUpdate, nameof(authorizationUpdate));
 
@@ -319,7 +319,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>
         /// This method requires authentication.
-        /// See the <a href="http://developer.github.com/v3/oauth/#delete-an-authorization">API 
+        /// See the <a href="http://developer.github.com/v3/oauth/#delete-an-authorization">API
         /// documentation</a> for more details.
         /// </remarks>
         /// <param name="id">The system-wide Id of the authorization to delete</param>
@@ -327,7 +327,7 @@ namespace Octokit.Reactive
         /// Thrown when the current user does not have permission to make the request.
         /// </exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public IObservable<Unit> Delete(int id)
+        public IObservable<Unit> Delete(long id)
         {
             return _client.Delete(id).ToObservable();
         }
@@ -337,7 +337,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>
         /// This method requires authentication.
-        /// See the <a href="http://developer.github.com/v3/oauth/#delete-an-authorization">API 
+        /// See the <a href="http://developer.github.com/v3/oauth/#delete-an-authorization">API
         /// documentation</a> for more details.
         /// </remarks>
         /// <param name="id">The system-wide Id of the authorization to delete</param>
@@ -346,7 +346,7 @@ namespace Octokit.Reactive
         /// Thrown when the current user does not have permission to make the request.
         /// </exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public IObservable<Unit> Delete(int id, string twoFactorAuthenticationCode)
+        public IObservable<Unit> Delete(long id, string twoFactorAuthenticationCode)
         {
             return _client.Delete(id, twoFactorAuthenticationCode).ToObservable();
         }

--- a/Octokit.Reactive/Clients/ObservableDeploymentStatusClient.cs
+++ b/Octokit.Reactive/Clients/ObservableDeploymentStatusClient.cs
@@ -34,7 +34,7 @@ namespace Octokit.Reactive.Clients
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
-        public IObservable<DeploymentStatus> GetAll(string owner, string name, int deploymentId)
+        public IObservable<DeploymentStatus> GetAll(string owner, string name, long deploymentId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -51,7 +51,7 @@ namespace Octokit.Reactive.Clients
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
-        public IObservable<DeploymentStatus> GetAll(long repositoryId, int deploymentId)
+        public IObservable<DeploymentStatus> GetAll(long repositoryId, long deploymentId)
         {
             return GetAll(repositoryId, deploymentId, ApiOptions.None);
         }
@@ -67,7 +67,7 @@ namespace Octokit.Reactive.Clients
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<DeploymentStatus> GetAll(string owner, string name, int deploymentId, ApiOptions options)
+        public IObservable<DeploymentStatus> GetAll(string owner, string name, long deploymentId, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -87,7 +87,7 @@ namespace Octokit.Reactive.Clients
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<DeploymentStatus> GetAll(long repositoryId, int deploymentId, ApiOptions options)
+        public IObservable<DeploymentStatus> GetAll(long repositoryId, long deploymentId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
@@ -106,7 +106,7 @@ namespace Octokit.Reactive.Clients
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus">The new deployment status to create.</param>
-        public IObservable<DeploymentStatus> Create(string owner, string name, int deploymentId, NewDeploymentStatus newDeploymentStatus)
+        public IObservable<DeploymentStatus> Create(string owner, string name, long deploymentId, NewDeploymentStatus newDeploymentStatus)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -125,7 +125,7 @@ namespace Octokit.Reactive.Clients
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus">The new deployment status to create.</param>
-        public IObservable<DeploymentStatus> Create(long repositoryId, int deploymentId, NewDeploymentStatus newDeploymentStatus)
+        public IObservable<DeploymentStatus> Create(long repositoryId, long deploymentId, NewDeploymentStatus newDeploymentStatus)
         {
             Ensure.ArgumentNotNull(newDeploymentStatus, nameof(newDeploymentStatus));
 

--- a/Octokit.Reactive/Clients/ObservableMigrationsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableMigrationsClient.cs
@@ -74,7 +74,7 @@ namespace Octokit.Reactive
         /// <param name="org">The organization which is migrating.</param>
         /// <param name="id">Migrations Id of the organization.</param>
         /// <returns>A <see cref="Migration"/> object representing the state of migration.</returns>
-        public IObservable<Migration> Get(string org, int id)
+        public IObservable<Migration> Get(string org, long id)
         {
             return _client.Get(org, id).ToObservable();
         }
@@ -88,7 +88,7 @@ namespace Octokit.Reactive
         /// <param name="org">The organization of which the migration was.</param>
         /// <param name="id">The Id of the migration.</param>
         /// <returns>The binary contents of the archive as a byte array.</returns>
-        public IObservable<byte[]> GetArchive(string org, int id)
+        public IObservable<byte[]> GetArchive(string org, long id)
         {
             return _client.GetArchive(org, id).ToObservable();
         }
@@ -102,7 +102,7 @@ namespace Octokit.Reactive
         /// <param name="org">The organization of which the migration was.</param>
         /// <param name="id">The Id of the migration.</param>
         /// <returns></returns>
-        public IObservable<Unit> DeleteArchive(string org, int id)
+        public IObservable<Unit> DeleteArchive(string org, long id)
         {
             return _client.DeleteArchive(org, id).ToObservable();
         }
@@ -117,7 +117,7 @@ namespace Octokit.Reactive
         /// <param name="id">The Id of the migration.</param>
         /// <param name="repo">The repo to unlock.</param>
         /// <returns></returns>
-        public IObservable<Unit> UnlockRepository(string org, int id, string repo)
+        public IObservable<Unit> UnlockRepository(string org, long id, string repo)
         {
             return _client.UnlockRepository(org, id, repo).ToObservable();
         }

--- a/Octokit.Reactive/Clients/ObservableOrganizationMembersClient.cs
+++ b/Octokit.Reactive/Clients/ObservableOrganizationMembersClient.cs
@@ -418,7 +418,7 @@ namespace Octokit.Reactive
 
             return _client.AddOrUpdateOrganizationMembership(org, user, addOrUpdateRequest).ToObservable();
         }
-        
+
         /// <summary>
         /// Create an organization invitation for a user
         /// </summary>
@@ -539,7 +539,7 @@ namespace Octokit.Reactive
         /// <param name="invitationId">The unique identifier of the invitation</param>
         /// <returns></returns>
         [ManualRoute("DELETE", "/orgs/{org}/invitations/{invitation_id}")]
-        public IObservable<Unit> CancelOrganizationInvitation(string org, int invitationId)
+        public IObservable<Unit> CancelOrganizationInvitation(string org, long invitationId)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
             Ensure.ArgumentNotNullOrDefault(invitationId, nameof(invitationId));

--- a/Octokit.Reactive/Clients/ObservableProjectCardsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableProjectCardsClient.cs
@@ -91,7 +91,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/repos/projects/#get-a-project-card">API documentation</a> for more information.
         /// </remarks>
         /// <param name="id">The id of the card</param>
-        public IObservable<ProjectCard> Get(int id)
+        public IObservable<ProjectCard> Get(long id)
         {
             return _client.Get(id).ToObservable();
         }
@@ -119,7 +119,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="id">The id of the card</param>
         /// <param name="projectCardUpdate">New values to update the card with</param>
-        public IObservable<ProjectCard> Update(int id, ProjectCardUpdate projectCardUpdate)
+        public IObservable<ProjectCard> Update(long id, ProjectCardUpdate projectCardUpdate)
         {
             Ensure.ArgumentNotNull(projectCardUpdate, nameof(projectCardUpdate));
 
@@ -133,7 +133,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/repos/projects/#delete-a-project-card">API documentation</a> for more information.
         /// </remarks>
         /// <param name="id">The id of the card</param>
-        public IObservable<bool> Delete(int id)
+        public IObservable<bool> Delete(long id)
         {
             return _client.Delete(id).ToObservable();
         }
@@ -143,10 +143,10 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/projects/#move-a-project-card">API documentation</a> for more information.
-        /// </remarks>        
+        /// </remarks>
         /// <param name="id">The id of the card</param>
         /// <param name="position">The position to move the card</param>
-        public IObservable<bool> Move(int id, ProjectCardMove position)
+        public IObservable<bool> Move(long id, ProjectCardMove position)
         {
             Ensure.ArgumentNotNull(position, nameof(position));
 

--- a/Octokit.Reactive/Clients/ObservableReleasesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableReleasesClient.cs
@@ -135,7 +135,7 @@ namespace Octokit.Reactive
         /// <param name="name">The repository's name</param>
         /// <param name="id">The id of the release</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public IObservable<Release> Get(string owner, string name, int id)
+        public IObservable<Release> Get(string owner, string name, long id)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -171,7 +171,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the release</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public IObservable<Release> Get(long repositoryId, int id)
+        public IObservable<Release> Get(long repositoryId, long id)
         {
             return _client.Get(repositoryId, id).ToObservable();
         }
@@ -268,7 +268,7 @@ namespace Octokit.Reactive
         /// <param name="id">The id of the release</param>
         /// <param name="data">A description of the release to edit</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public IObservable<Release> Edit(string owner, string name, int id, ReleaseUpdate data)
+        public IObservable<Release> Edit(string owner, string name, long id, ReleaseUpdate data)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -287,7 +287,7 @@ namespace Octokit.Reactive
         /// <param name="id">The id of the release</param>
         /// <param name="data">A description of the release to edit</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public IObservable<Release> Edit(long repositoryId, int id, ReleaseUpdate data)
+        public IObservable<Release> Edit(long repositoryId, long id, ReleaseUpdate data)
         {
             Ensure.ArgumentNotNull(data, nameof(data));
 
@@ -304,7 +304,7 @@ namespace Octokit.Reactive
         /// <param name="name">The repository's name</param>
         /// <param name="id">The id of the release to delete</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public IObservable<Unit> Delete(string owner, string name, int id)
+        public IObservable<Unit> Delete(string owner, string name, long id)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -321,7 +321,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the release to delete</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public IObservable<Unit> Delete(long repositoryId, int id)
+        public IObservable<Unit> Delete(long repositoryId, long id)
         {
             return _client.Delete(repositoryId, id).ToObservable();
         }
@@ -336,7 +336,7 @@ namespace Octokit.Reactive
         /// <param name="name">The repository's name</param>
         /// <param name="id">The id of the <see cref="Release"/>.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public IObservable<ReleaseAsset> GetAllAssets(string owner, string name, int id)
+        public IObservable<ReleaseAsset> GetAllAssets(string owner, string name, long id)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -353,7 +353,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the <see cref="Release"/>.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public IObservable<ReleaseAsset> GetAllAssets(long repositoryId, int id)
+        public IObservable<ReleaseAsset> GetAllAssets(long repositoryId, long id)
         {
             return GetAllAssets(repositoryId, id, ApiOptions.None);
         }
@@ -369,7 +369,7 @@ namespace Octokit.Reactive
         /// <param name="id">The id of the <see cref="Release"/>.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public IObservable<ReleaseAsset> GetAllAssets(string owner, string name, int id, ApiOptions options)
+        public IObservable<ReleaseAsset> GetAllAssets(string owner, string name, long id, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -388,7 +388,7 @@ namespace Octokit.Reactive
         /// <param name="id">The id of the <see cref="Release"/>.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public IObservable<ReleaseAsset> GetAllAssets(long repositoryId, int id, ApiOptions options)
+        public IObservable<ReleaseAsset> GetAllAssets(long repositoryId, long id, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 

--- a/Octokit.Reactive/Clients/ObservableRepositoryInvitationsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryInvitationsClient.cs
@@ -26,7 +26,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/repos/invitations/#accept-a-repository-invitation">API documentation</a> for more information.
         /// </remarks>
         /// <param name="invitationId">The id of the invitation.</param>
-        public IObservable<bool> Accept(int invitationId)
+        public IObservable<bool> Accept(long invitationId)
         {
             return _client.Accept(invitationId).ToObservable();
         }
@@ -38,7 +38,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/repos/invitations/#decline-a-repository-invitation">API documentation</a> for more information.
         /// </remarks>
         /// <param name="invitationId">The id of the invitation.</param>
-        public IObservable<bool> Decline(int invitationId)
+        public IObservable<bool> Decline(long invitationId)
         {
             return _client.Decline(invitationId).ToObservable();
         }
@@ -51,7 +51,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The id of the repository.</param>
         /// <param name="invitationId">The id of the invitation.</param>
-        public IObservable<bool> Delete(long repositoryId, int invitationId)
+        public IObservable<bool> Delete(long repositoryId, long invitationId)
         {
             return _client.Delete(repositoryId, invitationId).ToObservable();
         }
@@ -65,7 +65,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The id of the repository.</param>
         /// <param name="invitationId">The id of the invitatio.n</param>
         /// <param name="permissions">The permission to set.</param>
-        public IObservable<RepositoryInvitation> Edit(long repositoryId, int invitationId, InvitationUpdate permissions)
+        public IObservable<RepositoryInvitation> Edit(long repositoryId, long invitationId, InvitationUpdate permissions)
         {
             Ensure.ArgumentNotNull(permissions, nameof(permissions));
 

--- a/Octokit.Reactive/Clients/ObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableTeamsClient.cs
@@ -35,7 +35,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="id">The team identifier.</param>
         /// <returns>The <see cref="Team"/> with the given identifier.</returns>
-        public IObservable<Team> Get(int id)
+        public IObservable<Team> Get(long id)
         {
             return _client.Get(id).ToObservable();
         }
@@ -97,7 +97,7 @@ namespace Octokit.Reactive
         /// <remarks>
         /// https://developer.github.com/v3/orgs/teams/#list-child-teams
         /// </remarks>
-        public IObservable<Team> GetAllChildTeams(int id)
+        public IObservable<Team> GetAllChildTeams(long id)
         {
             return GetAllChildTeams(id, ApiOptions.None);
         }
@@ -110,7 +110,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="id">The team identifier</param>
         /// <param name="options">Options to change API behaviour.</param>
-        public IObservable<Team> GetAllChildTeams(int id, ApiOptions options)
+        public IObservable<Team> GetAllChildTeams(long id, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
@@ -126,7 +126,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of the team's member <see cref="User"/>s.</returns>
-        public IObservable<User> GetAllMembers(int id)
+        public IObservable<User> GetAllMembers(long id)
         {
             return GetAllMembers(id, ApiOptions.None);
         }
@@ -141,7 +141,7 @@ namespace Octokit.Reactive
         /// <param name="options">Options to change API behaviour.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of the team's member <see cref="User"/>s.</returns>
-        public IObservable<User> GetAllMembers(int id, ApiOptions options)
+        public IObservable<User> GetAllMembers(long id, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
@@ -156,7 +156,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="id">The team identifier</param>
         /// <param name="request">The request filter</param>
-        public IObservable<User> GetAllMembers(int id, TeamMembersRequest request)
+        public IObservable<User> GetAllMembers(long id, TeamMembersRequest request)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
 
@@ -172,7 +172,7 @@ namespace Octokit.Reactive
         /// <param name="id">The team identifier</param>
         /// <param name="request">The request filter</param>
         /// <param name="options">Options to change API behaviour.</param>
-        public IObservable<User> GetAllMembers(int id, TeamMembersRequest request, ApiOptions options)
+        public IObservable<User> GetAllMembers(long id, TeamMembersRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -198,7 +198,7 @@ namespace Octokit.Reactive
         /// To edit a team, the authenticated user must either be an organization owner or a team maintainer
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#update-a-team">API documentation</a> 
+        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#update-a-team">API documentation</a>
         /// for more information.
         /// </remarks>
         /// <returns>updated <see cref="Team" /> for the current org</returns>
@@ -218,12 +218,12 @@ namespace Octokit.Reactive
         /// <see cref="Update(string, string, UpdateTeam)"/>.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#update-a-team-legacy">API documentation</a> 
+        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#update-a-team-legacy">API documentation</a>
         /// for more information.
         /// </remarks>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>Updated <see cref="Team"/></returns>
-        public IObservable<Team> Update(int id, UpdateTeam team)
+        public IObservable<Team> Update(long id, UpdateTeam team)
         {
             Ensure.ArgumentNotNull(team, nameof(team));
 
@@ -235,7 +235,7 @@ namespace Octokit.Reactive
         /// If you are an organization owner, deleting a parent team will delete all of its child teams as well.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#delete-a-team">API documentation</a> 
+        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#delete-a-team">API documentation</a>
         /// </remarks>
         /// <param name="org">The organization name. The name is not case sensitive.</param>
         /// <param name="teamSlug">The slug of the team name.</param>
@@ -245,7 +245,7 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNull(org, nameof(org));
             Ensure.ArgumentNotNull(teamSlug, nameof(teamSlug));
-            
+
             return _client.Delete(org, teamSlug).ToObservable();
         }
 
@@ -256,12 +256,12 @@ namespace Octokit.Reactive
         /// <see cref="Delete(string, string)"/>.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#delete-a-team-legacy">API documentation</a> 
+        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#delete-a-team-legacy">API documentation</a>
         /// </remarks>
         /// <param name="id">The unique identifier of the team.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns></returns>
-        public IObservable<Unit> Delete(int id)
+        public IObservable<Unit> Delete(long id)
         {
             return _client.Delete(id).ToObservable();
         }
@@ -275,7 +275,7 @@ namespace Octokit.Reactive
         /// <param name="id">The team identifier.</param>
         /// <param name="login">The user to add to the team.</param>
         /// <param name="request">Additional parameters for the request</param>
-        public IObservable<TeamMembershipDetails> AddOrEditMembership(int id, string login, UpdateTeamMembership request)
+        public IObservable<TeamMembershipDetails> AddOrEditMembership(long id, string login, UpdateTeamMembership request)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -292,7 +292,7 @@ namespace Octokit.Reactive
         /// <param name="id">The team identifier.</param>
         /// <param name="login">The user to remove from the team.</param>
         /// <returns><see langword="true"/> if the user was removed from the team; <see langword="false"/> otherwise.</returns>
-        public IObservable<bool> RemoveMembership(int id, string login)
+        public IObservable<bool> RemoveMembership(long id, string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
 
@@ -309,7 +309,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="id">The team to check.</param>
         /// <param name="login">The user to check.</param>
-        public IObservable<TeamMembershipDetails> GetMembershipDetails(int id, string login)
+        public IObservable<TeamMembershipDetails> GetMembershipDetails(long id, string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
 
@@ -321,7 +321,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The team's repositories</returns>
-        public IObservable<Repository> GetAllRepositories(int id)
+        public IObservable<Repository> GetAllRepositories(long id)
         {
             return GetAllRepositories(id, ApiOptions.None);
         }
@@ -333,7 +333,7 @@ namespace Octokit.Reactive
         /// <param name="options">Options to change API behaviour.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The team's repositories</returns>
-        public IObservable<Repository> GetAllRepositories(int id, ApiOptions options)
+        public IObservable<Repository> GetAllRepositories(long id, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
@@ -351,7 +351,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/orgs/teams/#add-team-repo">API documentation</a> for more information.
         /// </remarks>
         /// <returns><see langword="true"/> if the repository was added to the team; <see langword="false"/> otherwise.</returns>
-        public IObservable<bool> AddRepository(int id, string organization, string repoName)
+        public IObservable<bool> AddRepository(long id, string organization, string repoName)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, nameof(organization));
             Ensure.ArgumentNotNullOrEmptyString(repoName, nameof(repoName));
@@ -371,7 +371,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/orgs/teams/#add-team-repo">API documentation</a> for more information.
         /// </remarks>
         /// <returns><see langword="true"/> if the repository was added to the team; <see langword="false"/> otherwise.</returns>
-        public IObservable<bool> AddRepository(int id, string organization, string repoName, RepositoryPermissionRequest permission)
+        public IObservable<bool> AddRepository(long id, string organization, string repoName, RepositoryPermissionRequest permission)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, nameof(organization));
             Ensure.ArgumentNotNullOrEmptyString(repoName, nameof(repoName));
@@ -384,7 +384,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns></returns>
-        public IObservable<bool> RemoveRepository(int id, string organization, string repoName)
+        public IObservable<bool> RemoveRepository(long id, string organization, string repoName)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, nameof(organization));
             Ensure.ArgumentNotNullOrEmptyString(repoName, nameof(repoName));
@@ -402,7 +402,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/orgs/teams/#get-team-repo">API documentation</a> for more information.
         /// </remarks>
         /// <returns><see langword="true"/> if the repository is managed by the given team; <see langword="false"/> otherwise.</returns>
-        public IObservable<bool> IsRepositoryManagedByTeam(int id, string owner, string repo)
+        public IObservable<bool> IsRepositoryManagedByTeam(long id, string owner, string repo)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(repo, nameof(repo));
@@ -418,7 +418,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="id">The team identifier</param>
         /// <returns></returns>
-        public IObservable<OrganizationMembershipInvitation> GetAllPendingInvitations(int id)
+        public IObservable<OrganizationMembershipInvitation> GetAllPendingInvitations(long id)
         {
             Ensure.ArgumentNotNull(id, nameof(id));
 
@@ -435,7 +435,7 @@ namespace Octokit.Reactive
         /// <param name="id">The team identifier</param>
         /// <param name="options">Options to change API behaviour</param>
         /// <returns></returns>
-        public IObservable<OrganizationMembershipInvitation> GetAllPendingInvitations(int id, ApiOptions options)
+        public IObservable<OrganizationMembershipInvitation> GetAllPendingInvitations(long id, ApiOptions options)
         {
             Ensure.ArgumentNotNull(id, nameof(id));
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -492,9 +492,9 @@ namespace Octokit.Reactive
         /// <param name="owner">The account owner of the repository. The name is not case sensitive.</param>
         /// <param name="repo">The name of the repository. The name is not case sensitive.</param>
         /// <param name="permission">
-        /// The permission to grant the team on this repository. We accept the following permissions to be set: 
-        /// pull, triage, push, maintain, admin and you can also specify a custom repository role name, if the 
-        /// owning organization has defined any. If no permission is specified, the team's permission attribute 
+        /// The permission to grant the team on this repository. We accept the following permissions to be set:
+        /// pull, triage, push, maintain, admin and you can also specify a custom repository role name, if the
+        /// owning organization has defined any. If no permission is specified, the team's permission attribute
         /// will be used to determine what permission to grant the team on this repository
         /// </param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>

--- a/Octokit.Reactive/Clients/ObservableUserGpgKeysClient.cs
+++ b/Octokit.Reactive/Clients/ObservableUserGpgKeysClient.cs
@@ -63,7 +63,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/users/gpg_keys/#get-a-single-gpg-key">API documentation</a> for more information.
         /// </remarks>
         /// <returns>The <see cref="GpgKey"/> for the specified Id.</returns>
-        public IObservable<GpgKey> Get(int id)
+        public IObservable<GpgKey> Get(long id)
         {
             return _client.Get(id).ToObservable();
         }
@@ -91,7 +91,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/users/gpg_keys/#delete-a-gpg-key">API documentation</a> for more information.
         /// </remarks>
         /// <returns></returns>
-        public IObservable<Unit> Delete(int id)
+        public IObservable<Unit> Delete(long id)
         {
             return _client.Delete(id).ToObservable();
         }

--- a/Octokit.Reactive/Clients/ObservableUserKeysClient.cs
+++ b/Octokit.Reactive/Clients/ObservableUserKeysClient.cs
@@ -89,7 +89,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="id">The Id of the SSH key</param>
         /// <returns>View extended details for a single public key.</returns>
-        public IObservable<PublicKey> Get(int id)
+        public IObservable<PublicKey> Get(long id)
         {
             return _client.Get(id).ToObservable();
         }
@@ -117,7 +117,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="id">The id of the key to delete</param>
         /// <returns>Removes a public key.</returns>
-        public IObservable<Unit> Delete(int id)
+        public IObservable<Unit> Delete(long id)
         {
             return _client.Delete(id).ToObservable();
         }

--- a/Octokit.Tests.Integration/Clients/GitHubClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/GitHubClientTests.cs
@@ -26,7 +26,7 @@ public class GitHubClientTests
 
                 var result = github.GetLastApiInfo();
 
-                Assert.Equal(0, result.Links.Count);
+                Assert.Empty(result.Links);
                 Assert.True(result.AcceptedOauthScopes.Count > -1);
                 Assert.True(result.OauthScopes.Count > -1);
                 Assert.False(string.IsNullOrEmpty(result.Etag));
@@ -67,8 +67,8 @@ public class GitHubClientTests
 
             var result = github.GetLastApiInfo();
 
-            Assert.Equal(0, result.Links.Count);
-            Assert.Equal(0, result.AcceptedOauthScopes.Count);
+            Assert.Single(result.Links);
+            Assert.Single(result.AcceptedOauthScopes);
             Assert.True(result.OauthScopes.Count > 0);
             Assert.False(string.IsNullOrEmpty(result.Etag));
             Assert.True(result.RateLimit.Limit > 0);

--- a/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
@@ -197,7 +197,7 @@ public class IssuesClientTests : IDisposable
 
             var retrieved = await _issuesClient.Get(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
             Assert.NotNull(retrieved);
-            Assert.Equal(1, retrieved.Assignees.Count);
+            Assert.Single(retrieved.Assignees);
             Assert.True(retrieved.Assignees[0].Login == _context.RepositoryOwner);
             var all = await _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName);
             Assert.Contains(all, i => i.Number == retrieved.Number);
@@ -226,7 +226,7 @@ public class IssuesClientTests : IDisposable
 
         var retrieved = await _issuesClient.Get(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
         Assert.NotNull(retrieved);
-        Assert.Equal(1, retrieved.Assignees.Count);
+        Assert.Single(retrieved.Assignees);
         Assert.True(retrieved.Assignees[0].Login == _context.RepositoryOwner);
 
         var update = retrieved.ToUpdate();

--- a/Octokit.Tests.Integration/Clients/OrganizationMembersClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/OrganizationMembersClientTests.cs
@@ -187,25 +187,25 @@ namespace Octokit.Tests.Integration.Clients
             public async Task ReturnsOrganizationMembershipInvitationViaUserId()
             {
                 var user = await _gitHub.User.Get("alfhenrik-test-2");
-                
+
                 var organizationInvitationRequest = new OrganizationInvitationRequest(user.Id);
                 var organizationMembershipInvitation = await _gitHub.Organization.Member.CreateOrganizationInvitation(Helper.Organization, organizationInvitationRequest);
-                
+
                 Assert.Equal("alfhenrik-test-2", organizationMembershipInvitation.Login);
                 Assert.Equal(OrganizationMembershipRole.DirectMember, organizationMembershipInvitation.Role.Value);
                 Assert.Equal(Helper.UserName, organizationMembershipInvitation.Inviter.Login);
-                
+
                 await _gitHub.Organization.Member.RemoveOrganizationMembership(Helper.Organization, "alfhenrik-test-2");
             }
-            
+
             [OrganizationTest]
             public async Task ReturnsOrganizationMembershipInvitationViaUserEmail()
             {
                 var email = RandomEmailGenerator.GenerateRandomEmail();
-                
+
                 var organizationInvitationRequest = new OrganizationInvitationRequest(email);
                 var organizationMembershipInvitation = await _gitHub.Organization.Member.CreateOrganizationInvitation(Helper.Organization, organizationInvitationRequest);
-                
+
                 Assert.Equal(email, organizationMembershipInvitation.Email);
                 Assert.Equal(OrganizationMembershipRole.DirectMember, organizationMembershipInvitation.Role.Value);
                 Assert.Equal(Helper.UserName, organizationMembershipInvitation.Inviter.Login);
@@ -218,7 +218,7 @@ namespace Octokit.Tests.Integration.Clients
             {
                 var user = await _gitHub.User.Get(Helper.UserName);
                 var organizationInvitationRequest = new OrganizationInvitationRequest(user.Id);
-                
+
                 await Assert.ThrowsAsync<ApiValidationException>(() => _gitHub.Organization.Member.CreateOrganizationInvitation(Helper.Organization, organizationInvitationRequest));
             }
 
@@ -228,19 +228,19 @@ namespace Octokit.Tests.Integration.Clients
                 var user = await _gitHub.User.Get("alfhenrik-test-2");
 
                 var team1 = await _gitHub.Organization.Team.Create(Helper.Organization, new NewTeam("TestTeam1"));
-                
-                var organizationInvitationRequest = new OrganizationInvitationRequest(user.Id, new int[] {team1.Id});
+
+                var organizationInvitationRequest = new OrganizationInvitationRequest(user.Id, new long[] {team1.Id});
                 var organizationMembershipInvitation = await _gitHub.Organization.Member.CreateOrganizationInvitation(Helper.Organization, organizationInvitationRequest);
-                
+
                 Assert.Equal("alfhenrik-test-2", organizationMembershipInvitation.Login);
                 Assert.Equal(OrganizationMembershipRole.DirectMember, organizationMembershipInvitation.Role.Value);
                 Assert.Equal(Helper.UserName, organizationMembershipInvitation.Inviter.Login);
                 Assert.Equal(1, organizationMembershipInvitation.TeamCount);
-                
+
                 await _gitHub.Organization.Team.Delete(Helper.Organization, team1.Slug);
                 await _gitHub.Organization.Member.RemoveOrganizationMembership(Helper.Organization, "alfhenrik-test-2");
             }
-            
+
             [OrganizationTest]
             public async Task ReturnsOrganizationMembershipInvitationMultipleTeams()
             {
@@ -248,15 +248,15 @@ namespace Octokit.Tests.Integration.Clients
 
                 var team1 = await _gitHub.Organization.Team.Create(Helper.Organization, new NewTeam("TestTeam1"));
                 var team2 = await _gitHub.Organization.Team.Create(Helper.Organization, new NewTeam("TestTeam2"));
-                
-                var organizationInvitationRequest = new OrganizationInvitationRequest(user.Id, new int[] {team1.Id, team2.Id});
+
+                var organizationInvitationRequest = new OrganizationInvitationRequest(user.Id, new long[] {team1.Id, team2.Id});
                 var organizationMembershipInvitation = await _gitHub.Organization.Member.CreateOrganizationInvitation(Helper.Organization, organizationInvitationRequest);
-                
+
                 Assert.Equal("alfhenrik-test-2", organizationMembershipInvitation.Login);
                 Assert.Equal(OrganizationMembershipRole.DirectMember, organizationMembershipInvitation.Role.Value);
                 Assert.Equal(Helper.UserName, organizationMembershipInvitation.Inviter.Login);
                 Assert.Equal(2, organizationMembershipInvitation.TeamCount);
-                
+
                 await _gitHub.Organization.Team.Delete(Helper.Organization, team1.Slug);
                 await _gitHub.Organization.Team.Delete(Helper.Organization, team2.Slug);
                 await _gitHub.Organization.Member.RemoveOrganizationMembership(Helper.Organization, "alfhenrik-test-2");

--- a/Octokit.Tests.Integration/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/ReleasesClientTests.cs
@@ -160,7 +160,7 @@ public class ReleasesClientTests
 
             var releases = await _releaseClient.GetAll(_context.RepositoryOwner, _context.RepositoryName);
 
-            Assert.Equal(1, releases.Count);
+            Assert.Single(releases);
             Assert.False(releases.First().PublishedAt.HasValue);
         }
 
@@ -173,7 +173,7 @@ public class ReleasesClientTests
 
             var releases = await _releaseClient.GetAll(_context.Repository.Id);
 
-            Assert.Equal(1, releases.Count);
+            Assert.Single(releases);
             Assert.False(releases.First().PublishedAt.HasValue);
         }
 

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -2193,7 +2193,7 @@ public class RepositoriesClientTests
                 NewTeam team = new NewTeam(Helper.MakeNameWithTimestamp("transfer-team"));
                 using (var teamContext = await github.CreateTeamContext(Helper.Organization, team))
                 {
-                    var transferTeamIds = new int[] { teamContext.TeamId };
+                    var transferTeamIds = new long[] { teamContext.TeamId };
                     var transfer = new RepositoryTransfer(newOwner, transferTeamIds);
                     await github.Repository.Transfer(
                         repositoryContext.RepositoryOwner, repositoryContext.RepositoryName, transfer);
@@ -2222,7 +2222,7 @@ public class RepositoriesClientTests
                 NewTeam team = new NewTeam(Helper.MakeNameWithTimestamp("transfer-team"));
                 using (var teamContext = await github.CreateTeamContext(Helper.Organization, team))
                 {
-                    var transferTeamIds = new int[] { teamContext.TeamId };
+                    var transferTeamIds = new long[] { teamContext.TeamId };
                     var transfer = new RepositoryTransfer(newOwner, transferTeamIds);
                     await github.Repository.Transfer(repositoryContext.RepositoryId, transfer);
                     var transferred = await github.Repository.Get(repositoryContext.RepositoryId);

--- a/Octokit.Tests.Integration/Helper.cs
+++ b/Octokit.Tests.Integration/Helper.cs
@@ -100,13 +100,13 @@ namespace Octokit.Tests.Integration
         static Helper()
         {
             // Force reading of environment variables.
-            // This wasn't happening if UserName/Organization were 
+            // This wasn't happening if UserName/Organization were
             // retrieved before Credentials.
             Debug.WriteIf(Credentials == null, "No credentials specified.");
         }
 
         public static string UserName { get; private set; }
-        
+
         public static string Organization { get; private set; }
 
         public static bool HasNoOrganization => Organization == null;
@@ -214,7 +214,7 @@ namespace Octokit.Tests.Integration
                 DeleteKey(connection, key.Id);
         }
 
-        public static void DeleteKey(IConnection connection, int keyId)
+        public static void DeleteKey(IConnection connection, long keyId)
         {
             try
             {
@@ -230,7 +230,7 @@ namespace Octokit.Tests.Integration
                 DeleteGpgKey(connection, key.Id);
         }
 
-        public static void DeleteGpgKey(IConnection connection, int keyId)
+        public static void DeleteGpgKey(IConnection connection, long keyId)
         {
             try
             {
@@ -328,7 +328,7 @@ namespace Octokit.Tests.Integration
             };
         }
 
-        public static void DeleteInvitations(IConnection connection, List<string> invitees, int teamId)
+        public static void DeleteInvitations(IConnection connection, List<string> invitees)
         {
             try
             {
@@ -340,7 +340,7 @@ namespace Octokit.Tests.Integration
             catch { }
         }
 
-        public static string InviteMemberToTeam(IConnection connection, int teamId, string login)
+        public static string InviteMemberToTeam(IConnection connection, long teamId, string login)
         {
             try
             {

--- a/Octokit.Tests.Integration/Helpers/EnterpriseUserContext.cs
+++ b/Octokit.Tests.Integration/Helpers/EnterpriseUserContext.cs
@@ -18,7 +18,7 @@ namespace Octokit.Tests.Integration.Helpers
         }
 
         private readonly IConnection _connection;
-        internal int UserId { get; private set; }
+        internal long UserId { get; private set; }
         internal string UserLogin { get; private set; }
         internal string UserEmail { get; private set; }
 

--- a/Octokit.Tests.Integration/Helpers/GpgKeyContext.cs
+++ b/Octokit.Tests.Integration/Helpers/GpgKeyContext.cs
@@ -18,7 +18,7 @@ namespace Octokit.Tests.Integration.Helpers
         }
 
         private readonly IConnection _connection;
-        internal int GpgKeyId { get; set; }
+        internal long GpgKeyId { get; set; }
         internal string KeyId { get; set; }
         internal string PublicKeyData { get; set; }
 

--- a/Octokit.Tests.Integration/Helpers/PublicKeyContext.cs
+++ b/Octokit.Tests.Integration/Helpers/PublicKeyContext.cs
@@ -18,7 +18,7 @@ namespace Octokit.Tests.Integration.Helpers
         }
 
         private readonly IConnection _connection;
-        internal int KeyId { get; private set; }
+        internal long KeyId { get; private set; }
         internal string KeyTitle { get; private set; }
         internal string KeyData { get; private set; }
 

--- a/Octokit.Tests.Integration/Helpers/TeamContext.cs
+++ b/Octokit.Tests.Integration/Helpers/TeamContext.cs
@@ -16,7 +16,7 @@ namespace Octokit.Tests.Integration.Helpers
         }
 
         private readonly IConnection _connection;
-        internal int TeamId { get; private set; }
+        internal long TeamId { get; private set; }
         internal string TeamName { get; private set; }
 
         internal Team Team { get; private set; }
@@ -30,7 +30,7 @@ namespace Octokit.Tests.Integration.Helpers
         public void Dispose()
         {
             if (Invitations.Any())
-                Helper.DeleteInvitations(_connection, Invitations, TeamId);
+                Helper.DeleteInvitations(_connection, Invitations);
 
             Helper.DeleteTeam(_connection, Team);
         }

--- a/Octokit.Tests.Integration/Reactive/ObservableOrganizationMembersClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableOrganizationMembersClientTests.cs
@@ -64,7 +64,7 @@ namespace Octokit.Tests.Integration.Reactive
                 await _client.RemoveOrganizationMembership(Helper.Organization, "alfhenrik-test-2");
             }
         }
-        
+
         public class TheCreateOrganizationInvitationMethod
         {
             readonly IGitHubClient _gitHub;
@@ -80,25 +80,25 @@ namespace Octokit.Tests.Integration.Reactive
             public async Task ReturnsOrganizationMembershipInvitationViaUserId()
             {
                 var user = await _gitHub.User.Get("alfhenrik-test-2");
-                
+
                 var organizationInvitationRequest = new OrganizationInvitationRequest(user.Id);
                 var organizationMembershipInvitation = await _client.CreateOrganizationInvitation(Helper.Organization, organizationInvitationRequest);
-                
+
                 Assert.Equal("alfhenrik-test-2", organizationMembershipInvitation.Login);
                 Assert.Equal(OrganizationMembershipRole.DirectMember, organizationMembershipInvitation.Role.Value);
                 Assert.Equal(Helper.UserName, organizationMembershipInvitation.Inviter.Login);
-                
+
                 await _client.RemoveOrganizationMembership(Helper.Organization, "alfhenrik-test-2");
             }
-            
+
             [OrganizationTest]
             public async Task ReturnsOrganizationMembershipInvitationViaUserEmail()
             {
                 var email = RandomEmailGenerator.GenerateRandomEmail();
-                
+
                 var organizationInvitationRequest = new OrganizationInvitationRequest(email);
                 var organizationMembershipInvitation = await _client.CreateOrganizationInvitation(Helper.Organization, organizationInvitationRequest);
-                
+
                 Assert.Equal(email, organizationMembershipInvitation.Email);
                 Assert.Equal(OrganizationMembershipRole.DirectMember, organizationMembershipInvitation.Role.Value);
                 Assert.Equal(Helper.UserName, organizationMembershipInvitation.Inviter.Login);
@@ -111,7 +111,7 @@ namespace Octokit.Tests.Integration.Reactive
             {
                 var user = await _gitHub.User.Get(Helper.UserName);
                 var organizationInvitationRequest = new OrganizationInvitationRequest(user.Id);
-                
+
                 await Assert.ThrowsAsync<ApiValidationException>(() => _client.CreateOrganizationInvitation(Helper.Organization, organizationInvitationRequest).ToTask());
             }
 
@@ -121,19 +121,19 @@ namespace Octokit.Tests.Integration.Reactive
                 var user = await _gitHub.User.Get("alfhenrik-test-2");
 
                 var team1 = await _gitHub.Organization.Team.Create(Helper.Organization, new NewTeam("TestTeam1"));
-                
-                var organizationInvitationRequest = new OrganizationInvitationRequest(user.Id, new int[] {team1.Id});
+
+                var organizationInvitationRequest = new OrganizationInvitationRequest(user.Id, new long[] {team1.Id});
                 var organizationMembershipInvitation = await _client.CreateOrganizationInvitation(Helper.Organization, organizationInvitationRequest);
-                
+
                 Assert.Equal("alfhenrik-test-2", organizationMembershipInvitation.Login);
                 Assert.Equal(OrganizationMembershipRole.DirectMember, organizationMembershipInvitation.Role.Value);
                 Assert.Equal(Helper.UserName, organizationMembershipInvitation.Inviter.Login);
                 Assert.Equal(1, organizationMembershipInvitation.TeamCount);
-                
+
                 await _gitHub.Organization.Team.Delete(Helper.Organization, team1.Slug);
                 await _client.RemoveOrganizationMembership(Helper.Organization, "alfhenrik-test-2");
             }
-            
+
             [OrganizationTest]
             public async Task ReturnsOrganizationMembershipInvitationMultipleTeams()
             {
@@ -141,15 +141,15 @@ namespace Octokit.Tests.Integration.Reactive
 
                 var team1 = await _gitHub.Organization.Team.Create(Helper.Organization, new NewTeam("TestTeam1"));
                 var team2 = await _gitHub.Organization.Team.Create(Helper.Organization, new NewTeam("TestTeam2"));
-                
-                var organizationInvitationRequest = new OrganizationInvitationRequest(user.Id, new int[] {team1.Id, team2.Id});
+
+                var organizationInvitationRequest = new OrganizationInvitationRequest(user.Id, new long[] {team1.Id, team2.Id});
                 var organizationMembershipInvitation = await _client.CreateOrganizationInvitation(Helper.Organization, organizationInvitationRequest);
-                
+
                 Assert.Equal("alfhenrik-test-2", organizationMembershipInvitation.Login);
                 Assert.Equal(OrganizationMembershipRole.DirectMember, organizationMembershipInvitation.Role.Value);
                 Assert.Equal(Helper.UserName, organizationMembershipInvitation.Inviter.Login);
                 Assert.Equal(2, organizationMembershipInvitation.TeamCount);
-                
+
                 await _gitHub.Organization.Team.Delete(Helper.Organization, team1.Slug);
                 await _gitHub.Organization.Team.Delete(Helper.Organization, team2.Slug);
                 await _client.RemoveOrganizationMembership(Helper.Organization, "alfhenrik-test-2");

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -277,7 +277,7 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
-                var teamId = new int[2] { 35, 42 };
+                var teamId = new long[2] { 35, 42 };
                 var transfer = new RepositoryTransfer("newOwner", teamId);
 
                 await client.Transfer("owner", "name", transfer);
@@ -293,7 +293,7 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
-                var teamId = new int[2] { 35, 42 };
+                var teamId = new long[2] { 35, 42 };
                 var transfer = new RepositoryTransfer("newOwner", teamId);
                 var repositoryId = 1;
 
@@ -310,7 +310,7 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
-                var teamId = new int[2] { 35, 42 };
+                var teamId = new long[2] { 35, 42 };
                 var transfer = new RepositoryTransfer("newOwner", teamId);
 
                 await client.Transfer("owner", "name", transfer);
@@ -326,7 +326,7 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
-                var teamId = new int[2] { 35, 42 };
+                var teamId = new long[2] { 35, 42 };
                 var transfer = new RepositoryTransfer("newOwner", teamId);
                 var repositoryId = 1;
 
@@ -343,7 +343,7 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
-                var teamId = new int[2] { 35, 42 };
+                var teamId = new long[2] { 35, 42 };
                 var transfer = new RepositoryTransfer("newOwner", teamId);
 
                 await client.Transfer("owner", "name", transfer);
@@ -359,7 +359,7 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
-                var teamId = new int[2] { 35, 42 };
+                var teamId = new long[2] { 35, 42 };
                 var transfer = new RepositoryTransfer("newOwner", teamId);
                 var repositoryId = 1;
 

--- a/Octokit.Tests/Models/RepositoryTransferTest.cs
+++ b/Octokit.Tests/Models/RepositoryTransferTest.cs
@@ -7,8 +7,8 @@ namespace Octokit.Tests.Models
     {
         public static readonly string emptyName = "";
         public static readonly string nonemptyName = "name";
-        public static readonly int[] emptyTeamId = new int[] { };
-        public static readonly int[] nonemptyTeamId = new int[] { 1, 2, 3 };
+        public static readonly long[] emptyTeamId = new long[] { };
+        public static readonly long[] nonemptyTeamId = new long[] { 1, 2, 3 };
 
         public class TheSingleArgumentConstructor
         {
@@ -77,7 +77,7 @@ namespace Octokit.Tests.Models
             [Fact]
             public void StoresGivenTeamId()
             {
-                int[] testTeamId = nonemptyTeamId;
+                long[] testTeamId = nonemptyTeamId;
                 RepositoryTransfer repositoryTransfer = new RepositoryTransfer(nonemptyName, testTeamId);
                 Assert.Equal(repositoryTransfer.TeamIds, testTeamId);
             }

--- a/Octokit.Tests/Reactive/Enterprise/ObservableEnterpriseLdapClientTests.cs
+++ b/Octokit.Tests/Reactive/Enterprise/ObservableEnterpriseLdapClientTests.cs
@@ -61,7 +61,7 @@ namespace Octokit.Tests
 
                 client.UpdateTeamMapping(1, new NewLdapMapping(_distinguishedName));
                 github.Enterprise.Ldap.Received(1).UpdateTeamMapping(
-                    Arg.Is<int>(a => a == 1),
+                    Arg.Is<long>(a => a == 1),
                     Arg.Is<NewLdapMapping>(a =>
                         a.LdapDistinguishedName == _distinguishedName));
             }
@@ -77,7 +77,7 @@ namespace Octokit.Tests
 
                 client.QueueSyncTeamMapping(1);
                 github.Enterprise.Ldap.Received(1).QueueSyncTeamMapping(
-                    Arg.Is<int>(a => a == 1));
+                    Arg.Is<long>(a => a == 1));
             }
         }
     }

--- a/Octokit/Clients/AuthorizationsClient.cs
+++ b/Octokit/Clients/AuthorizationsClient.cs
@@ -73,7 +73,7 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The specified <see cref="Authorization"/>.</returns>
         [ManualRoute("GET", "/authorizations/{id}")]
-        public Task<Authorization> Get(int authorizationId)
+        public Task<Authorization> Get(long authorizationId)
         {
             return ApiConnection.Get<Authorization>(ApiUrls.Authorizations(authorizationId), null);
         }
@@ -426,7 +426,7 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The updated <see cref="Authorization"/>.</returns>
         [ManualRoute("PATCH", "/authorizations/{id}")]
-        public Task<Authorization> Update(int authorizationId, AuthorizationUpdate authorizationUpdate)
+        public Task<Authorization> Update(long authorizationId, AuthorizationUpdate authorizationUpdate)
         {
             Ensure.ArgumentNotNull(authorizationUpdate, nameof(authorizationUpdate));
 
@@ -450,7 +450,7 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="Task"/> for the request's execution.</returns>
         [ManualRoute("DELETE", "/authorizations/{id}")]
-        public Task Delete(int authorizationId)
+        public Task Delete(long authorizationId)
         {
             return ApiConnection.Delete(ApiUrls.Authorizations(authorizationId));
         }
@@ -471,7 +471,7 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="Task"/> for the request's execution.</returns>
         [ManualRoute("DELETE", "/authorizations/{id}")]
-        public Task Delete(int authorizationId, string twoFactorAuthenticationCode)
+        public Task Delete(long authorizationId, string twoFactorAuthenticationCode)
         {
             return ApiConnection.Delete(ApiUrls.Authorizations(authorizationId), twoFactorAuthenticationCode);
         }

--- a/Octokit/Clients/Codespace.cs
+++ b/Octokit/Clients/Codespace.cs
@@ -8,7 +8,7 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Codespace
     {
-        public int Id { get; private set; }
+        public long Id { get; private set; }
         public string Name { get; private set; }
         public User Owner { get; private set; }
         public User BillableOwner { get; private set; }
@@ -24,7 +24,7 @@ namespace Octokit
         public string StartUrl { get; private set; }
         public string StopUrl { get; private set; }
 
-        public Codespace(int id, string name, User owner, User billableOwner, Repository repository, Machine machine, DateTime createdAt, DateTime updatedAt, DateTime lastUsedAt, StringEnum<CodespaceState> state, string url, string machinesUrl, string webUrl, string startUrl, string stopUrl)
+        public Codespace(long id, string name, User owner, User billableOwner, Repository repository, Machine machine, DateTime createdAt, DateTime updatedAt, DateTime lastUsedAt, StringEnum<CodespaceState> state, string url, string machinesUrl, string webUrl, string startUrl, string stopUrl)
         {
             Id = id;
             Name = name;

--- a/Octokit/Clients/DeploymentStatusClient.cs
+++ b/Octokit/Clients/DeploymentStatusClient.cs
@@ -28,7 +28,7 @@ namespace Octokit
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/deployments/{deployment_id}/statuses")]
-        public Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, int deploymentId)
+        public Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, long deploymentId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -46,7 +46,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         [ManualRoute("GET", "/repositories/{id}/deployments/{deployment_id}/statuses")]
-        public Task<IReadOnlyList<DeploymentStatus>> GetAll(long repositoryId, int deploymentId)
+        public Task<IReadOnlyList<DeploymentStatus>> GetAll(long repositoryId, long deploymentId)
         {
             return GetAll(repositoryId, deploymentId, ApiOptions.None);
         }
@@ -63,7 +63,7 @@ namespace Octokit
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/deployments/{deployment_id}/statuses")]
-        public Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, int deploymentId, ApiOptions options)
+        public Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, long deploymentId, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -83,7 +83,7 @@ namespace Octokit
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/repositories/{id}/deployments/{deployment_id}/statuses")]
-        public Task<IReadOnlyList<DeploymentStatus>> GetAll(long repositoryId, int deploymentId, ApiOptions options)
+        public Task<IReadOnlyList<DeploymentStatus>> GetAll(long repositoryId, long deploymentId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
@@ -102,7 +102,7 @@ namespace Octokit
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus">The new deployment status to create.</param>
         [ManualRoute("POST", "/repos/{owner}/{repo}/deployments/{deployment_id}/statuses")]
-        public Task<DeploymentStatus> Create(string owner, string name, int deploymentId, NewDeploymentStatus newDeploymentStatus)
+        public Task<DeploymentStatus> Create(string owner, string name, long deploymentId, NewDeploymentStatus newDeploymentStatus)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -122,7 +122,7 @@ namespace Octokit
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus">The new deployment status to create.</param>
         [ManualRoute("POST", "/repositories/{id}/deployments/{deployment_id}/statuses")]
-        public Task<DeploymentStatus> Create(long repositoryId, int deploymentId, NewDeploymentStatus newDeploymentStatus)
+        public Task<DeploymentStatus> Create(long repositoryId, long deploymentId, NewDeploymentStatus newDeploymentStatus)
         {
             Ensure.ArgumentNotNull(newDeploymentStatus, nameof(newDeploymentStatus));
 

--- a/Octokit/Clients/Enterprise/EnterpriseLdapClient.cs
+++ b/Octokit/Clients/Enterprise/EnterpriseLdapClient.cs
@@ -69,7 +69,7 @@ namespace Octokit
         /// <param name="newLdapMapping">The <see cref="NewLdapMapping"/></param>
         /// <returns>The <see cref="Team"/> object.</returns>
         [ManualRoute("PATCH", "/admin/ldap/teams/{team_id}/mapping")]
-        public Task<Team> UpdateTeamMapping(int teamId, NewLdapMapping newLdapMapping)
+        public Task<Team> UpdateTeamMapping(long teamId, NewLdapMapping newLdapMapping)
         {
             Ensure.ArgumentNotNull(teamId, nameof(teamId));
             Ensure.ArgumentNotNull(newLdapMapping, nameof(newLdapMapping));
@@ -88,7 +88,7 @@ namespace Octokit
         /// <param name="teamId">The teamId to update LDAP mapping</param>
         /// <returns>The <see cref="LdapSyncResponse"/> of the queue request.</returns>
         [ManualRoute("POST", "/admin/ldap/teams/{team_id}/sync")]
-        public async Task<LdapSyncResponse> QueueSyncTeamMapping(int teamId)
+        public async Task<LdapSyncResponse> QueueSyncTeamMapping(long teamId)
         {
             Ensure.ArgumentNotNull(teamId, nameof(teamId));
 

--- a/Octokit/Clients/Enterprise/IEnterpriseLdapClient.cs
+++ b/Octokit/Clients/Enterprise/IEnterpriseLdapClient.cs
@@ -40,7 +40,7 @@ namespace Octokit
         /// <param name="teamId">The teamId to update LDAP mapping</param>
         /// <param name="newLdapMapping">The <see cref="NewLdapMapping"/></param>
         /// <returns>The <see cref="Team"/> object.</returns>
-        Task<Team> UpdateTeamMapping(int teamId, NewLdapMapping newLdapMapping);
+        Task<Team> UpdateTeamMapping(long teamId, NewLdapMapping newLdapMapping);
 
         /// <summary>
         /// Queue an LDAP Sync job for a team on a GitHub Enterprise appliance (must be Site Admin user).
@@ -50,6 +50,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="teamId">The teamId to update LDAP mapping</param>
         /// <returns>The <see cref="LdapSyncResponse"/> of the queue request.</returns>
-        Task<LdapSyncResponse> QueueSyncTeamMapping(int teamId);
+        Task<LdapSyncResponse> QueueSyncTeamMapping(long teamId);
     }
 }

--- a/Octokit/Clients/IAuthorizationsClient.cs
+++ b/Octokit/Clients/IAuthorizationsClient.cs
@@ -61,7 +61,7 @@ namespace Octokit
         /// <returns>The specified <see cref="Authorization"/>.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "It's fiiiine. It's fine. Trust us.")]
-        Task<Authorization> Get(int id);
+        Task<Authorization> Get(long id);
 
         /// <summary>
         /// Creates a new personal token for the authenticated user.
@@ -151,7 +151,7 @@ namespace Octokit
             string twoFactorAuthenticationCode);
 
         /// <summary>
-        /// Creates a new authorization for the specified OAuth application if an authorization for that application doesn’t already 
+        /// Creates a new authorization for the specified OAuth application if an authorization for that application doesn’t already
         /// exist for the user; otherwise, returns the user’s existing authorization for that application.
         /// </summary>
         /// <remarks>
@@ -175,7 +175,7 @@ namespace Octokit
             NewAuthorization newAuthorization);
 
         /// <summary>
-        /// Creates a new authorization for the specified OAuth application if an authorization for that application doesn’t already 
+        /// Creates a new authorization for the specified OAuth application if an authorization for that application doesn’t already
         /// exist for the user; otherwise, returns the user’s existing authorization for that application.
         /// </summary>
         /// <remarks>
@@ -241,7 +241,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>
         /// This method requires authentication.
-        /// See the <a href="http://developer.github.com/v3/oauth/#update-an-existing-authorization">API 
+        /// See the <a href="http://developer.github.com/v3/oauth/#update-an-existing-authorization">API
         /// documentation</a> for more details.
         /// </remarks>
         /// <param name="id">Id of the <see cref="Authorization"/> to update</param>
@@ -251,14 +251,14 @@ namespace Octokit
         /// </exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The updated <see cref="Authorization"/>.</returns>
-        Task<Authorization> Update(int id, AuthorizationUpdate authorizationUpdate);
+        Task<Authorization> Update(long id, AuthorizationUpdate authorizationUpdate);
 
         /// <summary>
         /// Deletes the specified <see cref="Authorization"/>.
         /// </summary>
         /// <remarks>
         /// This method requires authentication.
-        /// See the <a href="http://developer.github.com/v3/oauth/#delete-an-authorization">API 
+        /// See the <a href="http://developer.github.com/v3/oauth/#delete-an-authorization">API
         /// documentation</a> for more details.
         /// </remarks>
         /// <param name="id">The system-wide Id of the authorization to delete</param>
@@ -267,14 +267,14 @@ namespace Octokit
         /// </exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="Task"/> for the request's execution.</returns>
-        Task Delete(int id);
+        Task Delete(long id);
 
         /// <summary>
         /// Deletes the specified <see cref="Authorization"/>.
         /// </summary>
         /// <remarks>
         /// This method requires authentication.
-        /// See the <a href="http://developer.github.com/v3/oauth/#delete-an-authorization">API 
+        /// See the <a href="http://developer.github.com/v3/oauth/#delete-an-authorization">API
         /// documentation</a> for more details.
         /// </remarks>
         /// <param name="id">The system-wide Id of the authorization to delete</param>
@@ -284,6 +284,6 @@ namespace Octokit
         /// </exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="Task"/> for the request's execution.</returns>
-        Task Delete(int id, string twoFactorAuthenticationCode);
+        Task Delete(long id, string twoFactorAuthenticationCode);
     }
 }

--- a/Octokit/Clients/IDeploymentStatusClient.cs
+++ b/Octokit/Clients/IDeploymentStatusClient.cs
@@ -22,7 +22,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
-        Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, long  deploymentId);
+        Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, long deploymentId);
 
         /// <summary>
         /// Gets all the statuses for the given deployment. Any user with pull access to a repository can
@@ -33,7 +33,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
-        Task<IReadOnlyList<DeploymentStatus>> GetAll(long repositoryId, long  deploymentId);
+        Task<IReadOnlyList<DeploymentStatus>> GetAll(long repositoryId, long deploymentId);
 
         /// <summary>
         /// Gets all the statuses for the given deployment. Any user with pull access to a repository can
@@ -46,7 +46,7 @@ namespace Octokit
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, long  deploymentId, ApiOptions options);
+        Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, long deploymentId, ApiOptions options);
 
         /// <summary>
         /// Gets all the statuses for the given deployment. Any user with pull access to a repository can
@@ -58,7 +58,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<DeploymentStatus>> GetAll(long repositoryId, long  deploymentId, ApiOptions options);
+        Task<IReadOnlyList<DeploymentStatus>> GetAll(long repositoryId, long deploymentId, ApiOptions options);
 
         /// <summary>
         /// Creates a new status for the given deployment. Users with push access can create deployment
@@ -71,7 +71,7 @@ namespace Octokit
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus">The new deployment status to create.</param>
-        Task<DeploymentStatus> Create(string owner, string name, long  deploymentId, NewDeploymentStatus newDeploymentStatus);
+        Task<DeploymentStatus> Create(string owner, string name, long deploymentId, NewDeploymentStatus newDeploymentStatus);
 
         /// <summary>
         /// Creates a new status for the given deployment. Users with push access can create deployment
@@ -83,6 +83,6 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus">The new deployment status to create.</param>
-        Task<DeploymentStatus> Create(long repositoryId, long  deploymentId, NewDeploymentStatus newDeploymentStatus);
+        Task<DeploymentStatus> Create(long repositoryId, long deploymentId, NewDeploymentStatus newDeploymentStatus);
     }
 }

--- a/Octokit/Clients/IDeploymentStatusClient.cs
+++ b/Octokit/Clients/IDeploymentStatusClient.cs
@@ -22,7 +22,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
-        Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, int deploymentId);
+        Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, long  deploymentId);
 
         /// <summary>
         /// Gets all the statuses for the given deployment. Any user with pull access to a repository can
@@ -33,7 +33,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
-        Task<IReadOnlyList<DeploymentStatus>> GetAll(long repositoryId, int deploymentId);
+        Task<IReadOnlyList<DeploymentStatus>> GetAll(long repositoryId, long  deploymentId);
 
         /// <summary>
         /// Gets all the statuses for the given deployment. Any user with pull access to a repository can
@@ -46,7 +46,7 @@ namespace Octokit
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, int deploymentId, ApiOptions options);
+        Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, long  deploymentId, ApiOptions options);
 
         /// <summary>
         /// Gets all the statuses for the given deployment. Any user with pull access to a repository can
@@ -58,7 +58,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<DeploymentStatus>> GetAll(long repositoryId, int deploymentId, ApiOptions options);
+        Task<IReadOnlyList<DeploymentStatus>> GetAll(long repositoryId, long  deploymentId, ApiOptions options);
 
         /// <summary>
         /// Creates a new status for the given deployment. Users with push access can create deployment
@@ -71,7 +71,7 @@ namespace Octokit
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus">The new deployment status to create.</param>
-        Task<DeploymentStatus> Create(string owner, string name, int deploymentId, NewDeploymentStatus newDeploymentStatus);
+        Task<DeploymentStatus> Create(string owner, string name, long  deploymentId, NewDeploymentStatus newDeploymentStatus);
 
         /// <summary>
         /// Creates a new status for the given deployment. Users with push access can create deployment
@@ -83,6 +83,6 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus">The new deployment status to create.</param>
-        Task<DeploymentStatus> Create(long repositoryId, int deploymentId, NewDeploymentStatus newDeploymentStatus);
+        Task<DeploymentStatus> Create(long repositoryId, long  deploymentId, NewDeploymentStatus newDeploymentStatus);
     }
 }

--- a/Octokit/Clients/IMigrationsClient.cs
+++ b/Octokit/Clients/IMigrationsClient.cs
@@ -20,7 +20,7 @@ namespace Octokit
         /// https://developer.github.com/v3/migration/migrations/#start-a-migration
         /// </remarks>
         /// <param name="org">The organization for which to start a migration.</param>
-        /// <param name="migration">Specifies parameters for the migration in a 
+        /// <param name="migration">Specifies parameters for the migration in a
         /// <see cref="StartMigrationRequest"/> object.</param>
         /// <returns>The started migration.</returns>
         Task<Migration> Start(
@@ -63,7 +63,7 @@ namespace Octokit
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         Task<Migration> Get(
             string org,
-            int id);
+            long id);
 
         /// <summary>
         /// Get the migration archive.
@@ -76,7 +76,7 @@ namespace Octokit
         /// <returns>The binary contents of the archive as a byte array.</returns>
         Task<byte[]> GetArchive(
             string org,
-            int id);
+            long id);
 
         /// <summary>
         /// Deletes a previous migration archive.
@@ -89,7 +89,7 @@ namespace Octokit
         /// <returns></returns>
         Task DeleteArchive(
             string org,
-            int id);
+            long id);
 
         /// <summary>
         /// Unlocks a repository that was locked for migration.
@@ -103,7 +103,7 @@ namespace Octokit
         /// <returns></returns>
         Task UnlockRepository(
             string org,
-            int id,
+            long id,
             string repo);
     }
 }

--- a/Octokit/Clients/IOrganizationMembersClient.cs
+++ b/Octokit/Clients/IOrganizationMembersClient.cs
@@ -395,7 +395,7 @@ namespace Octokit
         /// <param name="org">The login for the organization</param>
         /// <param name="invitationId">The unique identifier of the invitation</param>
         /// <returns></returns>
-        Task CancelOrganizationInvitation(string org, int invitationId);
+        Task CancelOrganizationInvitation(string org, long invitationId);
 
         /// <summary>
         /// Returns all <see cref="OrganizationMembership" />s for the current user.

--- a/Octokit/Clients/IProjectCardsClient.cs
+++ b/Octokit/Clients/IProjectCardsClient.cs
@@ -60,7 +60,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The id of the card</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        Task<ProjectCard> Get(int id);
+        Task<ProjectCard> Get(long id);
 
         /// <summary>
         /// Creates a card.
@@ -80,7 +80,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The id of the card</param>
         /// <param name="projectCardUpdate">New values to update the card with</param>
-        Task<ProjectCard> Update(int id, ProjectCardUpdate projectCardUpdate);
+        Task<ProjectCard> Update(long id, ProjectCardUpdate projectCardUpdate);
 
         /// <summary>
         /// Deletes a card.
@@ -89,7 +89,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/projects/#delete-a-project-card">API documentation</a> for more information.
         /// </remarks>
         /// <param name="id">The id of the card</param>
-        Task<bool> Delete(int id);
+        Task<bool> Delete(long id);
 
         /// <summary>
         /// Moves a card.
@@ -99,6 +99,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The id of the card</param>
         /// <param name="position">The position to move the card</param>
-        Task<bool> Move(int id, ProjectCardMove position);
+        Task<bool> Move(long id, ProjectCardMove position);
     }
 }

--- a/Octokit/Clients/IReleasesClient.cs
+++ b/Octokit/Clients/IReleasesClient.cs
@@ -90,7 +90,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="id">The id of the release</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<Release> Get(string owner, string name, int id);
+        Task<Release> Get(string owner, string name, long id);
 
         /// <summary>
         /// Gets a single <see cref="Release"/> for the specified repository.
@@ -113,7 +113,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the release</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<Release> Get(long repositoryId, int id);
+        Task<Release> Get(long repositoryId, long id);
 
         /// <summary>
         /// Gets a single <see cref="Release"/> for the specified repository.
@@ -181,7 +181,7 @@ namespace Octokit
         /// <param name="id">The id of the release</param>
         /// <param name="data">A description of the release to edit</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<Release> Edit(string owner, string name, int id, ReleaseUpdate data);
+        Task<Release> Edit(string owner, string name, long id, ReleaseUpdate data);
 
         /// <summary>
         /// Edits an existing <see cref="Release"/> for the specified repository.
@@ -193,7 +193,7 @@ namespace Octokit
         /// <param name="id">The id of the release</param>
         /// <param name="data">A description of the release to edit</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<Release> Edit(long repositoryId, int id, ReleaseUpdate data);
+        Task<Release> Edit(long repositoryId, long id, ReleaseUpdate data);
 
         /// <summary>
         /// Deletes an existing <see cref="Release"/> for the specified repository.
@@ -205,7 +205,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="id">The id of the release to delete</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task Delete(string owner, string name, int id);
+        Task Delete(string owner, string name, long id);
 
         /// <summary>
         /// Deletes an existing <see cref="Release"/> for the specified repository.
@@ -216,7 +216,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the release to delete</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task Delete(long repositoryId, int id);
+        Task Delete(long repositoryId, long id);
 
         /// <summary>
         /// Gets all <see cref="ReleaseAsset"/> for the specified release of the specified repository.
@@ -228,7 +228,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="id">The id of the <see cref="Release"/>.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(string owner, string name, int id);
+        Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(string owner, string name, long id);
 
         /// <summary>
         /// Gets all <see cref="ReleaseAsset"/> for the specified release of the specified repository.
@@ -239,7 +239,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the <see cref="Release"/>.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(long repositoryId, int id);
+        Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(long repositoryId, long id);
 
         /// <summary>
         /// Gets all <see cref="ReleaseAsset"/> for the specified release of the specified repository.
@@ -252,7 +252,7 @@ namespace Octokit
         /// <param name="id">The id of the <see cref="Release"/>.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(string owner, string name, int id, ApiOptions options);
+        Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(string owner, string name, long id, ApiOptions options);
 
         /// <summary>
         /// Gets all <see cref="ReleaseAsset"/> for the specified release of the specified repository.
@@ -264,7 +264,7 @@ namespace Octokit
         /// <param name="id">The id of the <see cref="Release"/>.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(long repositoryId, int id, ApiOptions options);
+        Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(long repositoryId, long id, ApiOptions options);
 
         /// <summary>
         /// Uploads a <see cref="ReleaseAsset"/> for the specified release.

--- a/Octokit/Clients/IRepositoryInvitationsClient.cs
+++ b/Octokit/Clients/IRepositoryInvitationsClient.cs
@@ -17,20 +17,20 @@ namespace Octokit
         /// </summary>
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/invitations/#accept-a-repository-invitation">API documentation</a> for more information.
-        /// </remarks>        
+        /// </remarks>
         /// <param name="invitationId">The id of the invitation</param>
-        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>        
-        Task<bool> Accept(int invitationId);
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        Task<bool> Accept(long invitationId);
 
         /// <summary>
         /// Decline a repository invitation.
         /// </summary>
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/invitations/#decline-a-repository-invitation">API documentation</a> for more information.
-        /// </remarks>        
+        /// </remarks>
         /// <param name="invitationId">The id of the invitation</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<bool> Decline(int invitationId);
+        Task<bool> Decline(long invitationId);
 
         /// <summary>
         /// Deletes a repository invitation.
@@ -41,14 +41,14 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="invitationId">The id of the invitation</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<bool> Delete(long repositoryId, int invitationId);
+        Task<bool> Delete(long repositoryId, long invitationId);
 
         /// <summary>
         /// Gets all invitations for the current user.
         /// </summary>
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/invitations/#list-a-users-repository-invitations">API documentation</a> for more information.
-        /// </remarks>        
+        /// </remarks>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         Task<IReadOnlyList<RepositoryInvitation>> GetAllForCurrent();
@@ -69,7 +69,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/invitations/#list-invitations-for-a-repository">API documentation</a> for more information.
-        /// </remarks>        
+        /// </remarks>
         /// <param name="repositoryId">The id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         Task<IReadOnlyList<RepositoryInvitation>> GetAllForRepository(long repositoryId);
@@ -79,7 +79,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/invitations/#list-invitations-for-a-repository">API documentation</a> for more information.
-        /// </remarks>        
+        /// </remarks>
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
@@ -95,6 +95,6 @@ namespace Octokit
         /// <param name="invitationId">The id of the invitation</param>
         /// <param name="permissions">The permission for the collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<RepositoryInvitation> Edit(long repositoryId, int invitationId, InvitationUpdate permissions);
+        Task<RepositoryInvitation> Edit(long repositoryId, long invitationId, InvitationUpdate permissions);
     }
 }

--- a/Octokit/Clients/ITeamsClient.cs
+++ b/Octokit/Clients/ITeamsClient.cs
@@ -23,7 +23,7 @@ namespace Octokit
         /// <returns>The <see cref="Team"/> with the given identifier.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
-        Task<Team> Get(int id);
+        Task<Team> Get(long id);
 
         /// <summary>
         /// Returns all <see cref="Team" />s for the current org.
@@ -66,7 +66,7 @@ namespace Octokit
         /// https://developer.github.com/v3/orgs/teams/#list-child-teams
         /// </remarks>
         /// <param name="id">The team identifier</param>
-        Task<IReadOnlyList<Team>> GetAllChildTeams(int id);
+        Task<IReadOnlyList<Team>> GetAllChildTeams(long id);
 
         /// <summary>
         /// Returns all child teams of the given team.
@@ -76,26 +76,26 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The team identifier</param>
         /// <param name="options">Options to change API behaviour.</param>
-        Task<IReadOnlyList<Team>> GetAllChildTeams(int id, ApiOptions options);
+        Task<IReadOnlyList<Team>> GetAllChildTeams(long id, ApiOptions options);
 
         /// <summary>
-        /// Returns all members of the given team. 
+        /// Returns all members of the given team.
         /// </summary>
         /// <remarks>
         /// https://developer.github.com/v3/orgs/teams/#list-team-members
         /// </remarks>
         /// <param name="id">The team identifier</param>
-        Task<IReadOnlyList<User>> GetAllMembers(int id);
+        Task<IReadOnlyList<User>> GetAllMembers(long id);
 
         /// <summary>
-        /// Returns all members of the given team. 
+        /// Returns all members of the given team.
         /// </summary>
         /// <remarks>
         /// https://developer.github.com/v3/orgs/teams/#list-team-members
         /// </remarks>
         /// <param name="id">The team identifier</param>
         /// <param name="options">Options to change API behaviour.</param>
-        Task<IReadOnlyList<User>> GetAllMembers(int id, ApiOptions options);
+        Task<IReadOnlyList<User>> GetAllMembers(long id, ApiOptions options);
 
         /// <summary>
         /// Returns all members with the specified role in the given team of the given role.
@@ -105,7 +105,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The team identifier</param>
         /// <param name="request">The request filter</param>
-        Task<IReadOnlyList<User>> GetAllMembers(int id, TeamMembersRequest request);
+        Task<IReadOnlyList<User>> GetAllMembers(long id, TeamMembersRequest request);
 
         /// <summary>
         /// Returns all members with the specified role in the given team of the given role.
@@ -116,7 +116,7 @@ namespace Octokit
         /// <param name="id">The team identifier</param>
         /// <param name="request">The request filter</param>
         /// <param name="options">Options to change API behaviour.</param>
-        Task<IReadOnlyList<User>> GetAllMembers(int id, TeamMembersRequest request, ApiOptions options);
+        Task<IReadOnlyList<User>> GetAllMembers(long id, TeamMembersRequest request, ApiOptions options);
 
         /// <summary>
         /// Returns newly created <see cref="Team" /> for the current org.
@@ -130,7 +130,7 @@ namespace Octokit
         /// To edit a team, the authenticated user must either be an organization owner or a team maintainer
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#update-a-team">API documentation</a> 
+        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#update-a-team">API documentation</a>
         /// for more information.
         /// </remarks>
         /// <returns>updated <see cref="Team" /> for the current org</returns>
@@ -143,19 +143,19 @@ namespace Octokit
         /// <see cref="Update(string, string, UpdateTeam)"/>.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#update-a-team-legacy">API documentation</a> 
+        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#update-a-team-legacy">API documentation</a>
         /// for more information.
         /// </remarks>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>Updated <see cref="Team"/></returns>
-        Task<Team> Update(int id, UpdateTeam team);
+        Task<Team> Update(long id, UpdateTeam team);
 
         /// <summary>
         /// To delete a team, the authenticated user must be an organization owner or team maintainer.
         /// If you are an organization owner, deleting a parent team will delete all of its child teams as well.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#delete-a-team">API documentation</a> 
+        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#delete-a-team">API documentation</a>
         /// </remarks>
         /// <param name="org">The organization name. The name is not case sensitive.</param>
         /// <param name="teamSlug">The slug of the team name.</param>
@@ -167,15 +167,15 @@ namespace Octokit
         /// Delete a team - must have owner permissions to do this
         /// This endpoint route is deprecated and will be removed from the Teams API.
         /// We recommend migrating your existing code to use the new Delete a team endpoint.
-        /// <see cref="Delete(string, string)"/>.
+        /// <see cref="Delete(long)"/>.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#delete-a-team-legacy">API documentation</a> 
+        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#delete-a-team-legacy">API documentation</a>
         /// </remarks>
         /// <param name="id">The unique identifier of the team.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns></returns>
-        Task Delete(int id);
+        Task Delete(long id);
 
         /// <summary>
         /// Adds a <see cref="User"/> to a <see cref="Team"/>.
@@ -186,7 +186,7 @@ namespace Octokit
         /// <param name="id">The team identifier.</param>
         /// <param name="login">The user to add to the team.</param>
         /// <param name="request">Additional parameters for the request</param>
-        Task<TeamMembershipDetails> AddOrEditMembership(int id, string login, UpdateTeamMembership request);
+        Task<TeamMembershipDetails> AddOrEditMembership(long id, string login, UpdateTeamMembership request);
 
         /// <summary>
         /// Removes a <see cref="User"/> from a <see cref="Team"/>.
@@ -197,10 +197,10 @@ namespace Octokit
         /// <param name="id">The team identifier.</param>
         /// <param name="login">The user to remove from the team.</param>
         /// <returns><see langword="true"/> if the user was removed from the team; <see langword="false"/> otherwise.</returns>
-        Task<bool> RemoveMembership(int id, string login);
+        Task<bool> RemoveMembership(long id, string login);
 
         /// <summary>
-        /// Gets whether the user with the given <paramref name="login"/> 
+        /// Gets whether the user with the given <paramref name="login"/>
         /// is a member of the team with the given <paramref name="id"/>.
         /// A <see cref="NotFoundException"/> is thrown if the user is not a member.
         /// </summary>
@@ -209,7 +209,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The team to check.</param>
         /// <param name="login">The user to check.</param>
-        Task<TeamMembershipDetails> GetMembershipDetails(int id, string login);
+        Task<TeamMembershipDetails> GetMembershipDetails(long id, string login);
 
         /// <summary>
         /// Returns all team's repositories.
@@ -217,7 +217,7 @@ namespace Octokit
         /// <param name="id">Team Id to list repos.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The team's repositories</returns>
-        Task<IReadOnlyList<Repository>> GetAllRepositories(int id);
+        Task<IReadOnlyList<Repository>> GetAllRepositories(long id);
 
         /// <summary>
         /// Returns all team's repositories.
@@ -226,14 +226,14 @@ namespace Octokit
         /// <param name="options">Options to change API behaviour.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The team's repositories</returns>
-        Task<IReadOnlyList<Repository>> GetAllRepositories(int id, ApiOptions options);
+        Task<IReadOnlyList<Repository>> GetAllRepositories(long id, ApiOptions options);
 
         /// <summary>
         /// Add a repository to the team
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns></returns>
-        Task<bool> AddRepository(int id, string organization, string repoName);
+        Task<bool> AddRepository(long id, string organization, string repoName);
 
         /// <summary>
         /// Add a repository to the team
@@ -244,14 +244,14 @@ namespace Octokit
         /// <param name="permission">The permission to grant the team on this repository.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns></returns>
-        Task<bool> AddRepository(int id, string organization, string repoName, RepositoryPermissionRequest permission);
+        Task<bool> AddRepository(long id, string organization, string repoName, RepositoryPermissionRequest permission);
 
         /// <summary>
         /// Remove a repository from the team
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns></returns>
-        Task<bool> RemoveRepository(int id, string organization, string repoName);
+        Task<bool> RemoveRepository(long id, string organization, string repoName);
 
         /// <summary>
         /// Gets whether or not the given repository is managed by the given team.
@@ -263,7 +263,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/orgs/teams/#get-team-repo">API documentation</a> for more information.
         /// </remarks>
         /// <returns><see langword="true"/> if the repository is managed by the given team; <see langword="false"/> otherwise.</returns>
-        Task<bool> IsRepositoryManagedByTeam(int id, string owner, string repo);
+        Task<bool> IsRepositoryManagedByTeam(long id, string owner, string repo);
 
         /// <summary>
         /// List all pending invitations for the given team.
@@ -274,7 +274,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The team identifier</param>
         /// <returns></returns>
-        Task<IReadOnlyList<OrganizationMembershipInvitation>> GetAllPendingInvitations(int id);
+        Task<IReadOnlyList<OrganizationMembershipInvitation>> GetAllPendingInvitations(long id);
 
         /// <summary>
         /// List all pending invitations for the given team.
@@ -286,7 +286,7 @@ namespace Octokit
         /// <param name="id">The team identifier</param>
         /// <param name="options">Options to change API behaviour.</param>
         /// <returns></returns>
-        Task<IReadOnlyList<OrganizationMembershipInvitation>> GetAllPendingInvitations(int id, ApiOptions options);
+        Task<IReadOnlyList<OrganizationMembershipInvitation>> GetAllPendingInvitations(long id, ApiOptions options);
 
         /// <summary>
         /// Checks whether a team has admin, push, maintain, triage, or pull permission for a repository.
@@ -331,9 +331,9 @@ namespace Octokit
         /// <param name="owner">The account owner of the repository. The name is not case sensitive.</param>
         /// <param name="repo">The name of the repository. The name is not case sensitive.</param>
         /// <param name="permission">
-        /// The permission to grant the team on this repository. We accept the following permissions to be set: 
-        /// pull, triage, push, maintain, admin and you can also specify a custom repository role name, if the 
-        /// owning organization has defined any. If no permission is specified, the team's permission attribute 
+        /// The permission to grant the team on this repository. We accept the following permissions to be set:
+        /// pull, triage, push, maintain, admin and you can also specify a custom repository role name, if the
+        /// owning organization has defined any. If no permission is specified, the team's permission attribute
         /// will be used to determine what permission to grant the team on this repository
         /// </param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
@@ -354,7 +354,7 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns></returns>
         Task RemoveRepositoryFromATeam(string org, string teamSlug, string owner, string repo);
-        
+
         /// <summary>
         /// Get a team by slug name
         /// </summary>

--- a/Octokit/Clients/IUserGpgKeysClient.cs
+++ b/Octokit/Clients/IUserGpgKeysClient.cs
@@ -45,7 +45,7 @@ namespace Octokit
         /// <returns>The <see cref="GpgKey"/> for the specified Id.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
-        Task<GpgKey> Get(int id);
+        Task<GpgKey> Get(long id);
 
         /// <summary>
         /// Creates a new <see cref="GpgKey"/> for the authenticated user.
@@ -66,6 +66,6 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/users/gpg_keys/#delete-a-gpg-key">API documentation</a> for more information.
         /// </remarks>
         /// <returns></returns>
-        Task Delete(int id);
+        Task Delete(long id);
     }
 }

--- a/Octokit/Clients/IUserKeysClient.cs
+++ b/Octokit/Clients/IUserKeysClient.cs
@@ -63,7 +63,7 @@ namespace Octokit
         /// <param name="id">The Id of the SSH key</param>
         /// <returns>View extended details for a single public key.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        Task<PublicKey> Get(int id);
+        Task<PublicKey> Get(long id);
 
         /// <summary>
         /// Create a public key <see cref="NewPublicKey"/>.
@@ -83,6 +83,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The id of the key to delete</param>
         /// <returns>Removes a public key.</returns>
-        Task Delete(int id);
+        Task Delete(long id);
     }
 }

--- a/Octokit/Clients/MigrationsClient.cs
+++ b/Octokit/Clients/MigrationsClient.cs
@@ -85,7 +85,7 @@ namespace Octokit
         /// <param name="id">Migration Id of the organization.</param>
         /// <returns>A <see cref="Migration"/> object representing the state of migration.</returns>
         [ManualRoute("GET", "/orgs/{org}/migrations/{id}")]
-        public async Task<Migration> Get(string org, int id)
+        public async Task<Migration> Get(string org, long id)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
 
@@ -104,7 +104,7 @@ namespace Octokit
         /// <param name="id">The Id of the migration.</param>
         /// <returns>The binary contents of the archive as a byte array.</returns>
         [ManualRoute("GET", "/orgs/{org}/migrations/{id}/archive")]
-        public async Task<byte[]> GetArchive(string org, int id)
+        public async Task<byte[]> GetArchive(string org, long id)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
 
@@ -124,7 +124,7 @@ namespace Octokit
         /// <param name="id">The Id of the migration.</param>
         /// <returns></returns>
         [ManualRoute("DELETE", "/orgs/{org}/migrations/{id}/archive")]
-        public Task DeleteArchive(string org, int id)
+        public Task DeleteArchive(string org, long id)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
 
@@ -144,7 +144,7 @@ namespace Octokit
         /// <param name="repo">The repo to unlock.</param>
         /// <returns></returns>
         [ManualRoute("GET", "/orgs/{org}/migrations/{id}/repos/{name}/lock")]
-        public Task UnlockRepository(string org, int id, string repo)
+        public Task UnlockRepository(string org, long id, string repo)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
             Ensure.ArgumentNotNullOrEmptyString(repo, nameof(repo));

--- a/Octokit/Clients/OrganizationMembersClient.cs
+++ b/Octokit/Clients/OrganizationMembersClient.cs
@@ -637,7 +637,7 @@ namespace Octokit
         /// <param name="invitationId">The unique identifier of the invitation</param>
         /// <returns></returns>
         [ManualRoute("DELETE", "/orgs/{org}/invitations/{invitation_id}")]
-        public Task CancelOrganizationInvitation(string org, int invitationId)
+        public Task CancelOrganizationInvitation(string org, long invitationId)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
             Ensure.ArgumentNotNullOrDefault(invitationId, nameof(invitationId));

--- a/Octokit/Clients/ProjectCardsClient.cs
+++ b/Octokit/Clients/ProjectCardsClient.cs
@@ -88,7 +88,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="cardId">The id of the card</param>
         [ManualRoute("GET", "/projects/columns/cards/{card_id}")]
-        public Task<ProjectCard> Get(int cardId)
+        public Task<ProjectCard> Get(long cardId)
         {
             return ApiConnection.Get<ProjectCard>(ApiUrls.ProjectCard(cardId), null);
         }
@@ -118,7 +118,7 @@ namespace Octokit
         /// <param name="cardId">The id of the card</param>
         /// <param name="projectCardUpdate">New values to update the card with</param>
         [ManualRoute("GET", "/projects/columns/cards/{card_id}")]
-        public Task<ProjectCard> Update(int cardId, ProjectCardUpdate projectCardUpdate)
+        public Task<ProjectCard> Update(long cardId, ProjectCardUpdate projectCardUpdate)
         {
             Ensure.ArgumentNotNull(projectCardUpdate, nameof(projectCardUpdate));
 
@@ -133,7 +133,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="cardId">The id of the card</param>
         [ManualRoute("DELETE", "/projects/columns/cards/{card_id}")]
-        public async Task<bool> Delete(int cardId)
+        public async Task<bool> Delete(long cardId)
         {
             var endpoint = ApiUrls.ProjectCard(cardId);
 
@@ -157,7 +157,7 @@ namespace Octokit
         /// <param name="cardId">The id of the card</param>
         /// <param name="position">The position to move the card</param>
         [ManualRoute("POST", "/projects/columns/cards/{card_id}/moves")]
-        public async Task<bool> Move(int cardId, ProjectCardMove position)
+        public async Task<bool> Move(long cardId, ProjectCardMove position)
         {
             Ensure.ArgumentNotNull(position, nameof(position));
 

--- a/Octokit/Clients/ReleasesClient.cs
+++ b/Octokit/Clients/ReleasesClient.cs
@@ -141,7 +141,7 @@ namespace Octokit
         /// <param name="releaseId">The id of the release</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         [ManualRoute("GET", "/repos/{owner}/{repo}/releases/{release_id}")]
-        public Task<Release> Get(string owner, string name, int releaseId)
+        public Task<Release> Get(string owner, string name, long releaseId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -181,7 +181,7 @@ namespace Octokit
         /// <param name="releaseId">The id of the release</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         [ManualRoute("GET", "/repositories/{id}/releases/{id}")]
-        public Task<Release> Get(long repositoryId, int releaseId)
+        public Task<Release> Get(long repositoryId, long releaseId)
         {
             var endpoint = ApiUrls.Releases(repositoryId, releaseId);
             return ApiConnection.Get<Release>(endpoint);
@@ -290,7 +290,7 @@ namespace Octokit
         /// <param name="data">A description of the release to edit</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         [ManualRoute("PATCH", "/repos/{owner}/{repo}/releases/{release_id}")]
-        public Task<Release> Edit(string owner, string name, int releaseId, ReleaseUpdate data)
+        public Task<Release> Edit(string owner, string name, long releaseId, ReleaseUpdate data)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -311,7 +311,7 @@ namespace Octokit
         /// <param name="data">A description of the release to edit</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         [ManualRoute("PATCH", "/repositories/{id}/releases/{id}")]
-        public Task<Release> Edit(long repositoryId, int releaseId, ReleaseUpdate data)
+        public Task<Release> Edit(long repositoryId, long releaseId, ReleaseUpdate data)
         {
             Ensure.ArgumentNotNull(data, nameof(data));
 
@@ -330,7 +330,7 @@ namespace Octokit
         /// <param name="releaseId">The id of the release to delete</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         [ManualRoute("DELETE", "/repos/{owner}/{repo}/releases/{release_id}")]
-        public Task Delete(string owner, string name, int releaseId)
+        public Task Delete(string owner, string name, long releaseId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -349,7 +349,7 @@ namespace Octokit
         /// <param name="releaseId">The id of the release to delete</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         [ManualRoute("DELETE", "/repositories/{id}/releases/{id}")]
-        public Task Delete(long repositoryId, int releaseId)
+        public Task Delete(long repositoryId, long releaseId)
         {
             var endpoint = ApiUrls.Releases(repositoryId, releaseId);
             return ApiConnection.Delete(endpoint);
@@ -366,7 +366,7 @@ namespace Octokit
         /// <param name="releaseId">The id of the <see cref="Release"/>.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         [ManualRoute("GET", "/repos/{owner}/{repo}/releases/{release_id}/assets")]
-        public Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(string owner, string name, int releaseId)
+        public Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(string owner, string name, long releaseId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -384,7 +384,7 @@ namespace Octokit
         /// <param name="releaseId">The id of the <see cref="Release"/>.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         [ManualRoute("GET", "/repositories/{id}/releases/{id}/assets")]
-        public Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(long repositoryId, int releaseId)
+        public Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(long repositoryId, long releaseId)
         {
             return GetAllAssets(repositoryId, releaseId, ApiOptions.None);
         }
@@ -401,7 +401,7 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         [ManualRoute("GET", "/repos/{owner}/{repo}/releases/{release_id}/assets")]
-        public Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(string owner, string name, int releaseId, ApiOptions options)
+        public Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(string owner, string name, long releaseId, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -422,7 +422,7 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         [ManualRoute("GET", "/repositories/{id}/releases/{id}/assets")]
-        public Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(long repositoryId, int releaseId, ApiOptions options)
+        public Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(long repositoryId, long releaseId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 

--- a/Octokit/Clients/RepositoryInvitationsClient.cs
+++ b/Octokit/Clients/RepositoryInvitationsClient.cs
@@ -21,7 +21,7 @@ namespace Octokit
         /// <param name="invitationId">The id of the invitation</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         [ManualRoute("PATCH", "/user/repository_invitations/{invitation_id}")]
-        public async Task<bool> Accept(int invitationId)
+        public async Task<bool> Accept(long invitationId)
         {
             var endpoint = ApiUrls.UserInvitations(invitationId);
 
@@ -45,7 +45,7 @@ namespace Octokit
         /// <param name="invitationId">The id of the invitation</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         [ManualRoute("DELETE", "/user/repository_invitations/{invitation_id}")]
-        public async Task<bool> Decline(int invitationId)
+        public async Task<bool> Decline(long invitationId)
         {
             var endpoint = ApiUrls.UserInvitations(invitationId);
 
@@ -70,7 +70,7 @@ namespace Octokit
         /// <param name="invitationId">The id of the invitation</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         [ManualRoute("DELETE", "/repos/:owner/:repo/invitations/{invitation_id}")]
-        public async Task<bool> Delete(long repositoryId, int invitationId)
+        public async Task<bool> Delete(long repositoryId, long invitationId)
         {
             var endpoint = ApiUrls.RepositoryInvitations(repositoryId, invitationId);
 
@@ -154,7 +154,7 @@ namespace Octokit
         /// <param name="permissions">The permission for the collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         [ManualRoute("PATCH", "/repositories/{id}/invitations/{invitation_id}")]
-        public Task<RepositoryInvitation> Edit(long repositoryId, int invitationId, InvitationUpdate permissions)
+        public Task<RepositoryInvitation> Edit(long repositoryId, long invitationId, InvitationUpdate permissions)
         {
             Ensure.ArgumentNotNull(permissions, nameof(permissions));
 

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -28,12 +28,12 @@ namespace Octokit
         /// <remarks>
         /// https://developer.github.com/v3/orgs/teams/#get-team
         /// </remarks>
-        /// <param name="teamSlug">The team identifier.</param>
+        /// <param name="teamId">The team identifier.</param>
         /// <returns>The <see cref="Team"/> with the given identifier.</returns>
         [ManualRoute("GET", "/teams/{team_id}")]
-        public Task<Team> Get(int teamSlug)
+        public Task<Team> Get(long teamId)
         {
-            var endpoint = ApiUrls.Teams(teamSlug);
+            var endpoint = ApiUrls.Teams(teamId);
 
             return ApiConnection.Get<Team>(endpoint);
         }
@@ -97,14 +97,14 @@ namespace Octokit
         /// <summary>
         /// Returns all child teams of the given team.
         /// </summary>
-        /// <param name="teamSlug">The team identifier</param>
+        /// <param name="teamId">The team identifier</param>
         /// <remarks>
         /// https://developer.github.com/v3/orgs/teams/#list-child-teams
         /// </remarks>
         [ManualRoute("GET", "/teams{id}/teams")]
-        public Task<IReadOnlyList<Team>> GetAllChildTeams(int teamSlug)
+        public Task<IReadOnlyList<Team>> GetAllChildTeams(long teamId)
         {
-            return GetAllChildTeams(teamSlug, ApiOptions.None);
+            return GetAllChildTeams(teamId, ApiOptions.None);
         }
 
         /// <summary>
@@ -113,14 +113,14 @@ namespace Octokit
         /// <remarks>
         /// https://developer.github.com/v3/orgs/teams/#list-child-teams
         /// </remarks>
-        /// <param name="teamSlug">The team identifier</param>
+        /// <param name="teamId">The team identifier</param>
         /// <param name="options">Options to change API behaviour.</param>
         [ManualRoute("GET", "/teams{id}/teams")]
-        public Task<IReadOnlyList<Team>> GetAllChildTeams(int teamSlug, ApiOptions options)
+        public Task<IReadOnlyList<Team>> GetAllChildTeams(long teamId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            var endpoint = ApiUrls.TeamChildTeams(teamSlug);
+            var endpoint = ApiUrls.TeamChildTeams(teamId);
 
             return ApiConnection.GetAll<Team>(endpoint, options);
         }
@@ -131,11 +131,11 @@ namespace Octokit
         /// <remarks>
         /// https://developer.github.com/v3/orgs/teams/#list-team-members
         /// </remarks>
-        /// <param name="teamSlug">The team identifier</param>
+        /// <param name="teamId">The team identifier</param>
         [ManualRoute("GET", "/teams{id}/members")]
-        public Task<IReadOnlyList<User>> GetAllMembers(int teamSlug)
+        public Task<IReadOnlyList<User>> GetAllMembers(long teamId)
         {
-            return GetAllMembers(teamSlug, ApiOptions.None);
+            return GetAllMembers(teamId, ApiOptions.None);
         }
 
         /// <summary>
@@ -144,14 +144,14 @@ namespace Octokit
         /// <remarks>
         /// https://developer.github.com/v3/orgs/teams/#list-team-members
         /// </remarks>
-        /// <param name="teamSlug">The team identifier</param>
+        /// <param name="teamId">The team identifier</param>
         /// <param name="options">Options to change API behaviour.</param>
         [ManualRoute("GET", "/teams{id}/members")]
-        public Task<IReadOnlyList<User>> GetAllMembers(int teamSlug, ApiOptions options)
+        public Task<IReadOnlyList<User>> GetAllMembers(long teamId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            var endpoint = ApiUrls.TeamMembers(teamSlug);
+            var endpoint = ApiUrls.TeamMembers(teamId);
 
             return ApiConnection.GetAll<User>(endpoint, options);
         }
@@ -162,14 +162,14 @@ namespace Octokit
         /// <remarks>
         /// https://developer.github.com/v3/orgs/teams/#list-team-members
         /// </remarks>
-        /// <param name="teamSlug">The team identifier</param>
+        /// <param name="teamId">The team identifier</param>
         /// <param name="request">The request filter</param>
         [ManualRoute("GET", "/teams{id}/members")]
-        public Task<IReadOnlyList<User>> GetAllMembers(int teamSlug, TeamMembersRequest request)
+        public Task<IReadOnlyList<User>> GetAllMembers(long teamId, TeamMembersRequest request)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
 
-            return GetAllMembers(teamSlug, request, ApiOptions.None);
+            return GetAllMembers(teamId, request, ApiOptions.None);
         }
 
         /// <summary>
@@ -178,36 +178,36 @@ namespace Octokit
         /// <remarks>
         /// https://developer.github.com/v3/orgs/teams/#list-team-members
         /// </remarks>
-        /// <param name="teamSlug">The team identifier</param>
+        /// <param name="teamId">The team identifier</param>
         /// <param name="request">The request filter</param>
         /// <param name="options">Options to change API behaviour.</param>
         [ManualRoute("GET", "/teams{id}/members")]
-        public Task<IReadOnlyList<User>> GetAllMembers(int teamSlug, TeamMembersRequest request, ApiOptions options)
+        public Task<IReadOnlyList<User>> GetAllMembers(long teamId, TeamMembersRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            var endpoint = ApiUrls.TeamMembers(teamSlug);
+            var endpoint = ApiUrls.TeamMembers(teamId);
 
             return ApiConnection.GetAll<User>(endpoint, request.ToParametersDictionary(), options);
         }
 
         /// <summary>
         /// Gets whether the user with the given <paramref name="login"/>
-        /// is a member of the team with the given <paramref name="teamSlug"/>.
+        /// is a member of the team with the given <paramref name="teamId"/>.
         /// A <see cref="NotFoundException"/> is thrown if the user is not a member.
         /// </summary>
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/orgs/teams/#get-team-membership">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="teamSlug">The team to check.</param>
+        /// <param name="teamId">The team to check.</param>
         /// <param name="login">The user to check.</param>
         [ManualRoute("GET", "/teams/{team_id}/memberships/{username}")]
-        public Task<TeamMembershipDetails> GetMembershipDetails(int teamSlug, string login)
+        public Task<TeamMembershipDetails> GetMembershipDetails(long teamId, string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
 
-            var endpoint = ApiUrls.TeamMember(teamSlug, login);
+            var endpoint = ApiUrls.TeamMember(teamId, login);
 
             return ApiConnection.Get<TeamMembershipDetails>(endpoint);
         }
@@ -232,18 +232,18 @@ namespace Octokit
         /// To edit a team, the authenticated user must either be an organization owner or a team maintainer
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#update-a-team">API documentation</a> 
+        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#update-a-team">API documentation</a>
         /// for more information.
         /// </remarks>
         /// <returns>updated <see cref="Team" /> for the current org</returns>
         [ManualRoute("PATCH", "/orgs/{org}/teams/{team_slug}")]
-        public Task<Team> Update(string org, string teamSlug, UpdateTeam team)
+        public Task<Team> Update(string org, string teamId, UpdateTeam team)
         {
             Ensure.ArgumentNotNull(org, nameof(org));
-            Ensure.ArgumentNotNull(teamSlug, nameof(teamSlug));
+            Ensure.ArgumentNotNull(teamId, nameof(teamId));
             Ensure.ArgumentNotNull(team, nameof(team));
 
-            var endpoint = ApiUrls.TeamsByOrganizationAndSlug(org, teamSlug);
+            var endpoint = ApiUrls.TeamsByOrganizationAndSlug(org, teamId);
             return ApiConnection.Patch<Team>(endpoint, team);
         }
 
@@ -254,17 +254,17 @@ namespace Octokit
         /// <see cref="Update(string, string, UpdateTeam)"/>.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#update-a-team-legacy">API documentation</a> 
+        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#update-a-team-legacy">API documentation</a>
         /// for more information.
         /// </remarks>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>Updated <see cref="Team"/></returns>
         [ManualRoute("PATCH", "/teams/{team_id}")]
-        public Task<Team> Update(int teamSlug, UpdateTeam team)
+        public Task<Team> Update(long teamId, UpdateTeam team)
         {
             Ensure.ArgumentNotNull(team, nameof(team));
 
-            var endpoint = ApiUrls.Teams(teamSlug);
+            var endpoint = ApiUrls.Teams(teamId);
             return ApiConnection.Patch<Team>(endpoint, team);
         }
 
@@ -273,19 +273,19 @@ namespace Octokit
         /// If you are an organization owner, deleting a parent team will delete all of its child teams as well.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#delete-a-team">API documentation</a> 
+        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#delete-a-team">API documentation</a>
         /// </remarks>
         /// <param name="org">The organization name. The name is not case sensitive.</param>
-        /// <param name="teamSlug">The slug of the team name.</param>
+        /// <param name="teamId">The slug of the team name.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns></returns>
         [ManualRoute("DELETE", "/orgs/{org}/teams/{team_slug}")]
-        public Task Delete(string org, string teamSlug)
+        public Task Delete(string org, string teamId)
         {
             Ensure.ArgumentNotNull(org, nameof(org));
-            Ensure.ArgumentNotNull(teamSlug, nameof(teamSlug));
+            Ensure.ArgumentNotNull(teamId, nameof(teamId));
 
-            var endpoint = ApiUrls.TeamsByOrganizationAndSlug(org, teamSlug);
+            var endpoint = ApiUrls.TeamsByOrganizationAndSlug(org, teamId);
 
             return ApiConnection.Delete(endpoint);
         }
@@ -297,15 +297,15 @@ namespace Octokit
         /// <see cref="Delete(string, string)"/>.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#delete-a-team-legacy">API documentation</a> 
+        /// See the <a href="https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#delete-a-team-legacy">API documentation</a>
         /// </remarks>
-        /// <param name="teamSlug">The unique identifier of the team.</param>
+        /// <param name="teamId">The unique identifier of the team.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns></returns>
         [ManualRoute("DELETE", "/teams/{team_id}")]
-        public Task Delete(int teamSlug)
+        public Task Delete(long teamId)
         {
-            var endpoint = ApiUrls.Teams(teamSlug);
+            var endpoint = ApiUrls.Teams(teamId);
 
             return ApiConnection.Delete(endpoint);
         }
@@ -316,16 +316,16 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/orgs/teams/#add-or-update-team-membership">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="teamSlug">The team identifier.</param>
+        /// <param name="teamId">The team identifier.</param>
         /// <param name="login">The user to add to the team.</param>
         /// <param name="request">Additional parameters for the request</param>
         [ManualRoute("PUT", "/teams/{team_id}/memberships/{username}")]
-        public Task<TeamMembershipDetails> AddOrEditMembership(int teamSlug, string login, UpdateTeamMembership request)
+        public Task<TeamMembershipDetails> AddOrEditMembership(long teamId, string login, UpdateTeamMembership request)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
             Ensure.ArgumentNotNull(request, nameof(request));
 
-            var endpoint = ApiUrls.TeamMember(teamSlug, login);
+            var endpoint = ApiUrls.TeamMember(teamId, login);
 
             return ApiConnection.Put<TeamMembershipDetails>(endpoint, request);
         }
@@ -336,15 +336,15 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/orgs/teams/#remove-team-member">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="teamSlug">The team identifier.</param>
+        /// <param name="teamId">The team identifier.</param>
         /// <param name="login">The user to remove from the team.</param>
         /// <returns><see langword="true"/> if the user was removed from the team; <see langword="false"/> otherwise.</returns>
         [ManualRoute("DELETE", "/teams/{team_id}/memberships/{username}")]
-        public async Task<bool> RemoveMembership(int teamSlug, string login)
+        public async Task<bool> RemoveMembership(long teamId, string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
 
-            var endpoint = ApiUrls.TeamMember(teamSlug, login);
+            var endpoint = ApiUrls.TeamMember(teamId, login);
 
             try
             {
@@ -361,28 +361,28 @@ namespace Octokit
         /// <summary>
         /// Returns all team's repositories.
         /// </summary>
-        /// <param name="teamSlug">Team Id.</param>
+        /// <param name="teamId">Team Id.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The team's repositories</returns>
         [ManualRoute("GET", "/teams/{team_id}/repos")]
-        public Task<IReadOnlyList<Repository>> GetAllRepositories(int teamSlug)
+        public Task<IReadOnlyList<Repository>> GetAllRepositories(long teamId)
         {
-            return GetAllRepositories(teamSlug, ApiOptions.None);
+            return GetAllRepositories(teamId, ApiOptions.None);
         }
 
         /// <summary>
         /// Returns all team's repositories.
         /// </summary>
-        /// <param name="teamSlug">Team Id.</param>
+        /// <param name="teamId">Team Id.</param>
         /// <param name="options">Options to change API behaviour.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The team's repositories</returns>
         [ManualRoute("GET", "/teams/{team_id}/repos")]
-        public Task<IReadOnlyList<Repository>> GetAllRepositories(int teamSlug, ApiOptions options)
+        public Task<IReadOnlyList<Repository>> GetAllRepositories(long teamId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            var endpoint = ApiUrls.TeamRepositories(teamSlug);
+            var endpoint = ApiUrls.TeamRepositories(teamId);
 
             return ApiConnection.GetAll<Repository>(endpoint, options);
         }
@@ -395,7 +395,7 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns></returns>
         [ManualRoute("PUT", "/teams/{team_id}/repos/{owner}/{repo}")]
-        public async Task<bool> AddRepository(int teamSlug, string organization, string repoName)
+        public async Task<bool> AddRepository(long teamId, string organization, string repoName)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, nameof(organization));
             Ensure.ArgumentNotNullOrEmptyString(repoName, nameof(repoName));
@@ -412,7 +412,7 @@ namespace Octokit
             //
             // Likely will require a breaking change
 
-            var endpoint = ApiUrls.TeamRepository(teamSlug, organization, repoName);
+            var endpoint = ApiUrls.TeamRepository(teamId, organization, repoName);
 
             try
             {
@@ -430,14 +430,14 @@ namespace Octokit
         /// Deprecation Notice: This endpoint route is deprecated and will be removed from the Teams API.
         /// We recommend migrating your existing code to use the new "Add or update team repository permissions" endpoint.
         /// </summary>
-        /// <param name="teamSlug">The team identifier.</param>
+        /// <param name="teamId">The team identifier.</param>
         /// <param name="organization">Org to associate the repo with.</param>
         /// <param name="repoName">Name of the repo.</param>
         /// <param name="permission">The permission to grant the team on this repository.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns></returns>
         [ManualRoute("PUT", "/teams/{team_id}/repos/{owner}/{repo}")]
-        public async Task<bool> AddRepository(int teamSlug, string organization, string repoName, RepositoryPermissionRequest permission)
+        public async Task<bool> AddRepository(long teamId, string organization, string repoName, RepositoryPermissionRequest permission)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, nameof(organization));
             Ensure.ArgumentNotNullOrEmptyString(repoName, nameof(repoName));
@@ -454,7 +454,7 @@ namespace Octokit
             //
             // Likely will require a breaking change
 
-            var endpoint = ApiUrls.TeamRepository(teamSlug, organization, repoName);
+            var endpoint = ApiUrls.TeamRepository(teamId, organization, repoName);
 
             try
             {
@@ -475,7 +475,7 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns></returns>
         [ManualRoute("DELETE", "/teams/{team_id}/repos/{owner}/{repo}")]
-        public async Task<bool> RemoveRepository(int teamSlug, string organization, string repoName)
+        public async Task<bool> RemoveRepository(long teamId, string organization, string repoName)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, nameof(organization));
             Ensure.ArgumentNotNullOrEmptyString(repoName, nameof(repoName));
@@ -492,7 +492,7 @@ namespace Octokit
             //
             // Likely will require a breaking change
 
-            var endpoint = ApiUrls.TeamRepository(teamSlug, organization, repoName);
+            var endpoint = ApiUrls.TeamRepository(teamId, organization, repoName);
 
             try
             {
@@ -509,7 +509,7 @@ namespace Octokit
         /// <summary>
         /// Gets whether or not the given repository is managed by the given team.
         /// </summary>
-        /// <param name="teamSlug">The team identifier</param>
+        /// <param name="teamId">The team identifier</param>
         /// <param name="owner">Owner of the org the team is associated with.</param>
         /// <param name="repo">Name of the repo.</param>
         /// <remarks>
@@ -517,12 +517,12 @@ namespace Octokit
         /// </remarks>
         /// <returns><see langword="true"/> if the repository is managed by the given team; <see langword="false"/> otherwise.</returns>
         [ManualRoute("GET", "/teams/{team_id}/repos/{owner}/{name}")]
-        public async Task<bool> IsRepositoryManagedByTeam(int teamSlug, string owner, string repo)
+        public async Task<bool> IsRepositoryManagedByTeam(long teamId, string owner, string repo)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(repo, nameof(repo));
 
-            var endpoint = ApiUrls.TeamRepository(teamSlug, owner, repo);
+            var endpoint = ApiUrls.TeamRepository(teamId, owner, repo);
 
             try
             {
@@ -542,14 +542,14 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/orgs/teams/#list-pending-team-invitations">API Documentation</a>
         /// for more information.
         /// </remarks>
-        /// <param name="teamSlug">The team identifier</param>
+        /// <param name="teamId">The team identifier</param>
         /// <returns></returns>
         [ManualRoute("GET", "/teams/{team_id}/invitations")]
-        public Task<IReadOnlyList<OrganizationMembershipInvitation>> GetAllPendingInvitations(int teamSlug)
+        public Task<IReadOnlyList<OrganizationMembershipInvitation>> GetAllPendingInvitations(long teamId)
         {
-            Ensure.ArgumentNotNull(teamSlug, nameof(teamSlug));
+            Ensure.ArgumentNotNull(teamId, nameof(teamId));
 
-            return GetAllPendingInvitations(teamSlug, ApiOptions.None);
+            return GetAllPendingInvitations(teamId, ApiOptions.None);
         }
 
         /// <summary>
@@ -559,13 +559,13 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/orgs/teams/#list-pending-team-invitations">API Documentation</a>
         /// for more information.
         /// </remarks>
-        /// <param name="teamSlug">The team identifier</param>
+        /// <param name="teamId">The team identifier</param>
         /// <param name="options">Options to change API behaviour</param>
         /// <returns></returns>
         [ManualRoute("GET", "/teams/{team_id}/invitations")]
-        public Task<IReadOnlyList<OrganizationMembershipInvitation>> GetAllPendingInvitations(int teamSlug, ApiOptions options)
+        public Task<IReadOnlyList<OrganizationMembershipInvitation>> GetAllPendingInvitations(long teamId, ApiOptions options)
         {
-            return ApiConnection.GetAll<OrganizationMembershipInvitation>(ApiUrls.TeamPendingInvitations(teamSlug), null, options);
+            return ApiConnection.GetAll<OrganizationMembershipInvitation>(ApiUrls.TeamPendingInvitations(teamId), null, options);
         }
 
         /// <summary>
@@ -577,19 +577,19 @@ namespace Octokit
         /// for more information.
         /// </remarks>
         /// <param name="org">The organization name. The name is not case sensitive.</param>
-        /// <param name="teamSlug">The slug of the team name.</param>
+        /// <param name="teamId">The slug of the team name.</param>
         /// <param name="owner">The account owner of the repository. The name is not case sensitive.</param>
         /// <param name="repo">The name of the repository. The name is not case sensitive.</param>
         /// <returns></returns>
         [ManualRoute("GET", "/orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}")]
-        public async Task<bool> CheckTeamPermissionsForARepository(string org, string teamSlug, string owner, string repo)
+        public async Task<bool> CheckTeamPermissionsForARepository(string org, string teamId, string owner, string repo)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
-            Ensure.ArgumentNotNullOrEmptyString(teamSlug, nameof(teamSlug));
+            Ensure.ArgumentNotNullOrEmptyString(teamId, nameof(teamId));
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(repo, nameof(repo));
 
-            var endpoint = ApiUrls.TeamPermissionsForARepository(org, teamSlug, owner, repo);
+            var endpoint = ApiUrls.TeamPermissionsForARepository(org, teamId, owner, repo);
 
             try
             {
@@ -611,20 +611,20 @@ namespace Octokit
         /// for more information.
         /// </remarks>
         /// <param name="org">The organization name. The name is not case sensitive.</param>
-        /// <param name="teamSlug">The slug of the team name.</param>
+        /// <param name="teamId">The slug of the team name.</param>
         /// <param name="owner">The account owner of the repository. The name is not case sensitive.</param>
         /// <param name="repo">The name of the repository. The name is not case sensitive.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns></returns>
         [ManualRoute("GET", "/orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}")]
-        public Task<TeamRepository> CheckTeamPermissionsForARepositoryWithCustomAcceptHeader(string org, string teamSlug, string owner, string repo)
+        public Task<TeamRepository> CheckTeamPermissionsForARepositoryWithCustomAcceptHeader(string org, string teamId, string owner, string repo)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
-            Ensure.ArgumentNotNullOrEmptyString(teamSlug, nameof(teamSlug));
+            Ensure.ArgumentNotNullOrEmptyString(teamId, nameof(teamId));
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(repo, nameof(repo));
 
-            var endpoint = ApiUrls.TeamPermissionsForARepository(org, teamSlug, owner, repo);
+            var endpoint = ApiUrls.TeamPermissionsForARepository(org, teamId, owner, repo);
 
             return ApiConnection.Get<TeamRepository>(endpoint, null, AcceptHeaders.RepositoryContentMediaType);
         }
@@ -637,26 +637,26 @@ namespace Octokit
         /// for more information.
         /// </remarks>
         /// <param name="org">The organization name. The name is not case sensitive.</param>
-        /// <param name="teamSlug">The slug of the team name.</param>
+        /// <param name="teamId">The slug of the team name.</param>
         /// <param name="owner">The account owner of the repository. The name is not case sensitive.</param>
         /// <param name="repo">The name of the repository. The name is not case sensitive.</param>
         /// <param name="permission">
-        /// The permission to grant the team on this repository. We accept the following permissions to be set: 
-        /// pull, triage, push, maintain, admin and you can also specify a custom repository role name, if the 
-        /// owning organization has defined any. If no permission is specified, the team's permission attribute 
+        /// The permission to grant the team on this repository. We accept the following permissions to be set:
+        /// pull, triage, push, maintain, admin and you can also specify a custom repository role name, if the
+        /// owning organization has defined any. If no permission is specified, the team's permission attribute
         /// will be used to determine what permission to grant the team on this repository
         /// </param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns></returns>
         [ManualRoute("PUT", "/orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}")]
-        public Task AddOrUpdateTeamRepositoryPermissions(string org, string teamSlug, string owner, string repo, string permission)
+        public Task AddOrUpdateTeamRepositoryPermissions(string org, string teamId, string owner, string repo, string permission)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
-            Ensure.ArgumentNotNullOrEmptyString(teamSlug, nameof(teamSlug));
+            Ensure.ArgumentNotNullOrEmptyString(teamId, nameof(teamId));
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(repo, nameof(repo));
 
-            var endpoint = ApiUrls.TeamPermissionsForARepository(org, teamSlug, owner, repo);
+            var endpoint = ApiUrls.TeamPermissionsForARepository(org, teamId, owner, repo);
 
             return ApiConnection.Put(endpoint, new { permission });
         }
@@ -669,20 +669,20 @@ namespace Octokit
         /// for more information.
         /// </remarks>
         /// <param name="org">The organization name. The name is not case sensitive.</param>
-        /// <param name="teamSlug">The slug of the team name.</param>
+        /// <param name="teamId">The slug of the team name.</param>
         /// <param name="owner">The account owner of the repository. The name is not case sensitive.</param>
         /// <param name="repo">The name of the repository. The name is not case sensitive.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns></returns>
         [ManualRoute("DELETE", "/orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}")]
-        public Task RemoveRepositoryFromATeam(string org, string teamSlug, string owner, string repo)
+        public Task RemoveRepositoryFromATeam(string org, string teamId, string owner, string repo)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
-            Ensure.ArgumentNotNullOrEmptyString(teamSlug, nameof(teamSlug));
+            Ensure.ArgumentNotNullOrEmptyString(teamId, nameof(teamId));
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(repo, nameof(repo));
 
-            var endpoint = ApiUrls.TeamPermissionsForARepository(org, teamSlug, owner, repo);
+            var endpoint = ApiUrls.TeamPermissionsForARepository(org, teamId, owner, repo);
 
             return ApiConnection.Delete(endpoint);
         }
@@ -695,17 +695,17 @@ namespace Octokit
         /// for more information.
         /// </remarks>
         /// <param name="org">The organization name. The name is not case sensitive.</param>
-        /// <param name="teamSlug">The slug of the team name.</param>
+        /// <param name="teamId">The slug of the team name.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <exception cref="NotFoundException">Thrown when the team wasn't found</exception>
         /// <returns>A <see cref="Team"/> instance if found, otherwise a <see cref="NotFoundException"/></returns>
-        [ManualRoute("GET", "/orgs/{org}/teams/{teamSlug}")]
-        public Task<Team> GetByName(string org, string teamSlug)
+        [ManualRoute("GET", "/orgs/{org}/teams/{teamId}")]
+        public Task<Team> GetByName(string org, string teamId)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
-            Ensure.ArgumentNotNullOrEmptyString(teamSlug, nameof(teamSlug));
-            
-            var endpoint = ApiUrls.TeamsByOrganizationAndSlug(org, teamSlug);
+            Ensure.ArgumentNotNullOrEmptyString(teamId, nameof(teamId));
+
+            var endpoint = ApiUrls.TeamsByOrganizationAndSlug(org, teamId);
             return ApiConnection.Get<Team>(endpoint);
         }
     }

--- a/Octokit/Clients/UserGpgKeysClient.cs
+++ b/Octokit/Clients/UserGpgKeysClient.cs
@@ -59,7 +59,7 @@ namespace Octokit
         /// </remarks>
         /// <returns>The <see cref="GpgKey"/> for the specified Id.</returns>
         [ManualRoute("GET", "/user/gpg_keys/{gpg_key_id}")]
-        public Task<GpgKey> Get(int gpgKeyId)
+        public Task<GpgKey> Get(long gpgKeyId)
         {
             return ApiConnection.Get<GpgKey>(ApiUrls.GpgKeys(gpgKeyId));
         }
@@ -89,7 +89,7 @@ namespace Octokit
         /// </remarks>
         /// <returns></returns>
         [ManualRoute("DELETE", "/user/gpg_keys/{gpg_key_id}")]
-        public Task Delete(int gpgKeyId)
+        public Task Delete(long gpgKeyId)
         {
             return ApiConnection.Delete(ApiUrls.GpgKeys(gpgKeyId));
         }

--- a/Octokit/Clients/UserKeysClient.cs
+++ b/Octokit/Clients/UserKeysClient.cs
@@ -88,7 +88,7 @@ namespace Octokit
         /// <param name="keyId">The Id of the SSH key</param>
         /// <returns></returns>
         [ManualRoute("GET", "/user/keys/{key_id}")]
-        public Task<PublicKey> Get(int keyId)
+        public Task<PublicKey> Get(long keyId)
         {
             return ApiConnection.Get<PublicKey>(ApiUrls.Keys(keyId));
         }
@@ -118,7 +118,7 @@ namespace Octokit
         /// <param name="keyId">The id of the key to delete</param>
         /// <returns></returns>
         [ManualRoute("DELETE", "/user/keys/{key_id}")]
-        public Task Delete(int keyId)
+        public Task Delete(long keyId)
         {
             return ApiConnection.Delete(ApiUrls.Keys(keyId));
         }

--- a/Octokit/Helpers/ApiUrls.Authorizations.cs
+++ b/Octokit/Helpers/ApiUrls.Authorizations.cs
@@ -18,7 +18,7 @@ namespace Octokit
         /// Returns the <see cref="Uri"/> that returns all authorizations for a given user
         /// </summary>
         /// <param name="id">The user Id to search for</param>
-        public static Uri Authorizations(int id)
+        public static Uri Authorizations(long id)
         {
             return "authorizations/{0}".FormatUri(id);
         }

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -268,7 +268,7 @@ namespace Octokit
         /// Returns the <see cref="Uri"/> to retrieve a given key.
         /// </summary>
         /// <param name="keyId">The Key Id to retrieve</param>
-        public static Uri Keys(int keyId)
+        public static Uri Keys(long keyId)
         {
             return "user/keys/{0}".FormatUri(keyId);
         }
@@ -1003,7 +1003,7 @@ namespace Octokit
         /// <param name="org">The name of the organization</param>
         /// <param name="invitationId">The unique identifier of the invitation</param>
         /// <returns></returns>
-        public static Uri CancelOrganizationInvitation(string org, int invitationId)
+        public static Uri CancelOrganizationInvitation(string org, long invitationId)
         {
             return "orgs/{0}/invitations/{1}".FormatUri(org, invitationId);
         }
@@ -1981,7 +1981,7 @@ namespace Octokit
         /// </summary>
         /// <param name="parentTeamId">The id of the parent team</param>
         /// <returns></returns>
-        public static Uri TeamChildTeams(int parentTeamId)
+        public static Uri TeamChildTeams(long parentTeamId)
         {
             return "teams/{0}/teams".FormatUri(parentTeamId);
         }
@@ -1992,7 +1992,7 @@ namespace Octokit
         /// </summary>
         /// <param name="teamId">The id of the <see cref="Team"/>.</param>
         /// <returns></returns>
-        public static Uri Teams(int teamId)
+        public static Uri Teams(long teamId)
         {
             return "teams/{0}".FormatUri(teamId);
         }
@@ -2002,11 +2002,11 @@ namespace Octokit
         /// use for updating, or deleteing a <see cref="Team"/>.
         /// </summary>
         /// <param name="org"></param>
-        /// <param name="teamSlug"></param>
+        /// <param name="teamId"></param>
         /// <returns></returns>
-        public static Uri TeamsByOrganizationAndSlug(string org, string teamSlug)
+        public static Uri TeamsByOrganizationAndSlug(string org, string teamId)
         {
-            return "orgs/{0}/teams/{1}".FormatUri(org, teamSlug);
+            return "orgs/{0}/teams/{1}".FormatUri(org, teamId);
         }
 
         /// <summary>
@@ -2014,7 +2014,7 @@ namespace Octokit
         /// </summary>
         /// <param name="teamId">The team id</param>
         /// <param name="login">The user login.</param>
-        public static Uri TeamMember(int teamId, string login)
+        public static Uri TeamMember(long teamId, string login)
         {
             return "teams/{0}/memberships/{1}".FormatUri(teamId, login);
         }
@@ -2023,7 +2023,7 @@ namespace Octokit
         /// returns the <see cref="Uri"/> for team members list
         /// </summary>
         /// <param name="teamId">The team id</param>
-        public static Uri TeamMembers(int teamId)
+        public static Uri TeamMembers(long teamId)
         {
             return "teams/{0}/members".FormatUri(teamId);
         }
@@ -2032,7 +2032,7 @@ namespace Octokit
         /// returns the <see cref="Uri"/> for the repositories
         /// </summary>
         /// <param name="teamId">The team id</param>
-        public static Uri TeamRepositories(int teamId)
+        public static Uri TeamRepositories(long teamId)
         {
             return "teams/{0}/repos".FormatUri(teamId);
         }
@@ -2043,7 +2043,7 @@ namespace Octokit
         /// <param name="teamId">The team id</param>
         /// <param name="organization">The organization id</param>
         /// <param name="repoName">The repository name</param>
-        public static Uri TeamRepository(int teamId, string organization, string repoName)
+        public static Uri TeamRepository(long teamId, string organization, string repoName)
         {
             return "teams/{0}/repos/{1}/{2}".FormatUri(teamId, organization, repoName);
         }
@@ -2052,12 +2052,12 @@ namespace Octokit
         /// returns the <see cref="Uri"/> for a team repository
         /// </summary>
         /// <param name="org">The organization name. The name is not case sensitive.</param>
-        /// <param name="teamSlug">The slug of the team name.</param>
+        /// <param name="teamId">The slug of the team name.</param>
         /// <param name="owner">The account owner of the repository. The name is not case sensitive.</param>
         /// <param name="repo">The name of the repository. The name is not case sensitive.</param>
-        public static Uri TeamPermissionsForARepository(string org, string teamSlug, string owner, string repo)
+        public static Uri TeamPermissionsForARepository(string org, string teamId, string owner, string repo)
         {
-            return "/orgs/{0}/teams/{1}/repos/{2}/{3}".FormatUri(org, teamSlug, owner, repo);
+            return "/orgs/{0}/teams/{1}/repos/{2}/{3}".FormatUri(org, teamId, owner, repo);
         }
 
         /// <summary>
@@ -2065,7 +2065,7 @@ namespace Octokit
         /// </summary>
         /// <param name="teamId">The team id</param>
         /// <returns></returns>
-        public static Uri TeamPendingInvitations(int teamId)
+        public static Uri TeamPendingInvitations(long teamId)
         {
             return "teams/{0}/invitations".FormatUri(teamId);
         }
@@ -2665,7 +2665,7 @@ namespace Octokit
         /// <param name="name">Name of the repository</param>
         /// <param name="deploymentId">Id of the deployment</param>
         /// <returns></returns>
-        public static Uri DeploymentStatuses(string owner, string name, int deploymentId)
+        public static Uri DeploymentStatuses(string owner, string name, long deploymentId)
         {
             return "repos/{0}/{1}/deployments/{2}/statuses".FormatUri(owner, name, deploymentId);
         }
@@ -2982,12 +2982,12 @@ namespace Octokit
             return EnterpriseAdminStats("all");
         }
 
-        public static Uri EnterpriseLdapTeamMapping(int teamId)
+        public static Uri EnterpriseLdapTeamMapping(long teamId)
         {
             return "admin/ldap/teams/{0}/mapping".FormatUri(teamId);
         }
 
-        public static Uri EnterpriseLdapTeamSync(int teamId)
+        public static Uri EnterpriseLdapTeamSync(long teamId)
         {
             return "admin/ldap/teams/{0}/sync".FormatUri(teamId);
         }
@@ -3007,7 +3007,7 @@ namespace Octokit
             return "enterprise/settings/license".FormatUri();
         }
 
-        public static Uri EnterpriseMigrationById(string org, int migrationId)
+        public static Uri EnterpriseMigrationById(string org, long migrationId)
         {
             return "orgs/{0}/migrations/{1}".FormatUri(org, migrationId);
         }
@@ -3017,12 +3017,12 @@ namespace Octokit
             return "orgs/{0}/migrations".FormatUri(org);
         }
 
-        public static Uri EnterpriseMigrationArchive(string org, int migrationId)
+        public static Uri EnterpriseMigrationArchive(string org, long migrationId)
         {
             return "orgs/{0}/migrations/{1}/archive".FormatUri(org, migrationId);
         }
 
-        public static Uri EnterpriseMigrationUnlockRepository(string org, int migrationId, string repo)
+        public static Uri EnterpriseMigrationUnlockRepository(string org, long migrationId, string repo)
         {
             return "orgs/{0}/migrations/{1}/repos/{2}/lock".FormatUri(org, migrationId, repo);
         }
@@ -3360,7 +3360,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="deploymentId">Id of the deployment</param>
         /// <returns>The <see cref="Uri"/> for the Deployment Statuses API for the given deployment.</returns>
-        public static Uri DeploymentStatuses(long repositoryId, int deploymentId)
+        public static Uri DeploymentStatuses(long repositoryId, long deploymentId)
         {
             return "repositories/{0}/deployments/{1}/statuses".FormatUri(repositoryId, deploymentId);
         }
@@ -3391,7 +3391,7 @@ namespace Octokit
         /// <param name="gpgKeyId">The GPG Key Id.</param>
         /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Gpg")]
-        public static Uri GpgKeys(int gpgKeyId)
+        public static Uri GpgKeys(long gpgKeyId)
         {
             return "user/gpg_keys/{0}".FormatUri(gpgKeyId);
         }
@@ -4185,7 +4185,7 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="invitationId">The id of the invitation</param>
         /// <returns>The <see cref="Uri"/> for repository invitations.</returns>
-        public static Uri RepositoryInvitations(long repositoryId, int invitationId)
+        public static Uri RepositoryInvitations(long repositoryId, long invitationId)
         {
             return "repositories/{0}/invitations/{1}".FormatUri(repositoryId, invitationId);
         }
@@ -4204,7 +4204,7 @@ namespace Octokit
         /// </summary>
         /// <param name="invitationId">The id of the invitation</param>
         /// <returns>The <see cref="Uri"/> for invitations for the current user.</returns>
-        public static Uri UserInvitations(int invitationId)
+        public static Uri UserInvitations(long invitationId)
         {
             return "user/repository_invitations/{0}".FormatUri(invitationId);
         }
@@ -4392,7 +4392,7 @@ namespace Octokit
         /// </summary>
         /// <param name="cardId">The id of the card</param>
         /// <returns>The <see cref="Uri"/> for project cards.</returns>
-        public static Uri ProjectCard(int cardId)
+        public static Uri ProjectCard(long cardId)
         {
             return "projects/columns/cards/{0}".FormatUri(cardId);
         }
@@ -4412,7 +4412,7 @@ namespace Octokit
         /// </summary>
         /// <param name="cardId">The id of the card to move</param>
         /// <returns>The <see cref="Uri"/> to move a project card.</returns>
-        public static Uri ProjectCardMove(int cardId)
+        public static Uri ProjectCardMove(long cardId)
         {
             return "projects/columns/cards/{0}/moves".FormatUri(cardId);
         }

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -311,7 +311,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="releaseId">The id of the release</param>
         /// <returns></returns>
-        public static Uri Releases(string owner, string name, int releaseId)
+        public static Uri Releases(string owner, string name, long releaseId)
         {
             return "repos/{0}/{1}/releases/{2}".FormatUri(owner, name, releaseId);
         }
@@ -346,7 +346,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="releaseId">The id of the release</param>
         /// <returns></returns>
-        public static Uri ReleaseAssets(string owner, string name, int releaseId)
+        public static Uri ReleaseAssets(string owner, string name, long releaseId)
         {
             return "repos/{0}/{1}/releases/{2}/assets".FormatUri(owner, name, releaseId);
         }
@@ -3712,7 +3712,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="releaseId">The id of the release</param>
         /// <returns>The <see cref="Uri"/> that returns all the assets for the specified release for the specified repository.</returns>
-        public static Uri ReleaseAssets(long repositoryId, int releaseId)
+        public static Uri ReleaseAssets(long repositoryId, long releaseId)
         {
             return "repositories/{0}/releases/{1}/assets".FormatUri(repositoryId, releaseId);
         }
@@ -3743,7 +3743,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="releaseId">The id of the release</param>
         /// <returns>The <see cref="Uri"/> that returns a single release for the specified repository</returns>
-        public static Uri Releases(long repositoryId, int releaseId)
+        public static Uri Releases(long repositoryId, long releaseId)
         {
             return "repositories/{0}/releases/{1}".FormatUri(repositoryId, releaseId);
         }

--- a/Octokit/Models/Request/NewTeam.cs
+++ b/Octokit/Models/Request/NewTeam.cs
@@ -60,7 +60,7 @@ namespace Octokit
         /// <summary>
         /// Id of a team to set as the parent team
         /// </summary>
-        public int? ParentTeamId { get; set; }
+        public long? ParentTeamId { get; set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Request/OrganizationInvitationRequest.cs
+++ b/Octokit/Models/Request/OrganizationInvitationRequest.cs
@@ -10,60 +10,60 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class OrganizationInvitationRequest
     {
-        public OrganizationInvitationRequest(int inviteeId)
+        public OrganizationInvitationRequest(long inviteeId)
         {
             InviteeId = inviteeId;
         }
-        
+
         public OrganizationInvitationRequest(string email)
         {
             Email = email;
         }
-        
-        public OrganizationInvitationRequest(int inviteeId, OrganizationMembershipRole role)
+
+        public OrganizationInvitationRequest(long inviteeId, OrganizationMembershipRole role)
         {
             InviteeId = inviteeId;
             Role = role;
         }
-        
+
         public OrganizationInvitationRequest(string email, OrganizationMembershipRole role)
         {
             Email = email;
             Role = role;
         }
-        
-        public OrganizationInvitationRequest(int inviteeId, int[] teamIds)
+
+        public OrganizationInvitationRequest(long inviteeId, long[] teamIds)
         {
             InviteeId = inviteeId;
             TeamIds = teamIds;
         }
-        
-        public OrganizationInvitationRequest(string email, int[] teamIds)
+
+        public OrganizationInvitationRequest(string email, long[] teamIds)
         {
             Email = email;
             TeamIds = teamIds;
         }
-        
-        public OrganizationInvitationRequest(int inviteeId, OrganizationMembershipRole role, int[] teamIds)
+
+        public OrganizationInvitationRequest(long inviteeId, OrganizationMembershipRole role, long[] teamIds)
         {
             InviteeId = inviteeId;
             Role = role;
             TeamIds = teamIds;
         }
-        
-        public OrganizationInvitationRequest(string email, OrganizationMembershipRole role, int[] teamIds)
+
+        public OrganizationInvitationRequest(string email, OrganizationMembershipRole role, long[] teamIds)
         {
             Email = email;
             Role = role;
             TeamIds = teamIds;
         }
-        
+
         /// <summary>
         /// The user ID of the person being invited. Required if Email is not specified.
         /// </summary>
         [Parameter(Key = "invitee_id")]
-        public int? InviteeId { get; set; }
-        
+        public long? InviteeId { get; set; }
+
         /// <summary>
         /// The email address of the person being invited. Required if InviteeId is not specified.
         /// </summary>
@@ -75,12 +75,12 @@ namespace Octokit
         /// </summary>
         [Parameter(Key = "role")]
         public OrganizationMembershipRole Role { get; set; } = OrganizationMembershipRole.DirectMember;
-        
+
         /// <summary>
         /// The IDs for the team(s) to invite new members to
         /// </summary>
         [Parameter(Key = "team_ids")]
-        public int[] TeamIds { get; set; }
+        public long[] TeamIds { get; set; }
 
         internal string DebuggerDisplay => $"InviteeId: {InviteeId}; Email: {Email}; Role: {Role}; Team IDs: {(TeamIds != null ? string.Join(", ", TeamIds) : "")}";
     }

--- a/Octokit/Models/Request/OrganizationRequest.cs
+++ b/Octokit/Models/Request/OrganizationRequest.cs
@@ -13,7 +13,7 @@ namespace Octokit
         /// Initializes a new instance of the <see cref="OrganizationRequest"/> class.
         /// </summary>
         /// <param name="since">The integer Id of the last Organization that you've seen.</param>
-        public OrganizationRequest(int since)
+        public OrganizationRequest(long since)
         {
             Ensure.ArgumentNotNull(since, nameof(since));
 

--- a/Octokit/Models/Request/ProjectCardMove.cs
+++ b/Octokit/Models/Request/ProjectCardMove.cs
@@ -6,7 +6,7 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class ProjectCardMove
     {
-        public ProjectCardMove(ProjectCardPosition position, int columnId, int? cardId)
+        public ProjectCardMove(ProjectCardPosition position, int columnId, long? cardId)
         {
             ColumnId = columnId;
             switch (position)

--- a/Octokit/Models/Request/RepositoryTransfer.cs
+++ b/Octokit/Models/Request/RepositoryTransfer.cs
@@ -28,7 +28,7 @@ namespace Octokit
         /// </summary>
         /// <param name="newOwner">The new owner of the repository after the transfer.</param>
         /// <param name="teamIds">A list of team Ids to add to the repository after the transfer (only applies to transferring to an Organization).</param>
-        public RepositoryTransfer(string newOwner, IReadOnlyList<int> teamIds)
+        public RepositoryTransfer(string newOwner, IReadOnlyList<long> teamIds)
             : this(newOwner)
         {
             Ensure.ArgumentNotNullOrEmptyEnumerable(teamIds, nameof(teamIds));
@@ -44,13 +44,13 @@ namespace Octokit
         /// <summary>
         /// A list of team Ids to add to the repository after the transfer (only applies to transferring to an Organization).
         /// </summary>
-        public IReadOnlyList<int> TeamIds { get; set; }
+        public IReadOnlyList<long> TeamIds { get; set; }
 
         internal string DebuggerDisplay
         {
             get
             {
-                string teamIdsStr = string.Join(", ", TeamIds ?? new int[0]);
+                string teamIdsStr = string.Join(", ", TeamIds ?? new long[0]);
                 return string.Format(CultureInfo.InvariantCulture, "NewOwner: {0}, TeamIds: [{1}]", NewOwner, teamIdsStr);
             }
         }

--- a/Octokit/Models/Response/Account.cs
+++ b/Octokit/Models/Response/Account.cs
@@ -9,7 +9,7 @@ namespace Octokit
     {
         protected Account() { }
 
-        protected Account(string avatarUrl, string bio, string blog, int collaborators, string company, DateTimeOffset createdAt, int diskUsage, string email, int followers, int following, bool? hireable, string htmlUrl, int totalPrivateRepos, int id, string location, string login, string name, string nodeId, int ownedPrivateRepos, Plan plan, int privateGists, int publicGists, int publicRepos, AccountType type, string url)
+        protected Account(string avatarUrl, string bio, string blog, int collaborators, string company, DateTimeOffset createdAt, int diskUsage, string email, int followers, int following, bool? hireable, string htmlUrl, int totalPrivateRepos, long id, string location, string login, string name, string nodeId, int ownedPrivateRepos, Plan plan, int privateGists, int publicGists, int publicRepos, AccountType type, string url)
         {
             AvatarUrl = avatarUrl;
             Bio = bio;
@@ -102,7 +102,7 @@ namespace Octokit
         /// <summary>
         /// The account's system-wide unique Id.
         /// </summary>
-        public int Id { get; protected set; }
+        public long Id { get; protected set; }
 
         /// <summary>
         /// GraphQL Node Id

--- a/Octokit/Models/Response/Author.cs
+++ b/Octokit/Models/Response/Author.cs
@@ -9,7 +9,7 @@ namespace Octokit
     {
         public Author() { }
 
-        public Author(string login, int id, string nodeId, string avatarUrl, string url, string htmlUrl, string followersUrl, string followingUrl, string gistsUrl, string type, string starredUrl, string subscriptionsUrl, string organizationsUrl, string reposUrl, string eventsUrl, string receivedEventsUrl, bool siteAdmin)
+        public Author(string login, long id, string nodeId, string avatarUrl, string url, string htmlUrl, string followersUrl, string followingUrl, string gistsUrl, string type, string starredUrl, string subscriptionsUrl, string organizationsUrl, string reposUrl, string eventsUrl, string receivedEventsUrl, bool siteAdmin)
         {
             Login = login;
             Id = id;
@@ -32,7 +32,7 @@ namespace Octokit
 
         public string Login { get; protected set; }
 
-        public int Id { get; protected set; }
+        public long Id { get; protected set; }
 
         /// <summary>
         /// GraphQL Node Id

--- a/Octokit/Models/Response/Authorization.cs
+++ b/Octokit/Models/Response/Authorization.cs
@@ -14,7 +14,7 @@ namespace Octokit
         // TODO: I'd love to not need this
         public Authorization() { }
 
-        public Authorization(int id, string url, Application application, string tokenLastEight, string hashedToken, string fingerprint, string note, string noteUrl, DateTimeOffset createdAt, DateTimeOffset updateAt, string[] scopes)
+        public Authorization(long id, string url, Application application, string tokenLastEight, string hashedToken, string fingerprint, string note, string noteUrl, DateTimeOffset createdAt, DateTimeOffset updateAt, string[] scopes)
         {
             Id = id;
             Url = url;
@@ -36,7 +36,7 @@ namespace Octokit
         /// <summary>
         /// The Id of this <see cref="Authorization"/>.
         /// </summary>
-        public int Id { get; protected set; }
+        public long Id { get; protected set; }
 
         /// <summary>
         /// The API URL for this <see cref="Authorization"/>.

--- a/Octokit/Models/Response/Collaborator.cs
+++ b/Octokit/Models/Response/Collaborator.cs
@@ -8,7 +8,7 @@ namespace Octokit
     {
         public Collaborator() { }
 
-        public Collaborator(string login, int id, string email, string name, string nodeId, string avatarUrl, string gravatarUrl, string url, string htmlUrl, string followersUrl, string followingUrl, string gistsUrl, string type, string starredUrl, string subscriptionsUrl, string organizationsUrl, string reposUrl, string eventsUrl, string receivedEventsUrl, bool siteAdmin, CollaboratorPermissions permissions, string roleName)
+        public Collaborator(string login, long id, string email, string name, string nodeId, string avatarUrl, string gravatarUrl, string url, string htmlUrl, string followersUrl, string followingUrl, string gistsUrl, string type, string starredUrl, string subscriptionsUrl, string organizationsUrl, string reposUrl, string eventsUrl, string receivedEventsUrl, bool siteAdmin, CollaboratorPermissions permissions, string roleName)
         {
             Login = login;
             Id = id;
@@ -36,7 +36,7 @@ namespace Octokit
 
         public string Login { get; protected set; }
 
-        public int Id { get; protected set; }
+        public long Id { get; protected set; }
 
         public string Email { get; protected set; }
 
@@ -48,7 +48,7 @@ namespace Octokit
         public string NodeId { get; protected set; }
 
         public string AvatarUrl { get; protected set; }
-        
+
         public string GravatarUrl { get; protected set; }
 
         public string Url { get; protected set; }

--- a/Octokit/Models/Response/Deployment.cs
+++ b/Octokit/Models/Response/Deployment.cs
@@ -13,7 +13,7 @@ namespace Octokit
     {
         public Deployment() { }
 
-        public Deployment(int id, string nodeId, string sha, string @ref, string url, User creator, IReadOnlyDictionary<string, string> payload, DateTimeOffset createdAt, DateTimeOffset updatedAt, string description, string statusesUrl, string repositoryUrl, string environment, string originalEnvironment, bool transientEnvironment, bool productionEnvironment, string task)
+        public Deployment(long id, string nodeId, string sha, string @ref, string url, User creator, IReadOnlyDictionary<string, string> payload, DateTimeOffset createdAt, DateTimeOffset updatedAt, string description, string statusesUrl, string repositoryUrl, string environment, string originalEnvironment, bool transientEnvironment, bool productionEnvironment, string task)
         {
             Id = id;
             NodeId = nodeId;
@@ -37,7 +37,7 @@ namespace Octokit
         /// <summary>
         /// Id of this deployment.
         /// </summary>
-        public int Id { get; private set; }
+        public long Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id

--- a/Octokit/Models/Response/DeploymentEnvironment.cs
+++ b/Octokit/Models/Response/DeploymentEnvironment.cs
@@ -14,7 +14,7 @@ namespace Octokit.Models.Response
     {
         public DeploymentEnvironment() { }
 
-        public DeploymentEnvironment(int id, string nodeID, string name, string url, string htmlUrl, DateTimeOffset createdAt, DateTimeOffset updatedAt)
+        public DeploymentEnvironment(long id, string nodeID, string name, string url, string htmlUrl, DateTimeOffset createdAt, DateTimeOffset updatedAt)
         {
             Id = id;
             NodeId = nodeID;
@@ -28,7 +28,7 @@ namespace Octokit.Models.Response
         /// <summary>
         /// Id of this deployment environment
         /// </summary>
-        public int Id { get; private set; }
+        public long Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id

--- a/Octokit/Models/Response/Enterprise/PreReceiveHook.cs
+++ b/Octokit/Models/Response/Enterprise/PreReceiveHook.cs
@@ -12,7 +12,7 @@ namespace Octokit
         public PreReceiveHook()
         { }
 
-        public PreReceiveHook(int id, string name, StringEnum<PreReceiveHookEnforcement> enforcement, string script, Repository scriptRepository, PreReceiveEnvironment environment, bool allowDownstreamConfiguration)
+        public PreReceiveHook(long id, string name, StringEnum<PreReceiveHookEnforcement> enforcement, string script, Repository scriptRepository, PreReceiveEnvironment environment, bool allowDownstreamConfiguration)
         {
             Id = id;
             Name = name;
@@ -26,7 +26,7 @@ namespace Octokit
         /// <summary>
         /// The identifier for the pre-receive hook.
         /// </summary>
-        public int Id { get; private set; }
+        public long Id { get; private set; }
 
         /// <summary>
         /// The name of the hook.

--- a/Octokit/Models/Response/GpgKey.cs
+++ b/Octokit/Models/Response/GpgKey.cs
@@ -12,7 +12,7 @@ namespace Octokit
     {
         public GpgKey() { }
 
-        public GpgKey(int id, int? primaryKeyId, string keyId, string publicKey, IReadOnlyList<EmailAddress> emails, IReadOnlyList<GpgKey> subkeys, bool canSign, bool canEncryptCommunications, bool canEncryptStorage, bool canCertify, DateTimeOffset createdAt, DateTimeOffset? expiresAt)
+        public GpgKey(long id, long? primaryKeyId, string keyId, string publicKey, IReadOnlyList<EmailAddress> emails, IReadOnlyList<GpgKey> subkeys, bool canSign, bool canEncryptCommunications, bool canEncryptStorage, bool canCertify, DateTimeOffset createdAt, DateTimeOffset? expiresAt)
         {
             Id = id;
             PrimaryKeyId = primaryKeyId;
@@ -28,8 +28,8 @@ namespace Octokit
             ExpiresAt = expiresAt;
         }
 
-        public int Id { get; private set; }
-        public int? PrimaryKeyId { get; private set; }
+        public long Id { get; private set; }
+        public long? PrimaryKeyId { get; private set; }
         public string KeyId { get; private set; }
         public string PublicKey { get; private set; }
         public IReadOnlyList<EmailAddress> Emails { get; private set; }

--- a/Octokit/Models/Response/Migration.cs
+++ b/Octokit/Models/Response/Migration.cs
@@ -22,7 +22,7 @@ namespace Octokit
         { }
 
         public Migration(
-            int id,
+            long id,
             string nodeId,
             string guid,
             MigrationState state,
@@ -48,7 +48,7 @@ namespace Octokit
         /// <summary>
         /// Id of migration.
         /// </summary>
-        public int Id { get; private set; }
+        public long Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id

--- a/Octokit/Models/Response/OrganizationMembershipInvitation.cs
+++ b/Octokit/Models/Response/OrganizationMembershipInvitation.cs
@@ -12,7 +12,7 @@ namespace Octokit
         {
         }
 
-        public OrganizationMembershipInvitation(int id, string nodeId, string login, string email, OrganizationMembershipRole role, DateTimeOffset createdAt, User inviter, int teamCount)
+        public OrganizationMembershipInvitation(long id, string nodeId, string login, string email, OrganizationMembershipRole role, DateTimeOffset createdAt, User inviter, int teamCount)
         {
             Id = id;
             NodeId = nodeId;
@@ -24,7 +24,7 @@ namespace Octokit
             TeamCount = teamCount;
         }
 
-        public int Id { get; private set; }
+        public long Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id

--- a/Octokit/Models/Response/ProjectCard.cs
+++ b/Octokit/Models/Response/ProjectCard.cs
@@ -9,7 +9,7 @@ namespace Octokit
     {
         public ProjectCard() { }
 
-        public ProjectCard(string columnUrl, string contentUrl, int id, string nodeId, string note, User creator, DateTimeOffset createdAt, DateTimeOffset updatedAt, bool archived)
+        public ProjectCard(string columnUrl, string contentUrl, long id, string nodeId, string note, User creator, DateTimeOffset createdAt, DateTimeOffset updatedAt, bool archived)
         {
             ColumnUrl = columnUrl;
             ContentUrl = contentUrl;
@@ -35,7 +35,7 @@ namespace Octokit
         /// <summary>
         /// The Id for this card.
         /// </summary>
-        public int Id { get; private set; }
+        public long Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id

--- a/Octokit/Models/Response/PublicKey.cs
+++ b/Octokit/Models/Response/PublicKey.cs
@@ -8,7 +8,7 @@ namespace Octokit
     {
         public PublicKey() { }
 
-        public PublicKey(int id, string key, string url, string title)
+        public PublicKey(long id, string key, string url, string title)
         {
             Id = id;
             Key = key;
@@ -16,7 +16,7 @@ namespace Octokit
             Title = title;
         }
 
-        public int Id { get; private set; }
+        public long Id { get; private set; }
 
         public string Key { get; private set; }
 

--- a/Octokit/Models/Response/Release.cs
+++ b/Octokit/Models/Response/Release.cs
@@ -11,7 +11,7 @@ namespace Octokit
     {
         public Release() { }
 
-        public Release(string url, string htmlUrl, string assetsUrl, string uploadUrl, int id, string nodeId, string tagName, string targetCommitish, string name, string body, bool draft, bool prerelease, DateTimeOffset createdAt, DateTimeOffset? publishedAt, Author author, string tarballUrl, string zipballUrl, IReadOnlyList<ReleaseAsset> assets)
+        public Release(string url, string htmlUrl, string assetsUrl, string uploadUrl, long id, string nodeId, string tagName, string targetCommitish, string name, string body, bool draft, bool prerelease, DateTimeOffset createdAt, DateTimeOffset? publishedAt, Author author, string tarballUrl, string zipballUrl, IReadOnlyList<ReleaseAsset> assets)
         {
             Url = url;
             HtmlUrl = htmlUrl;
@@ -47,7 +47,7 @@ namespace Octokit
 
         public string UploadUrl { get; private set; }
 
-        public int Id { get; private set; }
+        public long Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id

--- a/Octokit/Models/Response/RepositoryContributor.cs
+++ b/Octokit/Models/Response/RepositoryContributor.cs
@@ -10,7 +10,7 @@ namespace Octokit
     {
         public RepositoryContributor() { }
 
-        public RepositoryContributor(string login, int id, string nodeId, string avatarUrl, string url, string htmlUrl, string followersUrl, string followingUrl, string gistsUrl, string type, string starredUrl, string subscriptionsUrl, string organizationsUrl, string reposUrl, string eventsUrl, string receivedEventsUrl, bool siteAdmin, int contributions)
+        public RepositoryContributor(string login, long id, string nodeId, string avatarUrl, string url, string htmlUrl, string followersUrl, string followingUrl, string gistsUrl, string type, string starredUrl, string subscriptionsUrl, string organizationsUrl, string reposUrl, string eventsUrl, string receivedEventsUrl, bool siteAdmin, int contributions)
             : base(login, id, nodeId, avatarUrl, url, htmlUrl, followersUrl, followingUrl, gistsUrl, type, starredUrl, subscriptionsUrl, organizationsUrl, reposUrl, eventsUrl, receivedEventsUrl, siteAdmin)
         {
             Contributions = contributions;

--- a/Octokit/Models/Response/RepositoryInvitation.cs
+++ b/Octokit/Models/Response/RepositoryInvitation.cs
@@ -12,7 +12,7 @@ namespace Octokit
     {
         public RepositoryInvitation() { }
 
-        public RepositoryInvitation(int id, string nodeId, Repository repository, User invitee, User inviter, InvitationPermissionType permissions, DateTimeOffset createdAt, bool expired, string url, string htmlUrl)
+        public RepositoryInvitation(long id, string nodeId, Repository repository, User invitee, User inviter, InvitationPermissionType permissions, DateTimeOffset createdAt, bool expired, string url, string htmlUrl)
         {
             Id = id;
             NodeId = nodeId;
@@ -29,7 +29,7 @@ namespace Octokit
         /// <summary>
         /// Unique identifier of the repository invitation.
         /// </summary>
-        public int Id { get; private set; }
+        public long Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id

--- a/Octokit/Models/Response/Team.cs
+++ b/Octokit/Models/Response/Team.cs
@@ -12,7 +12,7 @@ namespace Octokit
     {
         public Team() { }
 
-        public Team(string url, string htmlUrl, int id, string nodeId, string slug, string name, string description, TeamPrivacy privacy, string permission, TeamRepositoryPermissions teamRepositoryPermissions, int membersCount, int reposCount, Organization organization, Team parent, string ldapDistinguishedName)
+        public Team(string url, string htmlUrl, long id, string nodeId, string slug, string name, string description, TeamPrivacy privacy, string permission, TeamRepositoryPermissions teamRepositoryPermissions, int membersCount, int reposCount, Organization organization, Team parent, string ldapDistinguishedName)
         {
             Url = url;
             HtmlUrl = htmlUrl;
@@ -44,7 +44,7 @@ namespace Octokit
         /// <summary>
         /// team id
         /// </summary>
-        public int Id { get; private set; }
+        public long Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id
@@ -75,9 +75,9 @@ namespace Octokit
         /// Deprecated. The permission that new repositories will be added to the team with when none is specified
         /// </summary>
         public string Permission { get; private set; }
-        
+
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public TeamRepositoryPermissions TeamRepositoryPermissions { get; private set; }
 

--- a/Octokit/Models/Response/TeamRepository.cs
+++ b/Octokit/Models/Response/TeamRepository.cs
@@ -13,7 +13,7 @@ namespace Octokit
     {
         public TeamRepository() { }
 
-        public TeamRepository(int id,
+        public TeamRepository(long id,
             string nodeId,
             string name,
             string fullName,
@@ -198,7 +198,7 @@ namespace Octokit
         /// <summary>
         /// Unique identifier of the repository
         /// </summary>
-        public int Id { get; private set; }
+        public long Id { get; private set; }
 
         /// <summary>
         /// GraphQL Node Id
@@ -400,7 +400,7 @@ namespace Octokit
 
         /// <summary>
         /// example: git @github.com:octocat/Hello-World.git
-        /// 
+        ///
         /// </summary>
         public string SshUrl { get; private set; }
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Relates to #2893

We have uncovered a series of issues around the IDs used across our API surface (Issues, Pull Requests, deployments, etc.. are all effected).

The GitHub database schemas were changed to accommodate for the growing IDs - migrating many of them from int to bigint - this SDK was lagging behind in those changes so when API calls began to return data that was too large for the types defined in our SDKs  - their apps, integration, and automation began to break.

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Overflow issues would happen when calling an API that returned a `long` (e.g. a release ID) but the class had this defined as an `int` - this would cause the SDK to throw an overflow exception. 


### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* We have updated the `int` types to be `long` across the SDKs - this will allow for the larger IDs to be returned without causing an overflow exception. 


### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [x] Yes
- [ ] No

----
