### PR TITLE
[FEAT]: Add support for Public Keys API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ coverage-results/*
 
 # Rider
 **/.idea/*
+
+# macOS
+.DS_Store

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,9 @@
   "files.trimFinalNewlines": true,
   "files.insertFinalNewline": true,
   "editor.detectIndentation": false,
-  "editor.tabSize": 2,
-  "editor.insertSpaces": true
+  "editor.tabSize": 4,
+  "editor.insertSpaces": true,
+  "explorer.fileNesting.patterns": {
+    "*.cs": "I${capture}.cs",
+  },
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,7 @@
   },
   "files.trimTrailingWhitespace": true,
   "files.trimFinalNewlines": true,
-  "files.insertFinalNewline": true,
+  "files.insertFinalNewline": false,
   "editor.detectIndentation": false,
   "editor.tabSize": 4,
   "editor.insertSpaces": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,8 +13,7 @@
   "editor.tabSize": 2,
   "editor.insertSpaces": true,
   "[csharp]": {
-    "editor.tabSize": 4,
-    "files.insertFinalNewline": false,
+    "editor.tabSize": 4
   },
   "explorer.fileNesting.patterns": {
     "*.cs": "I${capture}.cs",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,11 +11,11 @@
   "files.insertFinalNewline": true,
   "editor.detectIndentation": false,
   "editor.tabSize": 2,
+  "editor.insertSpaces": true,
   "[csharp]": {
     "editor.tabSize": 4,
     "files.insertFinalNewline": false,
   },
-  "editor.insertSpaces": true,
   "explorer.fileNesting.patterns": {
     "*.cs": "I${capture}.cs",
   },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,9 +8,13 @@
   },
   "files.trimTrailingWhitespace": true,
   "files.trimFinalNewlines": true,
-  "files.insertFinalNewline": false,
+  "files.insertFinalNewline": true,
   "editor.detectIndentation": false,
-  "editor.tabSize": 4,
+  "editor.tabSize": 2,
+  "[csharp]": {
+    "editor.tabSize": 4,
+    "files.insertFinalNewline": false,
+  },
   "editor.insertSpaces": true,
   "explorer.fileNesting.patterns": {
     "*.cs": "I${capture}.cs",

--- a/Octokit.Reactive/Clients/IObservableMetaClient.cs
+++ b/Octokit.Reactive/Clients/IObservableMetaClient.cs
@@ -11,6 +11,11 @@ namespace Octokit.Reactive
     public interface IObservableMetaClient
     {
         /// <summary>
+        /// Returns a client to get public keys for validating request signatures.
+        /// </summary>
+        IObservablePublicKeysClient PublicKeys { get; }
+
+        /// <summary>
         /// Retrieves information about GitHub.com, the service or a GitHub Enterprise installation.
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>

--- a/Octokit.Reactive/Clients/IObservablePublicKeysClient.cs
+++ b/Octokit.Reactive/Clients/IObservablePublicKeysClient.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Octokit.Reactive
+{
+    /// <summary>
+    /// A client for GitHub's meta public keys API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://docs.github.com/code-security/secret-scanning/secret-scanning-partner-program#implement-signature-verification-in-your-secret-alert-service">Secret scanning documentation</a> for more details.
+    /// </remarks>
+    public interface IObservablePublicKeysClient
+    {
+        /// <summary>
+        /// Retrieves public keys for validating request signatures.
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>An <see cref="MetaPublicKeys"/> containing public keys for validating request signatures.</returns>
+        IObservable<MetaPublicKeys> Get(PublicKeyType keysType);
+    }
+}

--- a/Octokit.Reactive/Clients/ObservableMetaClient.cs
+++ b/Octokit.Reactive/Clients/ObservableMetaClient.cs
@@ -18,8 +18,15 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNull(client, nameof(client));
 
+            PublicKeys = new ObservablePublicKeysClient(client);
+
             _client = client.Meta;
         }
+
+        /// <summary>
+        /// Returns a client to manage get public keys for validating request signatures.
+        /// </summary>
+        public IObservablePublicKeysClient PublicKeys { get; private set; }
 
         /// <summary>
         /// Retrieves information about GitHub.com, the service or a GitHub Enterprise installation.

--- a/Octokit.Reactive/Clients/ObservablePublicKeysClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePublicKeysClient.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+
+namespace Octokit.Reactive
+{
+    /// <summary>
+    /// A client for GitHub's public keys API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://docs.github.com/code-security/secret-scanning/secret-scanning-partner-program#implement-signature-verification-in-your-secret-alert-service">Secret scanning documentation</a> for more details.
+    /// </remarks>
+    public class ObservablePublicKeysClient : IObservablePublicKeysClient
+    {
+        private readonly IPublicKeysClient _client;
+
+        public ObservablePublicKeysClient(IGitHubClient client)
+        {
+            Ensure.ArgumentNotNull(client, nameof(client));
+
+            _client = client.Meta.PublicKeys;
+        }
+
+        /// <summary>
+        /// Retrieves public keys for validating request signatures.
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>An <see cref="MetaPublicKeys"/> containing public keys for validating request signatures.</returns>
+        public IObservable<MetaPublicKeys> Get(PublicKeyType keysType)
+        {
+            return _client.Get(keysType).ToObservable();
+        }
+    }
+}

--- a/Octokit.Tests.Integration/Clients/PublicKeysClientTest.cs
+++ b/Octokit.Tests.Integration/Clients/PublicKeysClientTest.cs
@@ -1,0 +1,28 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace Octokit.Tests.Integration.Clients
+{
+    public class PublicKeysClientTests
+    {
+        public class TheGetMethod
+        {
+            [IntegrationTest]
+            public async Task CanRetrievePublicKeys()
+            {
+                var github = Helper.GetAnonymousClient();
+
+                var result = await github.Meta.PublicKeys.Get(PublicKeyType.SecretScanning);
+
+                Assert.NotNull(result);
+                Assert.Equal(2, result.PublicKeys.Count);
+
+                Assert.NotNull(result.PublicKeys[0].KeyIdentifier);
+                Assert.NotNull(result.PublicKeys[0].Key);
+
+                Assert.NotNull(result.PublicKeys[1].KeyIdentifier);
+                Assert.NotNull(result.PublicKeys[1].Key);
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Clients/PublicKeysClientTests.cs
+++ b/Octokit.Tests/Clients/PublicKeysClientTests.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Threading.Tasks;
+using NSubstitute;
+using Xunit;
+
+namespace Octokit.Tests.Clients
+{
+    public class PublicKeysClientTests
+    {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(() => new PublicKeysClient(null));
+            }
+        }
+
+        public class TheGetMethod
+        {
+            [Fact]
+            public async Task RequestsTheCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new PublicKeysClient(connection);
+
+                await client.Get(PublicKeyType.CopilotApi);
+
+                connection.Received()
+                    .Get<MetaPublicKeys>(Arg.Is<Uri>(u => u.ToString() == "meta/public_keys/copilot_api"));
+            }
+
+            [Fact]
+            public async Task RequestsCopilotApiPublicKeysEndpoint()
+            {
+                var publicKeys = new MetaPublicKeys(publicKeys: new[] {
+                    new MetaPublicKey("4fe6b016179b74078ade7581abf4e84fb398c6fae4fb973972235b84fcd70ca3", "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELPuPiLVQbHY/clvpNnY+0BzYIXgo\nS0+XhEkTWUZEEznIVpS3rQseDTG6//gEWr4j9fY35+dGOxwOx3Z9mK3i7w==\n-----END PUBLIC KEY-----\n", true),
+                    new MetaPublicKey("df3454252d91570ae1bc597182d1183c7a8d42ff0ae96e0f2be4ba278d776546", "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEl5xbyr5bmETCJzqAvDnYl1ZKJrkf\n89Nyq5j06TTKrnHXXDw4FYNY1uF2S/w6EOaxbf9BxOidCLvjJ8ZgKzNpww==\n-----END PUBLIC KEY-----\n", false)
+                });
+
+                var apiConnection = Substitute.For<IApiConnection>();
+                apiConnection.Get<MetaPublicKeys>(Arg.Is<Uri>(u => u.ToString() == "meta/public_keys/copilot_api")).Returns(Task.FromResult(publicKeys));
+
+                var client = new PublicKeysClient(apiConnection);
+
+                var result = await client.Get(PublicKeyType.CopilotApi);
+
+                Assert.Equal(2, result.PublicKeys.Count);
+                Assert.Equal("4fe6b016179b74078ade7581abf4e84fb398c6fae4fb973972235b84fcd70ca3", result.PublicKeys[0].KeyIdentifier);
+                Assert.Equal("-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELPuPiLVQbHY/clvpNnY+0BzYIXgo\nS0+XhEkTWUZEEznIVpS3rQseDTG6//gEWr4j9fY35+dGOxwOx3Z9mK3i7w==\n-----END PUBLIC KEY-----\n", result.PublicKeys[0].Key);
+                Assert.True(result.PublicKeys[0].IsCurrent);
+
+                Assert.Equal("df3454252d91570ae1bc597182d1183c7a8d42ff0ae96e0f2be4ba278d776546", result.PublicKeys[1].KeyIdentifier);
+                Assert.Equal("-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEl5xbyr5bmETCJzqAvDnYl1ZKJrkf\n89Nyq5j06TTKrnHXXDw4FYNY1uF2S/w6EOaxbf9BxOidCLvjJ8ZgKzNpww==\n-----END PUBLIC KEY-----\n", result.PublicKeys[1].Key);
+                Assert.False(result.PublicKeys[1].IsCurrent);
+
+                apiConnection.Received()
+                    .Get<MetaPublicKeys>(Arg.Is<Uri>(u => u.ToString() == "meta/public_keys/copilot_api"));
+            }
+
+            [Fact]
+            public async Task RequestSecretScanningPublicKeysEndpoint()
+            {
+                var publicKeys = new MetaPublicKeys(publicKeys: new[] {
+                    new MetaPublicKey("90a421169f0a406205f1563a953312f0be898d3c7b6c06b681aa86a874555f4a", "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE9MJJHnMfn2+H4xL4YaPDA4RpJqUq\nkCmRCBnYERxZanmcpzQSXs1X/AljlKkbJ8qpVIW4clayyef9gWhFbNHWAA==\n-----END PUBLIC KEY-----\n", false),
+                    new MetaPublicKey("bcb53661c06b4728e59d897fb6165d5c9cda0fd9cdf9d09ead458168deb7518c", "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYAGMWO8XgCamYKMJS6jc/qgvSlAd\nAjPuDPRcXU22YxgBrz+zoN19MzuRyW87qEt9/AmtoNP5GrobzUvQSyJFVw==\n-----END PUBLIC KEY-----\n", true)
+                });
+
+                var apiConnection = Substitute.For<IApiConnection>();
+                apiConnection.Get<MetaPublicKeys>(Arg.Is<Uri>(u => u.ToString() == "meta/public_keys/secret_scanning")).Returns(Task.FromResult(publicKeys));
+
+                var client = new PublicKeysClient(apiConnection);
+
+                var result = await client.Get(PublicKeyType.SecretScanning);
+
+                Assert.Equal(2, result.PublicKeys.Count);
+                Assert.Equal("90a421169f0a406205f1563a953312f0be898d3c7b6c06b681aa86a874555f4a", result.PublicKeys[0].KeyIdentifier);
+                Assert.Equal("-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE9MJJHnMfn2+H4xL4YaPDA4RpJqUq\nkCmRCBnYERxZanmcpzQSXs1X/AljlKkbJ8qpVIW4clayyef9gWhFbNHWAA==\n-----END PUBLIC KEY-----\n", result.PublicKeys[0].Key);
+                Assert.False(result.PublicKeys[0].IsCurrent);
+
+                Assert.Equal("bcb53661c06b4728e59d897fb6165d5c9cda0fd9cdf9d09ead458168deb7518c", result.PublicKeys[1].KeyIdentifier);
+                Assert.Equal("-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYAGMWO8XgCamYKMJS6jc/qgvSlAd\nAjPuDPRcXU22YxgBrz+zoN19MzuRyW87qEt9/AmtoNP5GrobzUvQSyJFVw==\n-----END PUBLIC KEY-----\n", result.PublicKeys[1].Key);
+                Assert.True(result.PublicKeys[1].IsCurrent);
+
+                apiConnection.Received()
+                    .Get<MetaPublicKeys>(Arg.Is<Uri>(u => u.ToString() == "meta/public_keys/secret_scanning"));
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Models/MetaPublicKeysTests.cs
+++ b/Octokit.Tests/Models/MetaPublicKeysTests.cs
@@ -1,0 +1,44 @@
+using Octokit.Internal;
+using Xunit;
+
+namespace Octokit.Tests.Models
+{
+    public class MetaPublicKeysTests
+    {
+        [Fact]
+        public void CanBeDeserialized()
+        {
+            const string json = @"{
+  ""public_keys"": [
+    {
+      ""key_identifier"": ""90a421169f0a406205f1563a953312f0be898d3c7b6c06b681aa86a874555f4a"",
+      ""key"": ""-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE9MJJHnMfn2+H4xL4YaPDA4RpJqUq\nkCmRCBnYERxZanmcpzQSXs1X/AljlKkbJ8qpVIW4clayyef9gWhFbNHWAA==\n-----END PUBLIC KEY-----\n"",
+      ""is_current"": false
+    },
+    {
+      ""key_identifier"": ""bcb53661c06b4728e59d897fb6165d5c9cda0fd9cdf9d09ead458168deb7518c"",
+      ""key"": ""-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYAGMWO8XgCamYKMJS6jc/qgvSlAd\nAjPuDPRcXU22YxgBrz+zoN19MzuRyW87qEt9/AmtoNP5GrobzUvQSyJFVw==\n-----END PUBLIC KEY-----\n"",
+      ""is_current"": true
+    }
+  ]
+}
+";
+            var serializer = new SimpleJsonSerializer();
+
+            var keys = serializer.Deserialize<MetaPublicKeys>(json);
+
+            Assert.NotNull(keys);
+            Assert.Equal(2, keys.PublicKeys.Count);
+
+            var key1 = keys.PublicKeys[0];
+            Assert.Equal("90a421169f0a406205f1563a953312f0be898d3c7b6c06b681aa86a874555f4a", key1.KeyIdentifier);
+            Assert.Equal("-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE9MJJHnMfn2+H4xL4YaPDA4RpJqUq\nkCmRCBnYERxZanmcpzQSXs1X/AljlKkbJ8qpVIW4clayyef9gWhFbNHWAA==\n-----END PUBLIC KEY-----\n", key1.Key);
+            Assert.False(key1.IsCurrent);
+
+            var key2 = keys.PublicKeys[1];
+            Assert.Equal("bcb53661c06b4728e59d897fb6165d5c9cda0fd9cdf9d09ead458168deb7518c", key2.KeyIdentifier);
+            Assert.Equal("-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYAGMWO8XgCamYKMJS6jc/qgvSlAd\nAjPuDPRcXU22YxgBrz+zoN19MzuRyW87qEt9/AmtoNP5GrobzUvQSyJFVw==\n-----END PUBLIC KEY-----\n", key2.Key);
+            Assert.True(key2.IsCurrent);
+        }
+    }
+}

--- a/Octokit.Tests/Reactive/ObservablePublicKeysClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservablePublicKeysClientTests.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using NSubstitute;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Reactive
+{
+    public class ObservablePublicKeysClientTests
+    {
+        public class TheGetMethod
+        {
+            [Fact]
+            public void CallsIntoClient()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservablePublicKeysClient(gitHubClient);
+
+                client.Get(PublicKeyType.SecretScanning);
+
+                gitHubClient.Meta.PublicKeys.Received(1).Get(PublicKeyType.SecretScanning);
+            }
+        }
+
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(() => new ObservablePublicKeysClient((IGitHubClient)null));
+            }
+        }
+    }
+}

--- a/Octokit/Clients/IMetaClient.cs
+++ b/Octokit/Clients/IMetaClient.cs
@@ -11,6 +11,11 @@ namespace Octokit
     public interface IMetaClient
     {
         /// <summary>
+        /// Returns a client to get public keys for validating request signatures.
+        /// </summary>
+        IPublicKeysClient PublicKeys { get; }
+
+        /// <summary>
         /// Retrieves information about GitHub.com, the service or a GitHub Enterprise installation.
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>

--- a/Octokit/Clients/IPublicKeysClient.cs
+++ b/Octokit/Clients/IPublicKeysClient.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+
+namespace Octokit
+{
+    /// <summary>
+    /// A client for GitHub's meta public keys API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://docs.github.com/code-security/secret-scanning/secret-scanning-partner-program#implement-signature-verification-in-your-secret-alert-service">Secret scanning documentation</a> for more details.
+    /// </remarks>
+    public interface IPublicKeysClient
+    {
+        /// <summary>
+        /// Retrieves public keys for validating request signatures.
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>An <see cref="MetaPublicKeys"/> containing public keys for validating request signatures.</returns>
+        Task<MetaPublicKeys> Get(PublicKeyType keysType);
+    }
+}

--- a/Octokit/Clients/MetaClient.cs
+++ b/Octokit/Clients/MetaClient.cs
@@ -18,7 +18,13 @@ namespace Octokit
         public MetaClient(IApiConnection apiConnection)
             : base(apiConnection)
         {
+            PublicKeys = new PublicKeysClient(apiConnection);
         }
+
+        /// <summary>
+        /// Returns a client to manage get public keys for validating request signatures.
+        /// </summary>
+        public IPublicKeysClient PublicKeys { get; private set; }
 
         /// <summary>
         /// Retrieves information about GitHub.com, the service or a GitHub Enterprise installation.

--- a/Octokit/Clients/PublicKeysClient.cs
+++ b/Octokit/Clients/PublicKeysClient.cs
@@ -1,0 +1,33 @@
+using System.Threading.Tasks;
+
+namespace Octokit
+{
+    /// <summary>
+    /// A client for GitHub's public keys API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://docs.github.com/code-security/secret-scanning/secret-scanning-partner-program#implement-signature-verification-in-your-secret-alert-service">Secret scanning documentation</a> for more details.
+    /// </remarks>
+    public class PublicKeysClient : ApiClient, IPublicKeysClient
+    {
+        /// <summary>
+        /// Initializes a new GitHub Meta Public Keys API client.
+        /// </summary>
+        /// <param name="apiConnection">An API connection.</param>
+        public PublicKeysClient(IApiConnection apiConnection)
+            : base(apiConnection)
+        {
+        }
+
+        /// <summary>
+        /// Retrieves public keys for validating request signatures.
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>An <see cref="MetaPublicKeys"/> containing public keys for validating request signatures.</returns>
+        [ManualRoute("GET", "/meta/public_keys/{keysType}")]
+        public Task<MetaPublicKeys> Get(PublicKeyType keysType)
+        {
+            return ApiConnection.Get<MetaPublicKeys>(ApiUrls.PublicKeys(keysType));
+        }
+    }
+}

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -4834,6 +4834,16 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Returns the <see cref="Uri"/> that returns meta in
+        /// response to a GET request.
+        /// </summary>
+        /// <returns>The <see cref="Uri"/> to meta.</returns>
+        public static Uri PublicKeys(PublicKeyType keysType)
+        {
+            return "meta/public_keys/{0}".FormatUri(keysType.ToParameter());
+        }
+
+        /// <summary>
         /// Returns the <see cref="Uri"/> that returns all organization credentials in
         /// response to a GET request.
         /// </summary>

--- a/Octokit/Models/Common/PublicKeyType.cs
+++ b/Octokit/Models/Common/PublicKeyType.cs
@@ -1,0 +1,19 @@
+using Octokit.Internal;
+
+namespace Octokit
+{
+    public enum PublicKeyType
+    {
+        /// <summary>
+        /// Copilot API public keys for validating request signatures
+        /// </summary>
+        [Parameter(Value = "copilot_api")]
+        CopilotApi,
+
+        /// <summary>
+        /// Secret scanning public keys for validating request signatures
+        /// </summary>
+        [Parameter(Value = "secret_scanning")]
+        SecretScanning
+    }
+}

--- a/Octokit/Models/Response/MetaPublicKey.cs
+++ b/Octokit/Models/Response/MetaPublicKey.cs
@@ -1,0 +1,29 @@
+using System.Diagnostics;
+using System.Globalization;
+
+namespace Octokit
+{
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class MetaPublicKey
+    {
+        public MetaPublicKey() { }
+
+        public MetaPublicKey(string keyIdentifier, string key, bool isCurrent)
+        {
+            KeyIdentifier = keyIdentifier;
+            Key = key;
+            IsCurrent = isCurrent;
+        }
+
+        public string KeyIdentifier { get; protected set; }
+
+        public string Key { get; protected set; }
+
+        public bool IsCurrent { get; protected set; }
+
+        internal string DebuggerDisplay
+        {
+            get { return string.Format(CultureInfo.InvariantCulture, "KeyIdentifier: {0} IsCurrent: {1}", KeyIdentifier, IsCurrent); }
+        }
+    }
+}

--- a/Octokit/Models/Response/MetaPublicKeys.cs
+++ b/Octokit/Models/Response/MetaPublicKeys.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace Octokit
+{
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class MetaPublicKeys
+    {
+        public MetaPublicKeys() { }
+
+        public MetaPublicKeys(IReadOnlyList<MetaPublicKey> publicKeys)
+        {
+            PublicKeys = publicKeys;
+        }
+
+        public IReadOnlyList<MetaPublicKey> PublicKeys { get; protected set; }
+
+        internal string DebuggerDisplay
+        {
+            get { return string.Format(CultureInfo.InvariantCulture, "PublicKeys: {0}", PublicKeys.Count); }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2944

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* No support for `/meta/public_keys/<keyType>`.

[Secret Scanning](https://docs.github.com/en/code-security/secret-scanning/secret-scanning-partner-program#implement-signature-verification-in-your-secret-alert-service) and [Copilot Extensions](https://github.blog/2024-05-21-introducing-github-copilot-extensions/) enable [signature verification](https://docs.github.com/en/code-security/secret-scanning/secret-scanning-partner-program#implement-signature-verification-in-your-secret-alert-service) using public keys from the [meta/public_keys](https://api.github.com/meta/public_keys/secret_scanning) API.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Adds support via`Client.Meta.PublicKeys.Get`

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
