### PR TITLE
[FIX]: reworks all number parameter names to represent what they actually are. Refactors some types to be the appropriate types based on OpenAPI and docs.

### DIFF
--- a/Octokit.AsyncPaginationExtension/Extensions.cs
+++ b/Octokit.AsyncPaginationExtension/Extensions.cs
@@ -15,289 +15,17 @@ namespace Octokit.AsyncPaginationExtension
   {
     private const int DEFAULT_PAGE_SIZE = 30;
 
-    /// <inheritdoc cref="IPullRequestReviewCommentsClient.GetAll(string, string, int, ApiOptions)"/>
-    public static IPaginatedList<PullRequestReviewComment> GetAllAsync(this IPullRequestReviewCommentsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAll(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IPullRequestReviewCommentsClient.GetAll(long, int, ApiOptions)"/>
-    public static IPaginatedList<PullRequestReviewComment> GetAllAsync(this IPullRequestReviewCommentsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAll(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IPullRequestReviewCommentsClient.GetAllForRepository(string, string, ApiOptions)"/>
-    public static IPaginatedList<PullRequestReviewComment> GetAllForRepositoryAsync(this IPullRequestReviewCommentsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IPullRequestReviewCommentsClient.GetAllForRepository(long, ApiOptions)"/>
-    public static IPaginatedList<PullRequestReviewComment> GetAllForRepositoryAsync(this IPullRequestReviewCommentsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IPullRequestReviewCommentsClient.GetAllForRepository(string, string, PullRequestReviewCommentRequest, ApiOptions)"/>
-    public static IPaginatedList<PullRequestReviewComment> GetAllForRepositoryAsync(this IPullRequestReviewCommentsClient t, string owner, string name, PullRequestReviewCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IPullRequestReviewCommentsClient.GetAllForRepository(long, PullRequestReviewCommentRequest, ApiOptions)"/>
-    public static IPaginatedList<PullRequestReviewComment> GetAllForRepositoryAsync(this IPullRequestReviewCommentsClient t, long repositoryId, PullRequestReviewCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IReleasesClient.GetAll(string, string, ApiOptions)"/>
-    public static IPaginatedList<Release> GetAllAsync(this IReleasesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Release>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IReleasesClient.GetAll(long, ApiOptions)"/>
-    public static IPaginatedList<Release> GetAllAsync(this IReleasesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Release>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IReleasesClient.GetAllAssets(string, string, long, ApiOptions)"/>
-    public static IPaginatedList<ReleaseAsset> GetAllAssetsAsync(this IReleasesClient t, string owner, string name, long id, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<ReleaseAsset>(options => t.GetAllAssets(owner, name, id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IReleasesClient.GetAllAssets(long, long, ApiOptions)"/>
-    public static IPaginatedList<ReleaseAsset> GetAllAssetsAsync(this IReleasesClient t, long repositoryId, long id, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<ReleaseAsset>(options => t.GetAllAssets(repositoryId, id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IProjectsClient.GetAllForRepository(string, string, ApiOptions)"/>
-    public static IPaginatedList<Project> GetAllForRepositoryAsync(this IProjectsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IProjectsClient.GetAllForRepository(string, string, ProjectRequest, ApiOptions)"/>
-    public static IPaginatedList<Project> GetAllForRepositoryAsync(this IProjectsClient t, string owner, string name, ProjectRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IProjectsClient.GetAllForRepository(long, ApiOptions)"/>
-    public static IPaginatedList<Project> GetAllForRepositoryAsync(this IProjectsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IProjectsClient.GetAllForRepository(long, ProjectRequest, ApiOptions)"/>
-    public static IPaginatedList<Project> GetAllForRepositoryAsync(this IProjectsClient t, long repositoryId, ProjectRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IProjectsClient.GetAllForOrganization(string, ApiOptions)"/>
-    public static IPaginatedList<Project> GetAllForOrganizationAsync(this IProjectsClient t, string organization, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForOrganization(organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IProjectsClient.GetAllForOrganization(string, ProjectRequest, ApiOptions)"/>
-    public static IPaginatedList<Project> GetAllForOrganizationAsync(this IProjectsClient t, string organization, ProjectRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForOrganization(organization, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IGistsClient.GetAll(ApiOptions)"/>
-    public static IPaginatedList<Gist> GetAllAsync(this IGistsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Gist>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IGistsClient.GetAll(DateTimeOffset, ApiOptions)"/>
-    public static IPaginatedList<Gist> GetAllAsync(this IGistsClient t, DateTimeOffset since, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Gist>(options => t.GetAll(since, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IGistsClient.GetAllPublic(ApiOptions)"/>
-    public static IPaginatedList<Gist> GetAllPublicAsync(this IGistsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Gist>(t.GetAllPublic, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IGistsClient.GetAllPublic(DateTimeOffset, ApiOptions)"/>
-    public static IPaginatedList<Gist> GetAllPublicAsync(this IGistsClient t, DateTimeOffset since, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Gist>(options => t.GetAllPublic(since, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IGistsClient.GetAllStarred(ApiOptions)"/>
-    public static IPaginatedList<Gist> GetAllStarredAsync(this IGistsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Gist>(t.GetAllStarred, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IGistsClient.GetAllStarred(DateTimeOffset, ApiOptions)"/>
-    public static IPaginatedList<Gist> GetAllStarredAsync(this IGistsClient t, DateTimeOffset since, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Gist>(options => t.GetAllStarred(since, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IGistsClient.GetAllForUser(string, ApiOptions)"/>
-    public static IPaginatedList<Gist> GetAllForUserAsync(this IGistsClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Gist>(options => t.GetAllForUser(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IGistsClient.GetAllForUser(string, DateTimeOffset, ApiOptions)"/>
-    public static IPaginatedList<Gist> GetAllForUserAsync(this IGistsClient t, string user, DateTimeOffset since, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Gist>(options => t.GetAllForUser(user, since, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IGistsClient.GetAllCommits(string, ApiOptions)"/>
-    public static IPaginatedList<GistHistory> GetAllCommitsAsync(this IGistsClient t, string id, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<GistHistory>(options => t.GetAllCommits(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IGistsClient.GetAllForks(string, ApiOptions)"/>
-    public static IPaginatedList<GistFork> GetAllForksAsync(this IGistsClient t, string id, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<GistFork>(options => t.GetAllForks(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IStarredClient.GetAllStargazers(string, string, ApiOptions)"/>
-    public static IPaginatedList<User> GetAllStargazersAsync(this IStarredClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllStargazers(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IStarredClient.GetAllStargazers(long, ApiOptions)"/>
-    public static IPaginatedList<User> GetAllStargazersAsync(this IStarredClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllStargazers(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IStarredClient.GetAllStargazersWithTimestamps(string, string, ApiOptions)"/>
-    public static IPaginatedList<UserStar> GetAllStargazersWithTimestampsAsync(this IStarredClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<UserStar>(options => t.GetAllStargazersWithTimestamps(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IStarredClient.GetAllStargazersWithTimestamps(long, ApiOptions)"/>
-    public static IPaginatedList<UserStar> GetAllStargazersWithTimestampsAsync(this IStarredClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<UserStar>(options => t.GetAllStargazersWithTimestamps(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IStarredClient.GetAllForCurrent(ApiOptions)"/>
-    public static IPaginatedList<Repository> GetAllForCurrentAsync(this IStarredClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Repository>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IStarredClient.GetAllForCurrentWithTimestamps(ApiOptions)"/>
-    public static IPaginatedList<RepositoryStar> GetAllForCurrentWithTimestampsAsync(this IStarredClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<RepositoryStar>(t.GetAllForCurrentWithTimestamps, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IStarredClient.GetAllForCurrent(StarredRequest, ApiOptions)"/>
-    public static IPaginatedList<Repository> GetAllForCurrentAsync(this IStarredClient t, StarredRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForCurrent(request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IStarredClient.GetAllForCurrentWithTimestamps(StarredRequest, ApiOptions)"/>
-    public static IPaginatedList<RepositoryStar> GetAllForCurrentWithTimestampsAsync(this IStarredClient t, StarredRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<RepositoryStar>(options => t.GetAllForCurrentWithTimestamps(request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IStarredClient.GetAllForUser(string, ApiOptions)"/>
-    public static IPaginatedList<Repository> GetAllForUserAsync(this IStarredClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForUser(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IStarredClient.GetAllForUserWithTimestamps(string, ApiOptions)"/>
-    public static IPaginatedList<RepositoryStar> GetAllForUserWithTimestampsAsync(this IStarredClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<RepositoryStar>(options => t.GetAllForUserWithTimestamps(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IStarredClient.GetAllForUser(string, StarredRequest, ApiOptions)"/>
-    public static IPaginatedList<Repository> GetAllForUserAsync(this IStarredClient t, string user, StarredRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForUser(user, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IStarredClient.GetAllForUserWithTimestamps(string, StarredRequest, ApiOptions)"/>
-    public static IPaginatedList<RepositoryStar> GetAllForUserWithTimestampsAsync(this IStarredClient t, string user, StarredRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<RepositoryStar>(options => t.GetAllForUserWithTimestamps(user, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="ILicensesClient.GetAllLicenses(ApiOptions)"/>
-    public static IPaginatedList<LicenseMetadata> GetAllLicensesAsync(this ILicensesClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<LicenseMetadata>(t.GetAllLicenses, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="ICommitCommentReactionsClient.GetAll(string, string, long, ApiOptions)"/>
-    public static IPaginatedList<Reaction> GetAllAsync(this ICommitCommentReactionsClient t, string owner, string name, long commentId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(owner, name, commentId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="ICommitCommentReactionsClient.GetAll(long, long, ApiOptions)"/>
-    public static IPaginatedList<Reaction> GetAllAsync(this ICommitCommentReactionsClient t, long repositoryId, long commentId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(repositoryId, commentId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IPullRequestReviewsClient.GetAll(string, string, int, ApiOptions)"/>
-    public static IPaginatedList<PullRequestReview> GetAllAsync(this IPullRequestReviewsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PullRequestReview>(options => t.GetAll(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IPullRequestReviewsClient.GetAll(long, int, ApiOptions)"/>
-    public static IPaginatedList<PullRequestReview> GetAllAsync(this IPullRequestReviewsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PullRequestReview>(options => t.GetAll(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IPullRequestReviewsClient.GetAllComments(string, string, int, long, ApiOptions)"/>
-    public static IPaginatedList<PullRequestReviewComment> GetAllCommentsAsync(this IPullRequestReviewsClient t, string owner, string name, int number, long reviewId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllComments(owner, name, number, reviewId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IPullRequestReviewsClient.GetAllComments(long, int, long, ApiOptions)"/>
-    public static IPaginatedList<PullRequestReviewComment> GetAllCommentsAsync(this IPullRequestReviewsClient t, long repositoryId, int number, long reviewId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllComments(repositoryId, number, reviewId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IActionsSelfHostedRunnerGroupsClient.ListAllRunnerGroupOrganizationsForEnterprise(string, long, ApiOptions)"/>
-    public static IPaginatedList<Organization> ListAllRunnerGroupOrganizationsForEnterpriseAsync(this IActionsSelfHostedRunnerGroupsClient t, string enterprise, long runnerGroupId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Organization>(options => t.ListAllRunnerGroupOrganizationsForEnterprise(enterprise, runnerGroupId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IActionsSelfHostedRunnerGroupsClient.ListAllRunnerGroupRepositoriesForOrganization(string, long, ApiOptions)"/>
-    public static IPaginatedList<Repository> ListAllRunnerGroupRepositoriesForOrganizationAsync(this IActionsSelfHostedRunnerGroupsClient t, string org, long runnerGroupId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Repository>(options => t.ListAllRunnerGroupRepositoriesForOrganization(org, runnerGroupId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IRepositoryDeployKeysClient.GetAll(string, string, ApiOptions)"/>
-    public static IPaginatedList<DeployKey> GetAllAsync(this IRepositoryDeployKeysClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<DeployKey>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IRepositoryDeployKeysClient.GetAll(long, ApiOptions)"/>
-    public static IPaginatedList<DeployKey> GetAllAsync(this IRepositoryDeployKeysClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<DeployKey>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IRepositoryForksClient.GetAll(string, string, ApiOptions)"/>
-    public static IPaginatedList<Repository> GetAllAsync(this IRepositoryForksClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IRepositoryForksClient.GetAll(long, ApiOptions)"/>
-    public static IPaginatedList<Repository> GetAllAsync(this IRepositoryForksClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IRepositoryForksClient.GetAll(string, string, RepositoryForksListRequest, ApiOptions)"/>
-    public static IPaginatedList<Repository> GetAllAsync(this IRepositoryForksClient t, string owner, string name, RepositoryForksListRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAll(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IRepositoryForksClient.GetAll(long, RepositoryForksListRequest, ApiOptions)"/>
-    public static IPaginatedList<Repository> GetAllAsync(this IRepositoryForksClient t, long repositoryId, RepositoryForksListRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAll(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IIssueCommentReactionsClient.GetAll(string, string, long, ApiOptions)"/>
-    public static IPaginatedList<Reaction> GetAllAsync(this IIssueCommentReactionsClient t, string owner, string name, long commentId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(owner, name, commentId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IIssueCommentReactionsClient.GetAll(long, long, ApiOptions)"/>
-    public static IPaginatedList<Reaction> GetAllAsync(this IIssueCommentReactionsClient t, long repositoryId, long commentId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(repositoryId, commentId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IRepositoryInvitationsClient.GetAllForCurrent(ApiOptions)"/>
-    public static IPaginatedList<RepositoryInvitation> GetAllForCurrentAsync(this IRepositoryInvitationsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<RepositoryInvitation>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IRepositoryInvitationsClient.GetAllForRepository(long, ApiOptions)"/>
-    public static IPaginatedList<RepositoryInvitation> GetAllForRepositoryAsync(this IRepositoryInvitationsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<RepositoryInvitation>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IOrganizationHooksClient.GetAll(string, ApiOptions)"/>
-    public static IPaginatedList<OrganizationHook> GetAllAsync(this IOrganizationHooksClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<OrganizationHook>(options => t.GetAll(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IRepositoryCommentsClient.GetAllForRepository(string, string, ApiOptions)"/>
-    public static IPaginatedList<CommitComment> GetAllForRepositoryAsync(this IRepositoryCommentsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<CommitComment>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IRepositoryCommentsClient.GetAllForRepository(long, ApiOptions)"/>
-    public static IPaginatedList<CommitComment> GetAllForRepositoryAsync(this IRepositoryCommentsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<CommitComment>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IRepositoryCommentsClient.GetAllForCommit(string, string, string, ApiOptions)"/>
-    public static IPaginatedList<CommitComment> GetAllForCommitAsync(this IRepositoryCommentsClient t, string owner, string name, string sha, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<CommitComment>(options => t.GetAllForCommit(owner, name, sha, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IRepositoryCommentsClient.GetAllForCommit(long, string, ApiOptions)"/>
-    public static IPaginatedList<CommitComment> GetAllForCommitAsync(this IRepositoryCommentsClient t, long repositoryId, string sha, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<CommitComment>(options => t.GetAllForCommit(repositoryId, sha, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IRepoCollaboratorsClient.GetAll(string, string, ApiOptions)"/>
-    public static IPaginatedList<Collaborator> GetAllAsync(this IRepoCollaboratorsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Collaborator>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IRepoCollaboratorsClient.GetAll(long, ApiOptions)"/>
-    public static IPaginatedList<Collaborator> GetAllAsync(this IRepoCollaboratorsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Collaborator>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IRepoCollaboratorsClient.GetAll(string, string, RepositoryCollaboratorListRequest, ApiOptions)"/>
-    public static IPaginatedList<Collaborator> GetAllAsync(this IRepoCollaboratorsClient t, string owner, string name, RepositoryCollaboratorListRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Collaborator>(options => t.GetAll(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IRepoCollaboratorsClient.GetAll(long, RepositoryCollaboratorListRequest, ApiOptions)"/>
-    public static IPaginatedList<Collaborator> GetAllAsync(this IRepoCollaboratorsClient t, long repositoryId, RepositoryCollaboratorListRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Collaborator>(options => t.GetAll(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IUserGpgKeysClient.GetAllForCurrent(ApiOptions)"/>
-    public static IPaginatedList<GpgKey> GetAllForCurrentAsync(this IUserGpgKeysClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<GpgKey>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IActionsSelfHostedRunnersClient.ListAllRunnerApplicationsForEnterprise(string, ApiOptions)"/>
-    public static IPaginatedList<RunnerApplication> ListAllRunnerApplicationsForEnterpriseAsync(this IActionsSelfHostedRunnersClient t, string enterprise, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<RunnerApplication>(options => t.ListAllRunnerApplicationsForEnterprise(enterprise, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IActionsSelfHostedRunnersClient.ListAllRunnerApplicationsForOrganization(string, ApiOptions)"/>
-    public static IPaginatedList<RunnerApplication> ListAllRunnerApplicationsForOrganizationAsync(this IActionsSelfHostedRunnersClient t, string organization, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<RunnerApplication>(options => t.ListAllRunnerApplicationsForOrganization(organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IActionsSelfHostedRunnersClient.ListAllRunnerApplicationsForRepository(string, string, ApiOptions)"/>
-    public static IPaginatedList<RunnerApplication> ListAllRunnerApplicationsForRepositoryAsync(this IActionsSelfHostedRunnersClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<RunnerApplication>(options => t.ListAllRunnerApplicationsForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IAutolinksClient.GetAll(string, string, ApiOptions)"/>
-    public static IPaginatedList<Autolink> GetAllAsync(this IAutolinksClient t, string owner, string repo, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Autolink>(options => t.GetAll(owner, repo, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IApiConnection.GetAll(Uri, ApiOptions)"/>
+    public static IPaginatedList<T> GetAllAsync<T>(this IApiConnection t, Uri uri, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<T>(options => t.GetAll<T>(uri, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IApiConnection.GetAll(Uri, IDictionary{string, string}, ApiOptions)"/>
+    public static IPaginatedList<T> GetAllAsync<T>(this IApiConnection t, Uri uri, IDictionary<string, string> parameters, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<T>(options => t.GetAll<T>(uri, parameters, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IApiConnection.GetAll(Uri, IDictionary{string, string}, string, ApiOptions)"/>
+    public static IPaginatedList<T> GetAllAsync<T>(this IApiConnection t, Uri uri, IDictionary<string, string> parameters, string accepts, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<T>(options => t.GetAll<T>(uri, parameters, accepts, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
     /// <inheritdoc cref="IIssueCommentsClient.GetAllForRepository(string, string, ApiOptions)"/>
     public static IPaginatedList<IssueComment> GetAllForRepositoryAsync(this IIssueCommentsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
@@ -316,20 +44,28 @@ namespace Octokit.AsyncPaginationExtension
         => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
     /// <inheritdoc cref="IIssueCommentsClient.GetAllForIssue(string, string, int, ApiOptions)"/>
-    public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForIssue(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, string owner, string name, int issueNumber, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForIssue(owner, name, issueNumber, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
     /// <inheritdoc cref="IIssueCommentsClient.GetAllForIssue(long, int, ApiOptions)"/>
-    public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForIssue(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, long repositoryId, int issueNumber, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForIssue(repositoryId, issueNumber, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
     /// <inheritdoc cref="IIssueCommentsClient.GetAllForIssue(string, string, int, IssueCommentRequest, ApiOptions)"/>
-    public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, string owner, string name, int number, IssueCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForIssue(owner, name, number, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, string owner, string name, int issueNumber, IssueCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForIssue(owner, name, issueNumber, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
     /// <inheritdoc cref="IIssueCommentsClient.GetAllForIssue(long, int, IssueCommentRequest, ApiOptions)"/>
-    public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, long repositoryId, int number, IssueCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForIssue(repositoryId, number, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, long repositoryId, int issueNumber, IssueCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForIssue(repositoryId, issueNumber, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryPagesClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<PagesBuild> GetAllAsync(this IRepositoryPagesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PagesBuild>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryPagesClient.GetAll(long, ApiOptions)"/>
+    public static IPaginatedList<PagesBuild> GetAllAsync(this IRepositoryPagesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PagesBuild>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
     /// <inheritdoc cref="IWatchedClient.GetAllWatchers(string, string, ApiOptions)"/>
     public static IPaginatedList<User> GetAllWatchersAsync(this IWatchedClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
@@ -346,246 +82,6 @@ namespace Octokit.AsyncPaginationExtension
     /// <inheritdoc cref="IWatchedClient.GetAllForUser(string, ApiOptions)"/>
     public static IPaginatedList<Repository> GetAllForUserAsync(this IWatchedClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForUser(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IIssuesEventsClient.GetAllForIssue(string, string, int, ApiOptions)"/>
-    public static IPaginatedList<IssueEvent> GetAllForIssueAsync(this IIssuesEventsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllForIssue(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IIssuesEventsClient.GetAllForIssue(long, int, ApiOptions)"/>
-    public static IPaginatedList<IssueEvent> GetAllForIssueAsync(this IIssuesEventsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllForIssue(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IIssuesEventsClient.GetAllForRepository(string, string, ApiOptions)"/>
-    public static IPaginatedList<IssueEvent> GetAllForRepositoryAsync(this IIssuesEventsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IIssuesEventsClient.GetAllForRepository(long, ApiOptions)"/>
-    public static IPaginatedList<IssueEvent> GetAllForRepositoryAsync(this IIssuesEventsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IMiscellaneousClient.GetAllLicenses(ApiOptions)"/>
-    public static IPaginatedList<LicenseMetadata> GetAllLicensesAsync(this IMiscellaneousClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<LicenseMetadata>(t.GetAllLicenses, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IIssueTimelineClient.GetAllForIssue(string, string, int, ApiOptions)"/>
-    public static IPaginatedList<TimelineEventInfo> GetAllForIssueAsync(this IIssueTimelineClient t, string owner, string repo, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<TimelineEventInfo>(options => t.GetAllForIssue(owner, repo, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IIssueTimelineClient.GetAllForIssue(long, int, ApiOptions)"/>
-    public static IPaginatedList<TimelineEventInfo> GetAllForIssueAsync(this IIssueTimelineClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<TimelineEventInfo>(options => t.GetAllForIssue(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IProjectCardsClient.GetAll(int, ApiOptions)"/>
-    public static IPaginatedList<ProjectCard> GetAllAsync(this IProjectCardsClient t, int columnId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<ProjectCard>(options => t.GetAll(columnId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IProjectCardsClient.GetAll(int, ProjectCardRequest, ApiOptions)"/>
-    public static IPaginatedList<ProjectCard> GetAllAsync(this IProjectCardsClient t, int columnId, ProjectCardRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<ProjectCard>(options => t.GetAll(columnId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IRepositoryCommitsClient.BranchesWhereHead(long, string, ApiOptions)"/>
-    public static IPaginatedList<Branch> BranchesWhereHeadAsync(this IRepositoryCommitsClient t, long repositoryId, string sha1, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Branch>(options => t.BranchesWhereHead(repositoryId, sha1, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IRepositoryCommitsClient.BranchesWhereHead(string, string, string, ApiOptions)"/>
-    public static IPaginatedList<Branch> BranchesWhereHeadAsync(this IRepositoryCommitsClient t, string owner, string name, string sha1, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Branch>(options => t.BranchesWhereHead(owner, name, sha1, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IRepositoryCommitsClient.GetAll(string, string, ApiOptions)"/>
-    public static IPaginatedList<GitHubCommit> GetAllAsync(this IRepositoryCommitsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<GitHubCommit>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IRepositoryCommitsClient.GetAll(long, ApiOptions)"/>
-    public static IPaginatedList<GitHubCommit> GetAllAsync(this IRepositoryCommitsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<GitHubCommit>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IRepositoryCommitsClient.GetAll(string, string, CommitRequest, ApiOptions)"/>
-    public static IPaginatedList<GitHubCommit> GetAllAsync(this IRepositoryCommitsClient t, string owner, string name, CommitRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<GitHubCommit>(options => t.GetAll(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IRepositoryCommitsClient.GetAll(long, CommitRequest, ApiOptions)"/>
-    public static IPaginatedList<GitHubCommit> GetAllAsync(this IRepositoryCommitsClient t, long repositoryId, CommitRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<GitHubCommit>(options => t.GetAll(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IRepositoryCommitsClient.PullRequests(long, string, ApiOptions)"/>
-    public static IPaginatedList<CommitPullRequest> PullRequestsAsync(this IRepositoryCommitsClient t, long repositoryId, string sha1, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<CommitPullRequest>(options => t.PullRequests(repositoryId, sha1, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IRepositoryCommitsClient.PullRequests(string, string, string, ApiOptions)"/>
-    public static IPaginatedList<CommitPullRequest> PullRequestsAsync(this IRepositoryCommitsClient t, string owner, string name, string sha1, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<CommitPullRequest>(options => t.PullRequests(owner, name, sha1, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IDeploymentsClient.GetAll(string, string, ApiOptions)"/>
-    public static IPaginatedList<Deployment> GetAllAsync(this IDeploymentsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Deployment>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IDeploymentsClient.GetAll(long, ApiOptions)"/>
-    public static IPaginatedList<Deployment> GetAllAsync(this IDeploymentsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Deployment>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IAssigneesClient.GetAllForRepository(string, string, ApiOptions)"/>
-    public static IPaginatedList<User> GetAllForRepositoryAsync(this IAssigneesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IAssigneesClient.GetAllForRepository(long, ApiOptions)"/>
-    public static IPaginatedList<User> GetAllForRepositoryAsync(this IAssigneesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IIssuesClient.GetAllForCurrent(ApiOptions)"/>
-    public static IPaginatedList<Issue> GetAllForCurrentAsync(this IIssuesClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Issue>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IIssuesClient.GetAllForCurrent(IssueRequest, ApiOptions)"/>
-    public static IPaginatedList<Issue> GetAllForCurrentAsync(this IIssuesClient t, IssueRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForCurrent(request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IIssuesClient.GetAllForOwnedAndMemberRepositories(ApiOptions)"/>
-    public static IPaginatedList<Issue> GetAllForOwnedAndMemberRepositoriesAsync(this IIssuesClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Issue>(t.GetAllForOwnedAndMemberRepositories, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IIssuesClient.GetAllForOwnedAndMemberRepositories(IssueRequest, ApiOptions)"/>
-    public static IPaginatedList<Issue> GetAllForOwnedAndMemberRepositoriesAsync(this IIssuesClient t, IssueRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForOwnedAndMemberRepositories(request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IIssuesClient.GetAllForOrganization(string, ApiOptions)"/>
-    public static IPaginatedList<Issue> GetAllForOrganizationAsync(this IIssuesClient t, string organization, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForOrganization(organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IIssuesClient.GetAllForOrganization(string, IssueRequest, ApiOptions)"/>
-    public static IPaginatedList<Issue> GetAllForOrganizationAsync(this IIssuesClient t, string organization, IssueRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForOrganization(organization, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IIssuesClient.GetAllForRepository(string, string, ApiOptions)"/>
-    public static IPaginatedList<Issue> GetAllForRepositoryAsync(this IIssuesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IIssuesClient.GetAllForRepository(long, ApiOptions)"/>
-    public static IPaginatedList<Issue> GetAllForRepositoryAsync(this IIssuesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IIssuesClient.GetAllForRepository(string, string, RepositoryIssueRequest, ApiOptions)"/>
-    public static IPaginatedList<Issue> GetAllForRepositoryAsync(this IIssuesClient t, string owner, string name, RepositoryIssueRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IIssuesClient.GetAllForRepository(long, RepositoryIssueRequest, ApiOptions)"/>
-    public static IPaginatedList<Issue> GetAllForRepositoryAsync(this IIssuesClient t, long repositoryId, RepositoryIssueRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IPullRequestsClient.GetAllForRepository(string, string, ApiOptions)"/>
-    public static IPaginatedList<PullRequest> GetAllForRepositoryAsync(this IPullRequestsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PullRequest>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IPullRequestsClient.GetAllForRepository(long, ApiOptions)"/>
-    public static IPaginatedList<PullRequest> GetAllForRepositoryAsync(this IPullRequestsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PullRequest>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IPullRequestsClient.GetAllForRepository(string, string, PullRequestRequest, ApiOptions)"/>
-    public static IPaginatedList<PullRequest> GetAllForRepositoryAsync(this IPullRequestsClient t, string owner, string name, PullRequestRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PullRequest>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IPullRequestsClient.GetAllForRepository(long, PullRequestRequest, ApiOptions)"/>
-    public static IPaginatedList<PullRequest> GetAllForRepositoryAsync(this IPullRequestsClient t, long repositoryId, PullRequestRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PullRequest>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IPullRequestsClient.Files(string, string, int, ApiOptions)"/>
-    public static IPaginatedList<PullRequestFile> FilesAsync(this IPullRequestsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PullRequestFile>(options => t.Files(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IPullRequestsClient.Files(long, int, ApiOptions)"/>
-    public static IPaginatedList<PullRequestFile> FilesAsync(this IPullRequestsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PullRequestFile>(options => t.Files(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IMilestonesClient.GetAllForRepository(string, string, ApiOptions)"/>
-    public static IPaginatedList<Milestone> GetAllForRepositoryAsync(this IMilestonesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Milestone>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IMilestonesClient.GetAllForRepository(long, ApiOptions)"/>
-    public static IPaginatedList<Milestone> GetAllForRepositoryAsync(this IMilestonesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Milestone>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IMilestonesClient.GetAllForRepository(string, string, MilestoneRequest, ApiOptions)"/>
-    public static IPaginatedList<Milestone> GetAllForRepositoryAsync(this IMilestonesClient t, string owner, string name, MilestoneRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Milestone>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IMilestonesClient.GetAllForRepository(long, MilestoneRequest, ApiOptions)"/>
-    public static IPaginatedList<Milestone> GetAllForRepositoryAsync(this IMilestonesClient t, long repositoryId, MilestoneRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Milestone>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IRepositoryHooksClient.GetAll(string, string, ApiOptions)"/>
-    public static IPaginatedList<RepositoryHook> GetAllAsync(this IRepositoryHooksClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<RepositoryHook>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IRepositoryHooksClient.GetAll(long, ApiOptions)"/>
-    public static IPaginatedList<RepositoryHook> GetAllAsync(this IRepositoryHooksClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<RepositoryHook>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IRepositoryPagesClient.GetAll(string, string, ApiOptions)"/>
-    public static IPaginatedList<PagesBuild> GetAllAsync(this IRepositoryPagesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PagesBuild>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IRepositoryPagesClient.GetAll(long, ApiOptions)"/>
-    public static IPaginatedList<PagesBuild> GetAllAsync(this IRepositoryPagesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PagesBuild>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IUserKeysClient.GetAll(string, ApiOptions)"/>
-    public static IPaginatedList<PublicKey> GetAllAsync(this IUserKeysClient t, string userName, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PublicKey>(options => t.GetAll(userName, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IUserKeysClient.GetAllForCurrent(ApiOptions)"/>
-    public static IPaginatedList<PublicKey> GetAllForCurrentAsync(this IUserKeysClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PublicKey>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="ITeamsClient.GetAll(string, ApiOptions)"/>
-    public static IPaginatedList<Team> GetAllAsync(this ITeamsClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Team>(options => t.GetAll(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="ITeamsClient.GetAllForCurrent(ApiOptions)"/>
-    public static IPaginatedList<Team> GetAllForCurrentAsync(this ITeamsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Team>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="ITeamsClient.GetAllChildTeams(long, ApiOptions)"/>
-    public static IPaginatedList<Team> GetAllChildTeamsAsync(this ITeamsClient t, long id, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Team>(options => t.GetAllChildTeams(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="ITeamsClient.GetAllMembers(long, ApiOptions)"/>
-    public static IPaginatedList<User> GetAllMembersAsync(this ITeamsClient t, long id, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllMembers(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="ITeamsClient.GetAllMembers(long, TeamMembersRequest, ApiOptions)"/>
-    public static IPaginatedList<User> GetAllMembersAsync(this ITeamsClient t, long id, TeamMembersRequest request, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllMembers(id, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="ITeamsClient.GetAllRepositories(long, ApiOptions)"/>
-    public static IPaginatedList<Repository> GetAllRepositoriesAsync(this ITeamsClient t, long id, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllRepositories(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="ITeamsClient.GetAllPendingInvitations(long, ApiOptions)"/>
-    public static IPaginatedList<OrganizationMembershipInvitation> GetAllPendingInvitationsAsync(this ITeamsClient t, long id, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<OrganizationMembershipInvitation>(options => t.GetAllPendingInvitations(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="ICheckRunsClient.GetAllAnnotations(string, string, long, ApiOptions)"/>
-    public static IPaginatedList<CheckRunAnnotation> GetAllAnnotationsAsync(this ICheckRunsClient t, string owner, string name, long checkRunId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<CheckRunAnnotation>(options => t.GetAllAnnotations(owner, name, checkRunId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="ICheckRunsClient.GetAllAnnotations(long, long, ApiOptions)"/>
-    public static IPaginatedList<CheckRunAnnotation> GetAllAnnotationsAsync(this ICheckRunsClient t, long repositoryId, long checkRunId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<CheckRunAnnotation>(options => t.GetAllAnnotations(repositoryId, checkRunId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IOrganizationOutsideCollaboratorsClient.GetAll(string, ApiOptions)"/>
-    public static IPaginatedList<User> GetAllAsync(this IOrganizationOutsideCollaboratorsClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IOrganizationOutsideCollaboratorsClient.GetAll(string, OrganizationMembersFilter, ApiOptions)"/>
-    public static IPaginatedList<User> GetAllAsync(this IOrganizationOutsideCollaboratorsClient t, string org, OrganizationMembersFilter filter, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, filter, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IPullRequestReviewCommentReactionsClient.GetAll(string, string, long, ApiOptions)"/>
-    public static IPaginatedList<Reaction> GetAllAsync(this IPullRequestReviewCommentReactionsClient t, string owner, string name, long commentId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(owner, name, commentId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IPullRequestReviewCommentReactionsClient.GetAll(long, long, ApiOptions)"/>
-    public static IPaginatedList<Reaction> GetAllAsync(this IPullRequestReviewCommentReactionsClient t, long repositoryId, long commentId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(repositoryId, commentId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
     /// <inheritdoc cref="INotificationsClient.GetAllForCurrent(ApiOptions)"/>
     public static IPaginatedList<Notification> GetAllForCurrentAsync(this INotificationsClient t, int pageSize = DEFAULT_PAGE_SIZE)
@@ -611,21 +107,33 @@ namespace Octokit.AsyncPaginationExtension
     public static IPaginatedList<Notification> GetAllForRepositoryAsync(this INotificationsClient t, long repositoryId, NotificationsRequest request, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<Notification>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IOrganizationsClient.GetAllForCurrent(ApiOptions)"/>
-    public static IPaginatedList<Organization> GetAllForCurrentAsync(this IOrganizationsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Organization>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IIssueTimelineClient.GetAllForIssue(string, string, int, ApiOptions)"/>
+    public static IPaginatedList<TimelineEventInfo> GetAllForIssueAsync(this IIssueTimelineClient t, string owner, string repo, int issueNumber, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<TimelineEventInfo>(options => t.GetAllForIssue(owner, repo, issueNumber, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IOrganizationsClient.GetAllForUser(string, ApiOptions)"/>
-    public static IPaginatedList<Organization> GetAllForUserAsync(this IOrganizationsClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Organization>(options => t.GetAllForUser(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IIssueTimelineClient.GetAllForIssue(long, int, ApiOptions)"/>
+    public static IPaginatedList<TimelineEventInfo> GetAllForIssueAsync(this IIssueTimelineClient t, long repositoryId, int issueNumber, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<TimelineEventInfo>(options => t.GetAllForIssue(repositoryId, issueNumber, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IOrganizationsClient.GetAllAuthorizations(string, ApiOptions)"/>
-    public static IPaginatedList<OrganizationCredential> GetAllAuthorizationsAsync(this IOrganizationsClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<OrganizationCredential>(options => t.GetAllAuthorizations(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IMiscellaneousClient.GetAllLicenses(ApiOptions)"/>
+    public static IPaginatedList<LicenseMetadata> GetAllLicensesAsync(this IMiscellaneousClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<LicenseMetadata>(t.GetAllLicenses, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IOrganizationsClient.GetAllAuthorizations(string, string, ApiOptions)"/>
-    public static IPaginatedList<OrganizationCredential> GetAllAuthorizationsAsync(this IOrganizationsClient t, string org, string login, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<OrganizationCredential>(options => t.GetAllAuthorizations(org, login, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IIssueReactionsClient.GetAll(string, string, int, ApiOptions)"/>
+    public static IPaginatedList<Reaction> GetAllAsync(this IIssueReactionsClient t, string owner, string name, int issueNumber, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(owner, name, issueNumber, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssueReactionsClient.GetAll(long, int, ApiOptions)"/>
+    public static IPaginatedList<Reaction> GetAllAsync(this IIssueReactionsClient t, long repositoryId, int issueNumber, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(repositoryId, issueNumber, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryDeployKeysClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<DeployKey> GetAllAsync(this IRepositoryDeployKeysClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<DeployKey>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryDeployKeysClient.GetAll(long, ApiOptions)"/>
+    public static IPaginatedList<DeployKey> GetAllAsync(this IRepositoryDeployKeysClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<DeployKey>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
     /// <inheritdoc cref="IEventsClient.GetAll(ApiOptions)"/>
     public static IPaginatedList<Activity> GetAllAsync(this IEventsClient t, int pageSize = DEFAULT_PAGE_SIZE)
@@ -675,29 +183,85 @@ namespace Octokit.AsyncPaginationExtension
     public static IPaginatedList<Activity> GetAllForAnOrganizationAsync(this IEventsClient t, string user, string organization, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<Activity>(options => t.GetAllForAnOrganization(user, organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForIssue(string, string, int, ApiOptions)"/>
-    public static IPaginatedList<Label> GetAllForIssueAsync(this IIssuesLabelsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForIssue(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IActionsSelfHostedRunnersClient.ListAllRunnerApplicationsForEnterprise(string, ApiOptions)"/>
+    public static IPaginatedList<RunnerApplication> ListAllRunnerApplicationsForEnterpriseAsync(this IActionsSelfHostedRunnersClient t, string enterprise, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RunnerApplication>(options => t.ListAllRunnerApplicationsForEnterprise(enterprise, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForIssue(long, int, ApiOptions)"/>
-    public static IPaginatedList<Label> GetAllForIssueAsync(this IIssuesLabelsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForIssue(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IActionsSelfHostedRunnersClient.ListAllRunnerApplicationsForOrganization(string, ApiOptions)"/>
+    public static IPaginatedList<RunnerApplication> ListAllRunnerApplicationsForOrganizationAsync(this IActionsSelfHostedRunnersClient t, string organization, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RunnerApplication>(options => t.ListAllRunnerApplicationsForOrganization(organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForRepository(string, string, ApiOptions)"/>
-    public static IPaginatedList<Label> GetAllForRepositoryAsync(this IIssuesLabelsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IActionsSelfHostedRunnersClient.ListAllRunnerApplicationsForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<RunnerApplication> ListAllRunnerApplicationsForRepositoryAsync(this IActionsSelfHostedRunnersClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RunnerApplication>(options => t.ListAllRunnerApplicationsForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForRepository(long, ApiOptions)"/>
-    public static IPaginatedList<Label> GetAllForRepositoryAsync(this IIssuesLabelsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IMilestonesClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<Milestone> GetAllForRepositoryAsync(this IMilestonesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Milestone>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForMilestone(string, string, int, ApiOptions)"/>
-    public static IPaginatedList<Label> GetAllForMilestoneAsync(this IIssuesLabelsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForMilestone(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IMilestonesClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<Milestone> GetAllForRepositoryAsync(this IMilestonesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Milestone>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForMilestone(long, int, ApiOptions)"/>
-    public static IPaginatedList<Label> GetAllForMilestoneAsync(this IIssuesLabelsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForMilestone(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IMilestonesClient.GetAllForRepository(string, string, MilestoneRequest, ApiOptions)"/>
+    public static IPaginatedList<Milestone> GetAllForRepositoryAsync(this IMilestonesClient t, string owner, string name, MilestoneRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Milestone>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IMilestonesClient.GetAllForRepository(long, MilestoneRequest, ApiOptions)"/>
+    public static IPaginatedList<Milestone> GetAllForRepositoryAsync(this IMilestonesClient t, long repositoryId, MilestoneRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Milestone>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IUserGpgKeysClient.GetAllForCurrent(ApiOptions)"/>
+    public static IPaginatedList<GpgKey> GetAllForCurrentAsync(this IUserGpgKeysClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<GpgKey>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IUserEmailsClient.GetAll(ApiOptions)"/>
+    public static IPaginatedList<EmailAddress> GetAllAsync(this IUserEmailsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<EmailAddress>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepoCollaboratorsClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<Collaborator> GetAllAsync(this IRepoCollaboratorsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Collaborator>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepoCollaboratorsClient.GetAll(long, ApiOptions)"/>
+    public static IPaginatedList<Collaborator> GetAllAsync(this IRepoCollaboratorsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Collaborator>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepoCollaboratorsClient.GetAll(string, string, RepositoryCollaboratorListRequest, ApiOptions)"/>
+    public static IPaginatedList<Collaborator> GetAllAsync(this IRepoCollaboratorsClient t, string owner, string name, RepositoryCollaboratorListRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Collaborator>(options => t.GetAll(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepoCollaboratorsClient.GetAll(long, RepositoryCollaboratorListRequest, ApiOptions)"/>
+    public static IPaginatedList<Collaborator> GetAllAsync(this IRepoCollaboratorsClient t, long repositoryId, RepositoryCollaboratorListRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Collaborator>(options => t.GetAll(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IActionsSelfHostedRunnerGroupsClient.ListAllRunnerGroupOrganizationsForEnterprise(string, long, ApiOptions)"/>
+    public static IPaginatedList<Organization> ListAllRunnerGroupOrganizationsForEnterpriseAsync(this IActionsSelfHostedRunnerGroupsClient t, string enterprise, long runnerGroupId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Organization>(options => t.ListAllRunnerGroupOrganizationsForEnterprise(enterprise, runnerGroupId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IActionsSelfHostedRunnerGroupsClient.ListAllRunnerGroupRepositoriesForOrganization(string, long, ApiOptions)"/>
+    public static IPaginatedList<Repository> ListAllRunnerGroupRepositoriesForOrganizationAsync(this IActionsSelfHostedRunnerGroupsClient t, string org, long runnerGroupId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(options => t.ListAllRunnerGroupRepositoriesForOrganization(org, runnerGroupId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IProjectColumnsClient.GetAll(int, ApiOptions)"/>
+    public static IPaginatedList<ProjectColumn> GetAllAsync(this IProjectColumnsClient t, int projectId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<ProjectColumn>(options => t.GetAll(projectId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IAuthorizationsClient.GetAll(ApiOptions)"/>
+    public static IPaginatedList<Authorization> GetAllAsync(this IAuthorizationsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Authorization>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IAssigneesClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllForRepositoryAsync(this IAssigneesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IAssigneesClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllForRepositoryAsync(this IAssigneesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationCustomPropertyValuesClient.GetAll(string, ApiOptions)"/>
+    public static IPaginatedList<OrganizationCustomPropertyValues> GetAllAsync(this IOrganizationCustomPropertyValuesClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<OrganizationCustomPropertyValues>(options => t.GetAll(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
     /// <inheritdoc cref="IDeploymentStatusClient.GetAll(string, string, long, ApiOptions)"/>
     public static IPaginatedList<DeploymentStatus> GetAllAsync(this IDeploymentStatusClient t, string owner, string name, long deploymentId, int pageSize = DEFAULT_PAGE_SIZE)
@@ -706,50 +270,6 @@ namespace Octokit.AsyncPaginationExtension
     /// <inheritdoc cref="IDeploymentStatusClient.GetAll(long, long, ApiOptions)"/>
     public static IPaginatedList<DeploymentStatus> GetAllAsync(this IDeploymentStatusClient t, long repositoryId, long deploymentId, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<DeploymentStatus>(options => t.GetAll(repositoryId, deploymentId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IIssueReactionsClient.GetAll(string, string, int, ApiOptions)"/>
-    public static IPaginatedList<Reaction> GetAllAsync(this IIssueReactionsClient t, string owner, string name, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(owner, name, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IIssueReactionsClient.GetAll(long, int, ApiOptions)"/>
-    public static IPaginatedList<Reaction> GetAllAsync(this IIssueReactionsClient t, long repositoryId, int number, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(repositoryId, number, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IReferencesClient.GetAll(string, string, ApiOptions)"/>
-    public static IPaginatedList<Reference> GetAllAsync(this IReferencesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Reference>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IReferencesClient.GetAll(long, ApiOptions)"/>
-    public static IPaginatedList<Reference> GetAllAsync(this IReferencesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Reference>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IReferencesClient.GetAllForSubNamespace(string, string, string, ApiOptions)"/>
-    public static IPaginatedList<Reference> GetAllForSubNamespaceAsync(this IReferencesClient t, string owner, string name, string subNamespace, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Reference>(options => t.GetAllForSubNamespace(owner, name, subNamespace, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IReferencesClient.GetAllForSubNamespace(long, string, ApiOptions)"/>
-    public static IPaginatedList<Reference> GetAllForSubNamespaceAsync(this IReferencesClient t, long repositoryId, string subNamespace, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Reference>(options => t.GetAllForSubNamespace(repositoryId, subNamespace, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IUserEmailsClient.GetAll(ApiOptions)"/>
-    public static IPaginatedList<EmailAddress> GetAllAsync(this IUserEmailsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<EmailAddress>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="ICommitStatusClient.GetAll(string, string, string, ApiOptions)"/>
-    public static IPaginatedList<CommitStatus> GetAllAsync(this ICommitStatusClient t, string owner, string name, string reference, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<CommitStatus>(options => t.GetAll(owner, name, reference, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="ICommitStatusClient.GetAll(long, string, ApiOptions)"/>
-    public static IPaginatedList<CommitStatus> GetAllAsync(this ICommitStatusClient t, long repositoryId, string reference, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<CommitStatus>(options => t.GetAll(repositoryId, reference, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IGistCommentsClient.GetAllForGist(string, ApiOptions)"/>
-    public static IPaginatedList<GistComment> GetAllForGistAsync(this IGistCommentsClient t, string gistId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<GistComment>(options => t.GetAllForGist(gistId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IProjectColumnsClient.GetAll(int, ApiOptions)"/>
-    public static IPaginatedList<ProjectColumn> GetAllAsync(this IProjectColumnsClient t, int projectId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<ProjectColumn>(options => t.GetAll(projectId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
     /// <inheritdoc cref="IFollowersClient.GetAllForCurrent(ApiOptions)"/>
     public static IPaginatedList<User> GetAllForCurrentAsync(this IFollowersClient t, int pageSize = DEFAULT_PAGE_SIZE)
@@ -766,6 +286,350 @@ namespace Octokit.AsyncPaginationExtension
     /// <inheritdoc cref="IFollowersClient.GetAllFollowing(string, ApiOptions)"/>
     public static IPaginatedList<User> GetAllFollowingAsync(this IFollowersClient t, string login, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllFollowing(login, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="ITeamsClient.GetAll(string, ApiOptions)"/>
+    public static IPaginatedList<Team> GetAllAsync(this ITeamsClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Team>(options => t.GetAll(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="ITeamsClient.GetAllForCurrent(ApiOptions)"/>
+    public static IPaginatedList<Team> GetAllForCurrentAsync(this ITeamsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Team>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="ITeamsClient.GetAllChildTeams(long, ApiOptions)"/>
+    public static IPaginatedList<Team> GetAllChildTeamsAsync(this ITeamsClient t, long id, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Team>(options => t.GetAllChildTeams(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="ITeamsClient.GetAllMembers(long, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllMembersAsync(this ITeamsClient t, long id, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllMembers(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="ITeamsClient.GetAllMembers(long, TeamMembersRequest, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllMembersAsync(this ITeamsClient t, long id, TeamMembersRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllMembers(id, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="ITeamsClient.GetAllRepositories(long, ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllRepositoriesAsync(this ITeamsClient t, long id, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllRepositories(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="ITeamsClient.GetAllPendingInvitations(long, ApiOptions)"/>
+    public static IPaginatedList<OrganizationMembershipInvitation> GetAllPendingInvitationsAsync(this ITeamsClient t, long id, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<OrganizationMembershipInvitation>(options => t.GetAllPendingInvitations(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IGitHubAppsClient.GetAllInstallationsForCurrent(ApiOptions)"/>
+    public static IPaginatedList<Installation> GetAllInstallationsForCurrentAsync(this IGitHubAppsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Installation>(t.GetAllInstallationsForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IPackagesClient.GetAllForOrg(string, PackageType, ApiOptions)"/>
+    public static IPaginatedList<Package> GetAllForOrgAsync(this IPackagesClient t, string org, PackageType packageType, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Package>(options => t.GetAllForOrg(org, packageType, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IPackagesClient.GetAllForOrg(string, PackageType, PackageVisibility?, ApiOptions)"/>
+    public static IPaginatedList<Package> GetAllForOrgAsync(this IPackagesClient t, string org, PackageType packageType, PackageVisibility? packageVisibility, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Package>(options => t.GetAllForOrg(org, packageType, packageVisibility, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IPackagesClient.GetAllForActiveUser(PackageType, ApiOptions)"/>
+    public static IPaginatedList<Package> GetAllForActiveUserAsync(this IPackagesClient t, PackageType packageType, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Package>(options => t.GetAllForActiveUser(packageType, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IPackagesClient.GetAllForActiveUser(PackageType, PackageVisibility?, ApiOptions)"/>
+    public static IPaginatedList<Package> GetAllForActiveUserAsync(this IPackagesClient t, PackageType packageType, PackageVisibility? packageVisibility, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Package>(options => t.GetAllForActiveUser(packageType, packageVisibility, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IPackagesClient.GetAllForUser(string, PackageType, ApiOptions)"/>
+    public static IPaginatedList<Package> GetAllForUserAsync(this IPackagesClient t, string username, PackageType packageType, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Package>(options => t.GetAllForUser(username, packageType, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IPackagesClient.GetAllForUser(string, PackageType, PackageVisibility?, ApiOptions)"/>
+    public static IPaginatedList<Package> GetAllForUserAsync(this IPackagesClient t, string username, PackageType packageType, PackageVisibility? packageVisibility, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Package>(options => t.GetAllForUser(username, packageType, packageVisibility, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="ILicensesClient.GetAllLicenses(ApiOptions)"/>
+    public static IPaginatedList<LicenseMetadata> GetAllLicensesAsync(this ILicensesClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<LicenseMetadata>(t.GetAllLicenses, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationMembersClient.GetAll(string, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllAsync(this IOrganizationMembersClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationMembersClient.GetAll(string, OrganizationMembersFilter, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllAsync(this IOrganizationMembersClient t, string org, OrganizationMembersFilter filter, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, filter, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationMembersClient.GetAll(string, OrganizationMembersRole, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllAsync(this IOrganizationMembersClient t, string org, OrganizationMembersRole role, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, role, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationMembersClient.GetAll(string, OrganizationMembersFilter, OrganizationMembersRole, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllAsync(this IOrganizationMembersClient t, string org, OrganizationMembersFilter filter, OrganizationMembersRole role, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, filter, role, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationMembersClient.GetAllPublic(string, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllPublicAsync(this IOrganizationMembersClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllPublic(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationMembersClient.GetAllPendingInvitations(string, ApiOptions)"/>
+    public static IPaginatedList<OrganizationMembershipInvitation> GetAllPendingInvitationsAsync(this IOrganizationMembersClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<OrganizationMembershipInvitation>(options => t.GetAllPendingInvitations(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationMembersClient.GetAllFailedInvitations(string, ApiOptions)"/>
+    public static IPaginatedList<OrganizationMembershipInvitation> GetAllFailedInvitationsAsync(this IOrganizationMembersClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<OrganizationMembershipInvitation>(options => t.GetAllFailedInvitations(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationMembersClient.GetAllOrganizationMembershipsForCurrent(ApiOptions)"/>
+    public static IPaginatedList<OrganizationMembership> GetAllOrganizationMembershipsForCurrentAsync(this IOrganizationMembersClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<OrganizationMembership>(t.GetAllOrganizationMembershipsForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationsClient.GetAllForCurrent(ApiOptions)"/>
+    public static IPaginatedList<Organization> GetAllForCurrentAsync(this IOrganizationsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Organization>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationsClient.GetAllForUser(string, ApiOptions)"/>
+    public static IPaginatedList<Organization> GetAllForUserAsync(this IOrganizationsClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Organization>(options => t.GetAllForUser(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationsClient.GetAllAuthorizations(string, ApiOptions)"/>
+    public static IPaginatedList<OrganizationCredential> GetAllAuthorizationsAsync(this IOrganizationsClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<OrganizationCredential>(options => t.GetAllAuthorizations(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationsClient.GetAllAuthorizations(string, string, ApiOptions)"/>
+    public static IPaginatedList<OrganizationCredential> GetAllAuthorizationsAsync(this IOrganizationsClient t, string org, string login, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<OrganizationCredential>(options => t.GetAllAuthorizations(org, login, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="ICheckRunsClient.GetAllAnnotations(string, string, long, ApiOptions)"/>
+    public static IPaginatedList<CheckRunAnnotation> GetAllAnnotationsAsync(this ICheckRunsClient t, string owner, string name, long checkRunId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<CheckRunAnnotation>(options => t.GetAllAnnotations(owner, name, checkRunId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="ICheckRunsClient.GetAllAnnotations(long, long, ApiOptions)"/>
+    public static IPaginatedList<CheckRunAnnotation> GetAllAnnotationsAsync(this ICheckRunsClient t, long repositoryId, long checkRunId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<CheckRunAnnotation>(options => t.GetAllAnnotations(repositoryId, checkRunId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForIssue(string, string, int, ApiOptions)"/>
+    public static IPaginatedList<Label> GetAllForIssueAsync(this IIssuesLabelsClient t, string owner, string name, int issueNumber, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForIssue(owner, name, issueNumber, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForIssue(long, int, ApiOptions)"/>
+    public static IPaginatedList<Label> GetAllForIssueAsync(this IIssuesLabelsClient t, long repositoryId, int issueNumber, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForIssue(repositoryId, issueNumber, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<Label> GetAllForRepositoryAsync(this IIssuesLabelsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<Label> GetAllForRepositoryAsync(this IIssuesLabelsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForMilestone(string, string, int, ApiOptions)"/>
+    public static IPaginatedList<Label> GetAllForMilestoneAsync(this IIssuesLabelsClient t, string owner, string name, int milestoneNumber, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForMilestone(owner, name, milestoneNumber, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForMilestone(long, int, ApiOptions)"/>
+    public static IPaginatedList<Label> GetAllForMilestoneAsync(this IIssuesLabelsClient t, long repositoryId, int milestoneNumber, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForMilestone(repositoryId, milestoneNumber, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationOutsideCollaboratorsClient.GetAll(string, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllAsync(this IOrganizationOutsideCollaboratorsClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationOutsideCollaboratorsClient.GetAll(string, OrganizationMembersFilter, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllAsync(this IOrganizationOutsideCollaboratorsClient t, string org, OrganizationMembersFilter filter, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, filter, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="ICommitCommentReactionsClient.GetAll(string, string, long, ApiOptions)"/>
+    public static IPaginatedList<Reaction> GetAllAsync(this ICommitCommentReactionsClient t, string owner, string name, long commentId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(owner, name, commentId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="ICommitCommentReactionsClient.GetAll(long, long, ApiOptions)"/>
+    public static IPaginatedList<Reaction> GetAllAsync(this ICommitCommentReactionsClient t, long repositoryId, long commentId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(repositoryId, commentId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryBranchesClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<Branch> GetAllAsync(this IRepositoryBranchesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Branch>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryBranchesClient.GetAll(long, ApiOptions)"/>
+    public static IPaginatedList<Branch> GetAllAsync(this IRepositoryBranchesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Branch>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IStarredClient.GetAllStargazers(string, string, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllStargazersAsync(this IStarredClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllStargazers(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IStarredClient.GetAllStargazers(long, ApiOptions)"/>
+    public static IPaginatedList<User> GetAllStargazersAsync(this IStarredClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllStargazers(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IStarredClient.GetAllStargazersWithTimestamps(string, string, ApiOptions)"/>
+    public static IPaginatedList<UserStar> GetAllStargazersWithTimestampsAsync(this IStarredClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<UserStar>(options => t.GetAllStargazersWithTimestamps(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IStarredClient.GetAllStargazersWithTimestamps(long, ApiOptions)"/>
+    public static IPaginatedList<UserStar> GetAllStargazersWithTimestampsAsync(this IStarredClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<UserStar>(options => t.GetAllStargazersWithTimestamps(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IStarredClient.GetAllForCurrent(ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllForCurrentAsync(this IStarredClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IStarredClient.GetAllForCurrentWithTimestamps(ApiOptions)"/>
+    public static IPaginatedList<RepositoryStar> GetAllForCurrentWithTimestampsAsync(this IStarredClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryStar>(t.GetAllForCurrentWithTimestamps, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IStarredClient.GetAllForCurrent(StarredRequest, ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllForCurrentAsync(this IStarredClient t, StarredRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForCurrent(request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IStarredClient.GetAllForCurrentWithTimestamps(StarredRequest, ApiOptions)"/>
+    public static IPaginatedList<RepositoryStar> GetAllForCurrentWithTimestampsAsync(this IStarredClient t, StarredRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryStar>(options => t.GetAllForCurrentWithTimestamps(request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IStarredClient.GetAllForUser(string, ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllForUserAsync(this IStarredClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForUser(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IStarredClient.GetAllForUserWithTimestamps(string, ApiOptions)"/>
+    public static IPaginatedList<RepositoryStar> GetAllForUserWithTimestampsAsync(this IStarredClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryStar>(options => t.GetAllForUserWithTimestamps(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IStarredClient.GetAllForUser(string, StarredRequest, ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllForUserAsync(this IStarredClient t, string user, StarredRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAllForUser(user, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IStarredClient.GetAllForUserWithTimestamps(string, StarredRequest, ApiOptions)"/>
+    public static IPaginatedList<RepositoryStar> GetAllForUserWithTimestampsAsync(this IStarredClient t, string user, StarredRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryStar>(options => t.GetAllForUserWithTimestamps(user, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="ICommitStatusClient.GetAll(string, string, string, ApiOptions)"/>
+    public static IPaginatedList<CommitStatus> GetAllAsync(this ICommitStatusClient t, string owner, string name, string reference, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<CommitStatus>(options => t.GetAll(owner, name, reference, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="ICommitStatusClient.GetAll(long, string, ApiOptions)"/>
+    public static IPaginatedList<CommitStatus> GetAllAsync(this ICommitStatusClient t, long repositoryId, string reference, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<CommitStatus>(options => t.GetAll(repositoryId, reference, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IAutolinksClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<Autolink> GetAllAsync(this IAutolinksClient t, string owner, string repo, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Autolink>(options => t.GetAll(owner, repo, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesClient.GetAllForCurrent(ApiOptions)"/>
+    public static IPaginatedList<Issue> GetAllForCurrentAsync(this IIssuesClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Issue>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesClient.GetAllForCurrent(IssueRequest, ApiOptions)"/>
+    public static IPaginatedList<Issue> GetAllForCurrentAsync(this IIssuesClient t, IssueRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForCurrent(request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesClient.GetAllForOwnedAndMemberRepositories(ApiOptions)"/>
+    public static IPaginatedList<Issue> GetAllForOwnedAndMemberRepositoriesAsync(this IIssuesClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Issue>(t.GetAllForOwnedAndMemberRepositories, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesClient.GetAllForOwnedAndMemberRepositories(IssueRequest, ApiOptions)"/>
+    public static IPaginatedList<Issue> GetAllForOwnedAndMemberRepositoriesAsync(this IIssuesClient t, IssueRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForOwnedAndMemberRepositories(request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesClient.GetAllForOrganization(string, ApiOptions)"/>
+    public static IPaginatedList<Issue> GetAllForOrganizationAsync(this IIssuesClient t, string organization, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForOrganization(organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesClient.GetAllForOrganization(string, IssueRequest, ApiOptions)"/>
+    public static IPaginatedList<Issue> GetAllForOrganizationAsync(this IIssuesClient t, string organization, IssueRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForOrganization(organization, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<Issue> GetAllForRepositoryAsync(this IIssuesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<Issue> GetAllForRepositoryAsync(this IIssuesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesClient.GetAllForRepository(string, string, RepositoryIssueRequest, ApiOptions)"/>
+    public static IPaginatedList<Issue> GetAllForRepositoryAsync(this IIssuesClient t, string owner, string name, RepositoryIssueRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesClient.GetAllForRepository(long, RepositoryIssueRequest, ApiOptions)"/>
+    public static IPaginatedList<Issue> GetAllForRepositoryAsync(this IIssuesClient t, long repositoryId, RepositoryIssueRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Issue>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IPullRequestReviewCommentReactionsClient.GetAll(string, string, long, ApiOptions)"/>
+    public static IPaginatedList<Reaction> GetAllAsync(this IPullRequestReviewCommentReactionsClient t, string owner, string name, long commentId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(owner, name, commentId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IPullRequestReviewCommentReactionsClient.GetAll(long, long, ApiOptions)"/>
+    public static IPaginatedList<Reaction> GetAllAsync(this IPullRequestReviewCommentReactionsClient t, long repositoryId, long commentId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(repositoryId, commentId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesEventsClient.GetAllForIssue(string, string, int, ApiOptions)"/>
+    public static IPaginatedList<IssueEvent> GetAllForIssueAsync(this IIssuesEventsClient t, string owner, string name, int issueNumber, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllForIssue(owner, name, issueNumber, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesEventsClient.GetAllForIssue(long, int, ApiOptions)"/>
+    public static IPaginatedList<IssueEvent> GetAllForIssueAsync(this IIssuesEventsClient t, long repositoryId, int issueNumber, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllForIssue(repositoryId, issueNumber, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesEventsClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<IssueEvent> GetAllForRepositoryAsync(this IIssuesEventsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssuesEventsClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<IssueEvent> GetAllForRepositoryAsync(this IIssuesEventsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IOrganizationHooksClient.GetAll(string, ApiOptions)"/>
+    public static IPaginatedList<OrganizationHook> GetAllAsync(this IOrganizationHooksClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<OrganizationHook>(options => t.GetAll(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryInvitationsClient.GetAllForCurrent(ApiOptions)"/>
+    public static IPaginatedList<RepositoryInvitation> GetAllForCurrentAsync(this IRepositoryInvitationsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryInvitation>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryInvitationsClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<RepositoryInvitation> GetAllForRepositoryAsync(this IRepositoryInvitationsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryInvitation>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IDeploymentsClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<Deployment> GetAllAsync(this IDeploymentsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Deployment>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IDeploymentsClient.GetAll(long, ApiOptions)"/>
+    public static IPaginatedList<Deployment> GetAllAsync(this IDeploymentsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Deployment>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryHooksClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<RepositoryHook> GetAllAsync(this IRepositoryHooksClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryHook>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryHooksClient.GetAll(long, ApiOptions)"/>
+    public static IPaginatedList<RepositoryHook> GetAllAsync(this IRepositoryHooksClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<RepositoryHook>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IGistCommentsClient.GetAllForGist(string, ApiOptions)"/>
+    public static IPaginatedList<GistComment> GetAllForGistAsync(this IGistCommentsClient t, string gistId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<GistComment>(options => t.GetAllForGist(gistId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssueCommentReactionsClient.GetAll(string, string, long, ApiOptions)"/>
+    public static IPaginatedList<Reaction> GetAllAsync(this IIssueCommentReactionsClient t, string owner, string name, long commentId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(owner, name, commentId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IIssueCommentReactionsClient.GetAll(long, long, ApiOptions)"/>
+    public static IPaginatedList<Reaction> GetAllAsync(this IIssueCommentReactionsClient t, long repositoryId, long commentId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(repositoryId, commentId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IReferencesClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<Reference> GetAllAsync(this IReferencesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reference>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IReferencesClient.GetAll(long, ApiOptions)"/>
+    public static IPaginatedList<Reference> GetAllAsync(this IReferencesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reference>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IReferencesClient.GetAllForSubNamespace(string, string, string, ApiOptions)"/>
+    public static IPaginatedList<Reference> GetAllForSubNamespaceAsync(this IReferencesClient t, string owner, string name, string subNamespace, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reference>(options => t.GetAllForSubNamespace(owner, name, subNamespace, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IReferencesClient.GetAllForSubNamespace(long, string, ApiOptions)"/>
+    public static IPaginatedList<Reference> GetAllForSubNamespaceAsync(this IReferencesClient t, long repositoryId, string subNamespace, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Reference>(options => t.GetAllForSubNamespace(repositoryId, subNamespace, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
     /// <inheritdoc cref="IRepositoriesClient.GetAllForCurrent(ApiOptions)"/>
     public static IPaginatedList<Repository> GetAllForCurrentAsync(this IRepositoriesClient t, int pageSize = DEFAULT_PAGE_SIZE)
@@ -815,121 +679,257 @@ namespace Octokit.AsyncPaginationExtension
     public static IPaginatedList<RepositoryTag> GetAllTagsAsync(this IRepositoriesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<RepositoryTag>(options => t.GetAllTags(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IRepositoryBranchesClient.GetAll(string, string, ApiOptions)"/>
-    public static IPaginatedList<Branch> GetAllAsync(this IRepositoryBranchesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Branch>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IRepositoryForksClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllAsync(this IRepositoryForksClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IRepositoryBranchesClient.GetAll(long, ApiOptions)"/>
-    public static IPaginatedList<Branch> GetAllAsync(this IRepositoryBranchesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Branch>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IRepositoryForksClient.GetAll(long, ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllAsync(this IRepositoryForksClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IOrganizationMembersClient.GetAll(string, ApiOptions)"/>
-    public static IPaginatedList<User> GetAllAsync(this IOrganizationMembersClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IRepositoryForksClient.GetAll(string, string, RepositoryForksListRequest, ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllAsync(this IRepositoryForksClient t, string owner, string name, RepositoryForksListRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAll(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IOrganizationMembersClient.GetAll(string, OrganizationMembersFilter, ApiOptions)"/>
-    public static IPaginatedList<User> GetAllAsync(this IOrganizationMembersClient t, string org, OrganizationMembersFilter filter, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, filter, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IRepositoryForksClient.GetAll(long, RepositoryForksListRequest, ApiOptions)"/>
+    public static IPaginatedList<Repository> GetAllAsync(this IRepositoryForksClient t, long repositoryId, RepositoryForksListRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Repository>(options => t.GetAll(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IOrganizationMembersClient.GetAll(string, OrganizationMembersRole, ApiOptions)"/>
-    public static IPaginatedList<User> GetAllAsync(this IOrganizationMembersClient t, string org, OrganizationMembersRole role, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, role, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IUserKeysClient.GetAll(string, ApiOptions)"/>
+    public static IPaginatedList<PublicKey> GetAllAsync(this IUserKeysClient t, string userName, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PublicKey>(options => t.GetAll(userName, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IOrganizationMembersClient.GetAll(string, OrganizationMembersFilter, OrganizationMembersRole, ApiOptions)"/>
-    public static IPaginatedList<User> GetAllAsync(this IOrganizationMembersClient t, string org, OrganizationMembersFilter filter, OrganizationMembersRole role, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAll(org, filter, role, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IUserKeysClient.GetAllForCurrent(ApiOptions)"/>
+    public static IPaginatedList<PublicKey> GetAllForCurrentAsync(this IUserKeysClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PublicKey>(t.GetAllForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IOrganizationMembersClient.GetAllPublic(string, ApiOptions)"/>
-    public static IPaginatedList<User> GetAllPublicAsync(this IOrganizationMembersClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<User>(options => t.GetAllPublic(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IPullRequestReviewCommentsClient.GetAll(string, string, int, ApiOptions)"/>
+    public static IPaginatedList<PullRequestReviewComment> GetAllAsync(this IPullRequestReviewCommentsClient t, string owner, string name, int pullRequestNumber, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAll(owner, name, pullRequestNumber, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IOrganizationMembersClient.GetAllPendingInvitations(string, ApiOptions)"/>
-    public static IPaginatedList<OrganizationMembershipInvitation> GetAllPendingInvitationsAsync(this IOrganizationMembersClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<OrganizationMembershipInvitation>(options => t.GetAllPendingInvitations(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IPullRequestReviewCommentsClient.GetAll(long, int, ApiOptions)"/>
+    public static IPaginatedList<PullRequestReviewComment> GetAllAsync(this IPullRequestReviewCommentsClient t, long repositoryId, int pullRequestNumber, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAll(repositoryId, pullRequestNumber, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IOrganizationMembersClient.GetAllFailedInvitations(string, ApiOptions)"/>
-    public static IPaginatedList<OrganizationMembershipInvitation> GetAllFailedInvitationsAsync(this IOrganizationMembersClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<OrganizationMembershipInvitation>(options => t.GetAllFailedInvitations(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IPullRequestReviewCommentsClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<PullRequestReviewComment> GetAllForRepositoryAsync(this IPullRequestReviewCommentsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IOrganizationMembersClient.GetAllOrganizationMembershipsForCurrent(ApiOptions)"/>
-    public static IPaginatedList<OrganizationMembership> GetAllOrganizationMembershipsForCurrentAsync(this IOrganizationMembersClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<OrganizationMembership>(t.GetAllOrganizationMembershipsForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IPullRequestReviewCommentsClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<PullRequestReviewComment> GetAllForRepositoryAsync(this IPullRequestReviewCommentsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IOrganizationCustomPropertyValuesClient.GetAll(string, ApiOptions)"/>
-    public static IPaginatedList<OrganizationCustomPropertyValues> GetAllAsync(this IOrganizationCustomPropertyValuesClient t, string org, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<OrganizationCustomPropertyValues>(options => t.GetAll(org, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IPullRequestReviewCommentsClient.GetAllForRepository(string, string, PullRequestReviewCommentRequest, ApiOptions)"/>
+    public static IPaginatedList<PullRequestReviewComment> GetAllForRepositoryAsync(this IPullRequestReviewCommentsClient t, string owner, string name, PullRequestReviewCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IPackagesClient.GetAllForOrg(string, PackageType, ApiOptions)"/>
-    public static IPaginatedList<Package> GetAllForOrgAsync(this IPackagesClient t, string org, PackageType packageType, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Package>(options => t.GetAllForOrg(org, packageType, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IPullRequestReviewCommentsClient.GetAllForRepository(long, PullRequestReviewCommentRequest, ApiOptions)"/>
+    public static IPaginatedList<PullRequestReviewComment> GetAllForRepositoryAsync(this IPullRequestReviewCommentsClient t, long repositoryId, PullRequestReviewCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IPackagesClient.GetAllForOrg(string, PackageType, PackageVisibility?, ApiOptions)"/>
-    public static IPaginatedList<Package> GetAllForOrgAsync(this IPackagesClient t, string org, PackageType packageType, PackageVisibility? packageVisibility, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Package>(options => t.GetAllForOrg(org, packageType, packageVisibility, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IReleasesClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<Release> GetAllAsync(this IReleasesClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Release>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IPackagesClient.GetAllForActiveUser(PackageType, ApiOptions)"/>
-    public static IPaginatedList<Package> GetAllForActiveUserAsync(this IPackagesClient t, PackageType packageType, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Package>(options => t.GetAllForActiveUser(packageType, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IReleasesClient.GetAll(long, ApiOptions)"/>
+    public static IPaginatedList<Release> GetAllAsync(this IReleasesClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Release>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IPackagesClient.GetAllForActiveUser(PackageType, PackageVisibility?, ApiOptions)"/>
-    public static IPaginatedList<Package> GetAllForActiveUserAsync(this IPackagesClient t, PackageType packageType, PackageVisibility? packageVisibility, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Package>(options => t.GetAllForActiveUser(packageType, packageVisibility, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IReleasesClient.GetAllAssets(string, string, long, ApiOptions)"/>
+    public static IPaginatedList<ReleaseAsset> GetAllAssetsAsync(this IReleasesClient t, string owner, string name, long id, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<ReleaseAsset>(options => t.GetAllAssets(owner, name, id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IPackagesClient.GetAllForUser(string, PackageType, ApiOptions)"/>
-    public static IPaginatedList<Package> GetAllForUserAsync(this IPackagesClient t, string username, PackageType packageType, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Package>(options => t.GetAllForUser(username, packageType, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IReleasesClient.GetAllAssets(long, long, ApiOptions)"/>
+    public static IPaginatedList<ReleaseAsset> GetAllAssetsAsync(this IReleasesClient t, long repositoryId, long id, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<ReleaseAsset>(options => t.GetAllAssets(repositoryId, id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IPackagesClient.GetAllForUser(string, PackageType, PackageVisibility?, ApiOptions)"/>
-    public static IPaginatedList<Package> GetAllForUserAsync(this IPackagesClient t, string username, PackageType packageType, PackageVisibility? packageVisibility, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Package>(options => t.GetAllForUser(username, packageType, packageVisibility, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IPullRequestsClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<PullRequest> GetAllForRepositoryAsync(this IPullRequestsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequest>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IGitHubAppsClient.GetAllInstallationsForCurrent(ApiOptions)"/>
-    public static IPaginatedList<Installation> GetAllInstallationsForCurrentAsync(this IGitHubAppsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Installation>(t.GetAllInstallationsForCurrent, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IPullRequestsClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<PullRequest> GetAllForRepositoryAsync(this IPullRequestsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequest>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IAuthorizationsClient.GetAll(ApiOptions)"/>
-    public static IPaginatedList<Authorization> GetAllAsync(this IAuthorizationsClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Authorization>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IPullRequestsClient.GetAllForRepository(string, string, PullRequestRequest, ApiOptions)"/>
+    public static IPaginatedList<PullRequest> GetAllForRepositoryAsync(this IPullRequestsClient t, string owner, string name, PullRequestRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequest>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IApiConnection.GetAll(Uri, ApiOptions)"/>
-    public static IPaginatedList<T> GetAllAsync<T>(this IApiConnection t, Uri uri, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<T>(options => t.GetAll<T>(uri, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IPullRequestsClient.GetAllForRepository(long, PullRequestRequest, ApiOptions)"/>
+    public static IPaginatedList<PullRequest> GetAllForRepositoryAsync(this IPullRequestsClient t, long repositoryId, PullRequestRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequest>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IApiConnection.GetAll(Uri, IDictionary{string, string}, ApiOptions)"/>
-    public static IPaginatedList<T> GetAllAsync<T>(this IApiConnection t, Uri uri, IDictionary<string, string> parameters, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<T>(options => t.GetAll<T>(uri, parameters, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IPullRequestsClient.Files(string, string, int, ApiOptions)"/>
+    public static IPaginatedList<PullRequestFile> FilesAsync(this IPullRequestsClient t, string owner, string name, int pullRequestNumber, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequestFile>(options => t.Files(owner, name, pullRequestNumber, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IApiConnection.GetAll(Uri, IDictionary{string, string}, string, ApiOptions)"/>
-    public static IPaginatedList<T> GetAllAsync<T>(this IApiConnection t, Uri uri, IDictionary<string, string> parameters, string accepts, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<T>(options => t.GetAll<T>(uri, parameters, accepts, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IPullRequestsClient.Files(long, int, ApiOptions)"/>
+    public static IPaginatedList<PullRequestFile> FilesAsync(this IPullRequestsClient t, long repositoryId, int pullRequestNumber, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequestFile>(options => t.Files(repositoryId, pullRequestNumber, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IEnterprisePreReceiveHooksClient.GetAll(ApiOptions)"/>
-    public static IPaginatedList<PreReceiveHook> GetAllAsync(this IEnterprisePreReceiveHooksClient t, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<PreReceiveHook>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IGistsClient.GetAll(ApiOptions)"/>
+    public static IPaginatedList<Gist> GetAllAsync(this IGistsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Gist>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IEnterpriseAuditLogClient.GetAll(string, AuditLogApiOptions)"/>
-    public static IPaginatedList<AuditLogEvent> GetAllAsync(this IEnterpriseAuditLogClient t, string enterprise, AuditLogApiOptions auditLog, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<AuditLogEvent>(options => t.GetAll(enterprise, auditLog), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IGistsClient.GetAll(DateTimeOffset, ApiOptions)"/>
+    public static IPaginatedList<Gist> GetAllAsync(this IGistsClient t, DateTimeOffset since, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Gist>(options => t.GetAll(since, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IEnterpriseAuditLogClient.GetAll(string, AuditLogRequest, AuditLogApiOptions)"/>
-    public static IPaginatedList<AuditLogEvent> GetAllAsync(this IEnterpriseAuditLogClient t, string enterprise, AuditLogRequest request, AuditLogApiOptions auditLog, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<AuditLogEvent>(options => t.GetAll(enterprise, request, auditLog), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IGistsClient.GetAllPublic(ApiOptions)"/>
+    public static IPaginatedList<Gist> GetAllPublicAsync(this IGistsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Gist>(t.GetAllPublic, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IEnterpriseAuditLogClient.GetAllJson(string, AuditLogApiOptions)"/>
-    public static IPaginatedList<object> GetAllJsonAsync(this IEnterpriseAuditLogClient t, string enterprise, AuditLogApiOptions auditLog, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<object>(options => t.GetAllJson(enterprise, auditLog), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IGistsClient.GetAllPublic(DateTimeOffset, ApiOptions)"/>
+    public static IPaginatedList<Gist> GetAllPublicAsync(this IGistsClient t, DateTimeOffset since, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Gist>(options => t.GetAllPublic(since, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IEnterpriseAuditLogClient.GetAllJson(string, AuditLogRequest, AuditLogApiOptions)"/>
-    public static IPaginatedList<object> GetAllJsonAsync(this IEnterpriseAuditLogClient t, string enterprise, AuditLogRequest request, AuditLogApiOptions auditLog, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<object>(options => t.GetAllJson(enterprise, request, auditLog), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IGistsClient.GetAllStarred(ApiOptions)"/>
+    public static IPaginatedList<Gist> GetAllStarredAsync(this IGistsClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Gist>(t.GetAllStarred, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IGistsClient.GetAllStarred(DateTimeOffset, ApiOptions)"/>
+    public static IPaginatedList<Gist> GetAllStarredAsync(this IGistsClient t, DateTimeOffset since, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Gist>(options => t.GetAllStarred(since, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IGistsClient.GetAllForUser(string, ApiOptions)"/>
+    public static IPaginatedList<Gist> GetAllForUserAsync(this IGistsClient t, string user, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Gist>(options => t.GetAllForUser(user, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IGistsClient.GetAllForUser(string, DateTimeOffset, ApiOptions)"/>
+    public static IPaginatedList<Gist> GetAllForUserAsync(this IGistsClient t, string user, DateTimeOffset since, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Gist>(options => t.GetAllForUser(user, since, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IGistsClient.GetAllCommits(string, ApiOptions)"/>
+    public static IPaginatedList<GistHistory> GetAllCommitsAsync(this IGistsClient t, string id, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<GistHistory>(options => t.GetAllCommits(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IGistsClient.GetAllForks(string, ApiOptions)"/>
+    public static IPaginatedList<GistFork> GetAllForksAsync(this IGistsClient t, string id, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<GistFork>(options => t.GetAllForks(id, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IProjectsClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<Project> GetAllForRepositoryAsync(this IProjectsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IProjectsClient.GetAllForRepository(string, string, ProjectRequest, ApiOptions)"/>
+    public static IPaginatedList<Project> GetAllForRepositoryAsync(this IProjectsClient t, string owner, string name, ProjectRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForRepository(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IProjectsClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<Project> GetAllForRepositoryAsync(this IProjectsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IProjectsClient.GetAllForRepository(long, ProjectRequest, ApiOptions)"/>
+    public static IPaginatedList<Project> GetAllForRepositoryAsync(this IProjectsClient t, long repositoryId, ProjectRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IProjectsClient.GetAllForOrganization(string, ApiOptions)"/>
+    public static IPaginatedList<Project> GetAllForOrganizationAsync(this IProjectsClient t, string organization, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForOrganization(organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IProjectsClient.GetAllForOrganization(string, ProjectRequest, ApiOptions)"/>
+    public static IPaginatedList<Project> GetAllForOrganizationAsync(this IProjectsClient t, string organization, ProjectRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Project>(options => t.GetAllForOrganization(organization, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IPullRequestReviewsClient.GetAll(string, string, int, ApiOptions)"/>
+    public static IPaginatedList<PullRequestReview> GetAllAsync(this IPullRequestReviewsClient t, string owner, string name, int pullRequestNumber, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequestReview>(options => t.GetAll(owner, name, pullRequestNumber, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IPullRequestReviewsClient.GetAll(long, int, ApiOptions)"/>
+    public static IPaginatedList<PullRequestReview> GetAllAsync(this IPullRequestReviewsClient t, long repositoryId, int pullRequestNumber, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequestReview>(options => t.GetAll(repositoryId, pullRequestNumber, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IPullRequestReviewsClient.GetAllComments(string, string, int, long, ApiOptions)"/>
+    public static IPaginatedList<PullRequestReviewComment> GetAllCommentsAsync(this IPullRequestReviewsClient t, string owner, string name, int pullRequestNumber, long reviewId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllComments(owner, name, pullRequestNumber, reviewId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IPullRequestReviewsClient.GetAllComments(long, int, long, ApiOptions)"/>
+    public static IPaginatedList<PullRequestReviewComment> GetAllCommentsAsync(this IPullRequestReviewsClient t, long repositoryId, int pullRequestNumber, long reviewId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PullRequestReviewComment>(options => t.GetAllComments(repositoryId, pullRequestNumber, reviewId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryCommentsClient.GetAllForRepository(string, string, ApiOptions)"/>
+    public static IPaginatedList<CommitComment> GetAllForRepositoryAsync(this IRepositoryCommentsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<CommitComment>(options => t.GetAllForRepository(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryCommentsClient.GetAllForRepository(long, ApiOptions)"/>
+    public static IPaginatedList<CommitComment> GetAllForRepositoryAsync(this IRepositoryCommentsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<CommitComment>(options => t.GetAllForRepository(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryCommentsClient.GetAllForCommit(string, string, string, ApiOptions)"/>
+    public static IPaginatedList<CommitComment> GetAllForCommitAsync(this IRepositoryCommentsClient t, string owner, string name, string sha, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<CommitComment>(options => t.GetAllForCommit(owner, name, sha, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryCommentsClient.GetAllForCommit(long, string, ApiOptions)"/>
+    public static IPaginatedList<CommitComment> GetAllForCommitAsync(this IRepositoryCommentsClient t, long repositoryId, string sha, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<CommitComment>(options => t.GetAllForCommit(repositoryId, sha, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryCommitsClient.BranchesWhereHead(long, string, ApiOptions)"/>
+    public static IPaginatedList<Branch> BranchesWhereHeadAsync(this IRepositoryCommitsClient t, long repositoryId, string sha1, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Branch>(options => t.BranchesWhereHead(repositoryId, sha1, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryCommitsClient.BranchesWhereHead(string, string, string, ApiOptions)"/>
+    public static IPaginatedList<Branch> BranchesWhereHeadAsync(this IRepositoryCommitsClient t, string owner, string name, string sha1, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<Branch>(options => t.BranchesWhereHead(owner, name, sha1, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryCommitsClient.GetAll(string, string, ApiOptions)"/>
+    public static IPaginatedList<GitHubCommit> GetAllAsync(this IRepositoryCommitsClient t, string owner, string name, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<GitHubCommit>(options => t.GetAll(owner, name, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryCommitsClient.GetAll(long, ApiOptions)"/>
+    public static IPaginatedList<GitHubCommit> GetAllAsync(this IRepositoryCommitsClient t, long repositoryId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<GitHubCommit>(options => t.GetAll(repositoryId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryCommitsClient.GetAll(string, string, CommitRequest, ApiOptions)"/>
+    public static IPaginatedList<GitHubCommit> GetAllAsync(this IRepositoryCommitsClient t, string owner, string name, CommitRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<GitHubCommit>(options => t.GetAll(owner, name, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryCommitsClient.GetAll(long, CommitRequest, ApiOptions)"/>
+    public static IPaginatedList<GitHubCommit> GetAllAsync(this IRepositoryCommitsClient t, long repositoryId, CommitRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<GitHubCommit>(options => t.GetAll(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryCommitsClient.PullRequests(long, string, ApiOptions)"/>
+    public static IPaginatedList<CommitPullRequest> PullRequestsAsync(this IRepositoryCommitsClient t, long repositoryId, string sha1, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<CommitPullRequest>(options => t.PullRequests(repositoryId, sha1, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IRepositoryCommitsClient.PullRequests(string, string, string, ApiOptions)"/>
+    public static IPaginatedList<CommitPullRequest> PullRequestsAsync(this IRepositoryCommitsClient t, string owner, string name, string sha1, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<CommitPullRequest>(options => t.PullRequests(owner, name, sha1, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IProjectCardsClient.GetAll(int, ApiOptions)"/>
+    public static IPaginatedList<ProjectCard> GetAllAsync(this IProjectCardsClient t, int columnId, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<ProjectCard>(options => t.GetAll(columnId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IProjectCardsClient.GetAll(int, ProjectCardRequest, ApiOptions)"/>
+    public static IPaginatedList<ProjectCard> GetAllAsync(this IProjectCardsClient t, int columnId, ProjectCardRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<ProjectCard>(options => t.GetAll(columnId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="ICopilotLicenseClient.GetAll(string, ApiOptions)"/>
+    public static IPaginatedList<CopilotSeats> GetAllAsync(this ICopilotLicenseClient t, string organization, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<CopilotSeats>(options => t.GetAll(organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
     /// <inheritdoc cref="IEnterprisePreReceiveEnvironmentsClient.GetAll(ApiOptions)"/>
     public static IPaginatedList<PreReceiveEnvironment> GetAllAsync(this IEnterprisePreReceiveEnvironmentsClient t, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<PreReceiveEnvironment>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="ICopilotLicenseClient.GetAll(string, ApiOptions)"/>
-    public static IPaginatedList<CopilotSeats> GetAllAsync(this ICopilotLicenseClient t, string organization, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<CopilotSeats>(options => t.GetAll(organization, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+    /// <inheritdoc cref="IEnterprisePreReceiveHooksClient.GetAll(ApiOptions)"/>
+    public static IPaginatedList<PreReceiveHook> GetAllAsync(this IEnterprisePreReceiveHooksClient t, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<PreReceiveHook>(t.GetAll, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IEnterpriseAuditLogClient.GetAll(string, AuditLogApiOptions, ApiOptions)"/>
+    public static IPaginatedList<AuditLogEvent> GetAllAsync(this IEnterpriseAuditLogClient t, string enterprise, AuditLogApiOptions auditLog, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<AuditLogEvent>(options => t.GetAll(enterprise, auditLog), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IEnterpriseAuditLogClient.GetAll(string, AuditLogRequest, AuditLogApiOptions, ApiOptions)"/>
+    public static IPaginatedList<AuditLogEvent> GetAllAsync(this IEnterpriseAuditLogClient t, string enterprise, AuditLogRequest request, AuditLogApiOptions auditLog, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<AuditLogEvent>(options => t.GetAll(enterprise, request, auditLog), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IEnterpriseAuditLogClient.GetAllJson(string, AuditLogApiOptions, ApiOptions)"/>
+    public static IPaginatedList<object> GetAllJsonAsync(this IEnterpriseAuditLogClient t, string enterprise, AuditLogApiOptions auditLog, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<object>(options => t.GetAllJson(enterprise, auditLog), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
+
+    /// <inheritdoc cref="IEnterpriseAuditLogClient.GetAllJson(string, AuditLogRequest, AuditLogApiOptions, ApiOptions" />
+    public static IPaginatedList<object> GetAllJsonAsync(this IEnterpriseAuditLogClient t, string enterprise, AuditLogRequest request, AuditLogApiOptions auditLog, int pageSize = DEFAULT_PAGE_SIZE)
+        => pageSize > 0 ? new PaginatedList<object>(options => t.GetAllJson(enterprise, request, auditLog), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
   }
 }

--- a/Octokit.Reactive/Clients/IObservableAssigneesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableAssigneesClient.cs
@@ -51,20 +51,20 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="assignees">List of names of assignees to add</param>
         /// <returns></returns>
-        IObservable<Issue> AddAssignees(string owner, string name, int number, AssigneesUpdate assignees);
+        IObservable<Issue> AddAssignees(string owner, string name, int issueNumber, AssigneesUpdate assignees);
 
         /// <summary>
         /// Remove assignees from a specified Issue.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="assignees">List of assignees to remove </param>
         /// <returns></returns>
-        IObservable<Issue> RemoveAssignees(string owner, string name, int number, AssigneesUpdate assignees);
+        IObservable<Issue> RemoveAssignees(string owner, string name, int issueNumber, AssigneesUpdate assignees);
 
         /// <summary>
         /// Checks to see if a user is an assignee for a repository.

--- a/Octokit.Reactive/Clients/IObservableIssueCommentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssueCommentsClient.cs
@@ -107,16 +107,16 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
-        IObservable<IssueComment> GetAllForIssue(string owner, string name, int number);
+        /// <param name="issueNumber">The issue number</param>
+        IObservable<IssueComment> GetAllForIssue(string owner, string name, int issueNumber);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
-        IObservable<IssueComment> GetAllForIssue(long repositoryId, int number);
+        /// <param name="issueNumber">The issue number</param>
+        IObservable<IssueComment> GetAllForIssue(long repositoryId, int issueNumber);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
@@ -124,18 +124,18 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<IssueComment> GetAllForIssue(string owner, string name, int number, ApiOptions options);
+        IObservable<IssueComment> GetAllForIssue(string owner, string name, int issueNumber, ApiOptions options);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<IssueComment> GetAllForIssue(long repositoryId, int number, ApiOptions options);
+        IObservable<IssueComment> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
@@ -143,18 +143,18 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
-        IObservable<IssueComment> GetAllForIssue(string owner, string name, int number, IssueCommentRequest request);
+        IObservable<IssueComment> GetAllForIssue(string owner, string name, int issueNumber, IssueCommentRequest request);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
-        IObservable<IssueComment> GetAllForIssue(long repositoryId, int number, IssueCommentRequest request);
+        IObservable<IssueComment> GetAllForIssue(long repositoryId, int issueNumber, IssueCommentRequest request);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
@@ -162,20 +162,20 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<IssueComment> GetAllForIssue(string owner, string name, int number, IssueCommentRequest request, ApiOptions options);
+        IObservable<IssueComment> GetAllForIssue(string owner, string name, int issueNumber, IssueCommentRequest request, ApiOptions options);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<IssueComment> GetAllForIssue(long repositoryId, int number, IssueCommentRequest request, ApiOptions options);
+        IObservable<IssueComment> GetAllForIssue(long repositoryId, int issueNumber, IssueCommentRequest request, ApiOptions options);
 
         /// <summary>
         /// Creates a new Issue Comment for a specified Issue.
@@ -183,18 +183,18 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/comments/#create-a-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="newComment">The text of the new comment</param>
-        IObservable<IssueComment> Create(string owner, string name, int number, string newComment);
+        IObservable<IssueComment> Create(string owner, string name, int issueNumber, string newComment);
 
         /// <summary>
         /// Creates a new Issue Comment for a specified Issue.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#create-a-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="newComment">The text of the new comment</param>
-        IObservable<IssueComment> Create(long repositoryId, int number, string newComment);
+        IObservable<IssueComment> Create(long repositoryId, int issueNumber, string newComment);
 
         /// <summary>
         /// Updates a specified Issue Comment.

--- a/Octokit.Reactive/Clients/IObservableIssueReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssueReactionsClient.cs
@@ -17,8 +17,8 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue id</param>
-        IObservable<Reaction> GetAll(string owner, string name, int number);
+        /// <param name="issueNumber">The issue number</param>
+        IObservable<Reaction> GetAll(string owner, string name, int issueNumber);
 
         /// <summary>
         /// List reactions for a specified Issue.
@@ -26,26 +26,26 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue id</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<Reaction> GetAll(string owner, string name, int number, ApiOptions options);
+        IObservable<Reaction> GetAll(string owner, string name, int issueNumber, ApiOptions options);
 
         /// <summary>
         /// List reactions for a specified Issue.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue id</param>
-        IObservable<Reaction> GetAll(long repositoryId, int number);
+        /// <param name="issueNumber">The issue number</param>
+        IObservable<Reaction> GetAll(long repositoryId, int issueNumber);
 
         /// <summary>
         /// List reactions for a specified Issue.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue id</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<Reaction> GetAll(long repositoryId, int number, ApiOptions options);
+        IObservable<Reaction> GetAll(long repositoryId, int issueNumber, ApiOptions options);
 
         /// <summary>
         /// Creates a reaction for a specified Issue.
@@ -53,18 +53,18 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue id</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="reaction">The reaction to create </param>
-        IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction);
+        IObservable<Reaction> Create(string owner, string name, int issueNumber, NewReaction reaction);
 
         /// <summary>
         /// Creates a reaction for a specified Issue.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue id</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="reaction">The reaction to create </param>
-        IObservable<Reaction> Create(long repositoryId, int number, NewReaction reaction);
+        IObservable<Reaction> Create(long repositoryId, int issueNumber, NewReaction reaction);
 
         /// <summary>
         /// Deletes a reaction for a specified Issue

--- a/Octokit.Reactive/Clients/IObservableIssueTimelineClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssueTimelineClient.cs
@@ -18,8 +18,8 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="repo">The name of the repository</param>
-        /// <param name="number">The issue number</param>
-        IObservable<TimelineEventInfo> GetAllForIssue(string owner, string repo, int number);
+        /// <param name="issueNumber">The issue number</param>
+        IObservable<TimelineEventInfo> GetAllForIssue(string owner, string repo, int issueNumber);
 
         /// <summary>
         /// Gets all the various events that have occurred around an issue or pull request.
@@ -29,9 +29,9 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="repo">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<TimelineEventInfo> GetAllForIssue(string owner, string repo, int number, ApiOptions options);
+        IObservable<TimelineEventInfo> GetAllForIssue(string owner, string repo, int issueNumber, ApiOptions options);
 
         /// <summary>
         /// Gets all the various events that have occurred around an issue or pull request.
@@ -40,8 +40,8 @@ namespace Octokit.Reactive
         /// https://developer.github.com/v3/issues/timeline/#list-events-for-an-issue
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
-        IObservable<TimelineEventInfo> GetAllForIssue(long repositoryId, int number);
+        /// <param name="issueNumber">The issue number</param>
+        IObservable<TimelineEventInfo> GetAllForIssue(long repositoryId, int issueNumber);
 
         /// <summary>
         /// Gets all the various events that have occurred around an issue or pull request.
@@ -50,8 +50,8 @@ namespace Octokit.Reactive
         /// https://developer.github.com/v3/issues/timeline/#list-events-for-an-issue
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<TimelineEventInfo> GetAllForIssue(long repositoryId, int number, ApiOptions options);
+        IObservable<TimelineEventInfo> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableIssuesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssuesClient.cs
@@ -23,8 +23,8 @@ namespace Octokit.Reactive
         IObservableMilestonesClient Milestone { get; }
 
         /// <summary>
-        /// Client for reading various event information associated with issues/pull requests.  
-        /// This is useful both for display on issue/pull request information pages and also to 
+        /// Client for reading various event information associated with issues/pull requests.
+        /// This is useful both for display on issue/pull request information pages and also to
         /// determine who should be notified of comments.
         /// </summary>
         IObservableIssuesEventsClient Events { get; }
@@ -57,10 +57,10 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        IObservable<Issue> Get(string owner, string name, int number);
+        IObservable<Issue> Get(string owner, string name, int issueNumber);
 
         /// <summary>
         /// Gets a single Issue by number.
@@ -69,10 +69,10 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/#get-a-single-issue
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        IObservable<Issue> Get(long repositoryId, int number);
+        IObservable<Issue> Get(long repositoryId, int issueNumber);
 
         /// <summary>
         /// Gets all open issues assigned to the authenticated user across all the authenticated user’s visible
@@ -96,7 +96,7 @@ namespace Octokit.Reactive
         IObservable<Issue> GetAllForCurrent(ApiOptions options);
 
         /// <summary>
-        /// Gets all issues across all the authenticated user’s visible repositories including owned repositories, 
+        /// Gets all issues across all the authenticated user’s visible repositories including owned repositories,
         /// member repositories, and organization repositories.
         /// </summary>
         /// <remarks>
@@ -106,7 +106,7 @@ namespace Octokit.Reactive
         IObservable<Issue> GetAllForCurrent(IssueRequest request);
 
         /// <summary>
-        /// Gets all issues across all the authenticated user’s visible repositories including owned repositories, 
+        /// Gets all issues across all the authenticated user’s visible repositories including owned repositories,
         /// member repositories, and organization repositories.
         /// </summary>
         /// <remarks>
@@ -306,10 +306,10 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/#create-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        IObservable<Issue> Update(string owner, string name, int number, IssueUpdate issueUpdate);
+        IObservable<Issue> Update(string owner, string name, int issueNumber, IssueUpdate issueUpdate);
 
         /// <summary>
         /// Creates an issue for the specified repository. Any user with pull access to a repository can create an
@@ -317,9 +317,9 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/#create-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        IObservable<Issue> Update(long repositoryId, int number, IssueUpdate issueUpdate);
+        IObservable<Issue> Update(long repositoryId, int issueNumber, IssueUpdate issueUpdate);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableIssuesEventsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssuesEventsClient.cs
@@ -19,8 +19,8 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
-        IObservable<IssueEvent> GetAllForIssue(string owner, string name, int number);
+        /// <param name="issueNumber">The issue number</param>
+        IObservable<IssueEvent> GetAllForIssue(string owner, string name, int issueNumber);
 
         /// <summary>
         /// Gets all events for the issue.
@@ -29,8 +29,8 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/events/#list-events-for-an-issue
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
-        IObservable<IssueEvent> GetAllForIssue(long repositoryId, int number);
+        /// <param name="issueNumber">The issue number</param>
+        IObservable<IssueEvent> GetAllForIssue(long repositoryId, int issueNumber);
 
         /// <summary>
         /// Gets all events for the issue.
@@ -40,9 +40,9 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<IssueEvent> GetAllForIssue(string owner, string name, int number, ApiOptions options);
+        IObservable<IssueEvent> GetAllForIssue(string owner, string name, int issueNumber, ApiOptions options);
 
         /// <summary>
         /// Gets all events for the issue.
@@ -51,9 +51,9 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/events/#list-events-for-an-issue
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<IssueEvent> GetAllForIssue(long repositoryId, int number, ApiOptions options);
+        IObservable<IssueEvent> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options);
 
         /// <summary>
         /// Gets all events for the repository.

--- a/Octokit.Reactive/Clients/IObservableIssuesLabelsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssuesLabelsClient.cs
@@ -20,8 +20,8 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
-        IObservable<Label> GetAllForIssue(string owner, string name, int number);
+        /// <param name="issueNumber">The issue number</param>
+        IObservable<Label> GetAllForIssue(string owner, string name, int issueNumber);
 
         /// <summary>
         /// Gets all  labels for the issue.
@@ -30,8 +30,8 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-labels-on-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the issue</param>
-        IObservable<Label> GetAllForIssue(long repositoryId, int number);
+        /// <param name="issueNumber">The issue number</param>
+        IObservable<Label> GetAllForIssue(long repositoryId, int issueNumber);
 
         /// <summary>
         /// Gets all  labels for the issue.
@@ -41,9 +41,9 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<Label> GetAllForIssue(string owner, string name, int number, ApiOptions options);
+        IObservable<Label> GetAllForIssue(string owner, string name, int issueNumber, ApiOptions options);
 
         /// <summary>
         /// Gets all  labels for the issue.
@@ -52,9 +52,9 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-labels-on-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<Label> GetAllForIssue(long repositoryId, int number, ApiOptions options);
+        IObservable<Label> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options);
 
         /// <summary>
         /// Gets all  labels for the repository.
@@ -104,8 +104,8 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the milestone</param>
-        IObservable<Label> GetAllForMilestone(string owner, string name, int number);
+        /// <param name="milestoneNumber">The number of the milestone</param>
+        IObservable<Label> GetAllForMilestone(string owner, string name, int milestoneNumber);
 
         /// <summary>
         /// Gets labels for every issue in a milestone
@@ -114,8 +114,8 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the milestone</param>
-        IObservable<Label> GetAllForMilestone(long repositoryId, int number);
+        /// <param name="milestoneNumber">The number of the milestone</param>
+        IObservable<Label> GetAllForMilestone(long repositoryId, int milestoneNumber);
 
         /// <summary>
         /// Gets labels for every issue in a milestone
@@ -125,9 +125,9 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the milestone</param>
+        /// <param name="milestoneNumber">The number of the milestone</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<Label> GetAllForMilestone(string owner, string name, int number, ApiOptions options);
+        IObservable<Label> GetAllForMilestone(string owner, string name, int milestoneNumber, ApiOptions options);
 
         /// <summary>
         /// Gets labels for every issue in a milestone
@@ -136,9 +136,9 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the milestone</param>
+        /// <param name="milestoneNumber">The number of the milestone</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<Label> GetAllForMilestone(long repositoryId, int number, ApiOptions options);
+        IObservable<Label> GetAllForMilestone(long repositoryId, int milestoneNumber, ApiOptions options);
 
         /// <summary>
         /// Gets a single Label by name.
@@ -238,9 +238,9 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="labels">The names of the labels to add</param>
-        IObservable<Label> AddToIssue(string owner, string name, int number, string[] labels);
+        IObservable<Label> AddToIssue(string owner, string name, int issueNumber, string[] labels);
 
         /// <summary>
         /// Adds a label to an issue
@@ -249,9 +249,9 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#add-labels-to-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="labels">The names of the labels to add</param>
-        IObservable<Label> AddToIssue(long repositoryId, int number, string[] labels);
+        IObservable<Label> AddToIssue(long repositoryId, int issueNumber, string[] labels);
 
         /// <summary>
         /// Removes a label from an issue
@@ -261,9 +261,9 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="labelName">The name of the label to remove</param>
-        IObservable<Label> RemoveFromIssue(string owner, string name, int number, string labelName);
+        IObservable<Label> RemoveFromIssue(string owner, string name, int issueNumber, string labelName);
 
         /// <summary>
         /// Removes a label from an issue
@@ -272,9 +272,9 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#remove-a-label-from-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="labelName">The name of the label to remove</param>
-        IObservable<Label> RemoveFromIssue(long repositoryId, int number, string labelName);
+        IObservable<Label> RemoveFromIssue(long repositoryId, int issueNumber, string labelName);
 
         /// <summary>
         /// Replaces all labels on the specified issues with the provided labels
@@ -284,9 +284,9 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="labels">The names of the labels to set</param>
-        IObservable<Label> ReplaceAllForIssue(string owner, string name, int number, string[] labels);
+        IObservable<Label> ReplaceAllForIssue(string owner, string name, int issueNumber, string[] labels);
 
         /// <summary>
         /// Replaces all labels on the specified issues with the provided labels
@@ -295,9 +295,9 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#replace-all-labels-for-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="labels">The names of the labels to set</param>
-        IObservable<Label> ReplaceAllForIssue(long repositoryId, int number, string[] labels);
+        IObservable<Label> ReplaceAllForIssue(long repositoryId, int issueNumber, string[] labels);
 
         /// <summary>
         /// Removes all labels from an issue
@@ -307,8 +307,8 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
-        IObservable<Unit> RemoveAllFromIssue(string owner, string name, int number);
+        /// <param name="issueNumber">The issue number</param>
+        IObservable<Unit> RemoveAllFromIssue(string owner, string name, int issueNumber);
 
         /// <summary>
         /// Removes all labels from an issue
@@ -317,7 +317,7 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#remove-all-labels-from-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the issue</param>
-        IObservable<Unit> RemoveAllFromIssue(long repositoryId, int number);
+        /// <param name="issueNumber">The issue number</param>
+        IObservable<Unit> RemoveAllFromIssue(long repositoryId, int issueNumber);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableLockUnlockClient.cs
+++ b/Octokit.Reactive/Clients/IObservableLockUnlockClient.cs
@@ -14,18 +14,18 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="lockReason">The reason for locking the issue</param>
-        IObservable<Unit> Lock(string owner, string name, int number, LockReason? lockReason = null);
+        IObservable<Unit> Lock(string owner, string name, int issueNumber, LockReason? lockReason = null);
 
         /// <summary>
         /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="lockReason">The reason for locking the issue</param>
-        IObservable<Unit> Lock(long repositoryId, int number, LockReason? lockReason = null);
+        IObservable<Unit> Lock(long repositoryId, int issueNumber, LockReason? lockReason = null);
 
         /// <summary>
         /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
@@ -33,15 +33,15 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
-        IObservable<Unit> Unlock(string owner, string name, int number);
+        /// <param name="issueNumber">The issue number</param>
+        IObservable<Unit> Unlock(string owner, string name, int issueNumber);
 
         /// <summary>
         /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
-        IObservable<Unit> Unlock(long repositoryId, int number);
+        /// <param name="issueNumber">The issue number</param>
+        IObservable<Unit> Unlock(long repositoryId, int issueNumber);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableMilestonesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableMilestonesClient.cs
@@ -21,7 +21,7 @@ namespace Octokit.Reactive
         /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
         Justification = "Method makes a network request")]
-        IObservable<Milestone> Get(string owner, string name, int number);
+        IObservable<Milestone> Get(string owner, string name, int milestoneNumber);
 
         /// <summary>
         /// Gets a single Milestone by number.
@@ -32,7 +32,7 @@ namespace Octokit.Reactive
         /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
         Justification = "Method makes a network request")]
-        IObservable<Milestone> Get(long repositoryId, int number);
+        IObservable<Milestone> Get(long repositoryId, int milestoneNumber);
 
         /// <summary>
         /// Gets all open milestones for the repository.
@@ -154,11 +154,11 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/milestones/#update-a-milestone</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The Milestone number</param>
+        /// <param name="milestoneNumber">The Milestone number</param>
         /// <param name="milestoneUpdate">An <see cref="MilestoneUpdate"/> instance describing the changes to make to the Milestone
         /// </param>
         /// <returns></returns>
-        IObservable<Milestone> Update(string owner, string name, int number, MilestoneUpdate milestoneUpdate);
+        IObservable<Milestone> Update(string owner, string name, int milestoneNumber, MilestoneUpdate milestoneUpdate);
 
         /// <summary>
         /// Updates a milestone for the specified repository. Any user with pull access to a repository can create a
@@ -166,11 +166,11 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/milestones/#update-a-milestone</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The Milestone number</param>
+        /// <param name="milestoneNumber">The Milestone number</param>
         /// <param name="milestoneUpdate">An <see cref="MilestoneUpdate"/> instance describing the changes to make to the Milestone
         /// </param>
         /// <returns></returns>
-        IObservable<Milestone> Update(long repositoryId, int number, MilestoneUpdate milestoneUpdate);
+        IObservable<Milestone> Update(long repositoryId, int milestoneNumber, MilestoneUpdate milestoneUpdate);
 
         /// <summary>
         /// Deletes a milestone for the specified repository. Any user with pull access to a repository can create an
@@ -179,9 +179,9 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/milestones/#delete-a-milestone</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The milestone number</param>
+        /// <param name="milestoneNumber">The Milestone number</param>
         /// <returns></returns>
-        IObservable<Unit> Delete(string owner, string name, int number);
+        IObservable<Unit> Delete(string owner, string name, int milestoneNumber);
 
         /// <summary>
         /// Deletes a milestone for the specified repository. Any user with pull access to a repository can create an
@@ -189,8 +189,8 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/milestones/#delete-a-milestone</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The milestone number</param>
+        /// <param name="milestoneNumber">The Milestone number</param>
         /// <returns></returns>
-        IObservable<Unit> Delete(long repositoryId, int number);
+        IObservable<Unit> Delete(long repositoryId, int milestoneNumber);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableNotificationsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableNotificationsClient.cs
@@ -160,38 +160,38 @@ namespace Octokit.Reactive
         /// <summary>
         /// Retrives a single <see cref="Notification"/> by Id.
         /// </summary>
-        /// <param name="id">The Id of the notification to retrieve.</param>
+        /// <param name="notificationId">The Id of the notification to retrieve.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#view-a-single-thread</remarks>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        IObservable<Notification> Get(int id);
+        IObservable<Notification> Get(int notificationId);
 
         /// <summary>
         /// Marks a single notification as read.
         /// </summary>
-        /// <param name="id">The id of the notification.</param>
+        /// <param name="notificationId">The id of the notification.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-a-thread-as-read</remarks>
-        IObservable<Unit> MarkAsRead(int id);
+        IObservable<Unit> MarkAsRead(int notificationId);
 
         /// <summary>
         /// Retrives a <see cref="ThreadSubscription"/> for the provided thread id.
         /// </summary>
-        /// <param name="id">The Id of the thread to retrieve subscription status.</param>
+        /// <param name="threadId">The Id of the thread to retrieve subscription status.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#get-a-thread-subscription</remarks>
-        IObservable<ThreadSubscription> GetThreadSubscription(int id);
+        IObservable<ThreadSubscription> GetThreadSubscription(int threadId);
 
         /// <summary>
         /// Sets the authenticated user's subscription settings for a given thread.
         /// </summary>
-        /// <param name="id">The Id of the thread to update.</param>
+        /// <param name="threadId">The Id of the thread to update.</param>
         /// <param name="threadSubscription">The subscription parameters to set.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#set-a-thread-subscription</remarks>
-        IObservable<ThreadSubscription> SetThreadSubscription(int id, NewThreadSubscription threadSubscription);
+        IObservable<ThreadSubscription> SetThreadSubscription(int threadId, NewThreadSubscription threadSubscription);
 
         /// <summary>
         /// Deletes the authenticated user's subscription to a given thread.
         /// </summary>
-        /// <param name="id">The Id of the thread to delete subscription from.</param>
+        /// <param name="threadId">The Id of the thread to delete subscription from.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#delete-a-thread-subscription</remarks>
-        IObservable<Unit> DeleteThreadSubscription(int id);
+        IObservable<Unit> DeleteThreadSubscription(int threadId);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableProjectColumnsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableProjectColumnsClient.cs
@@ -36,9 +36,9 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/projects/columns/#get-a-project-column">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="id">The id of the column</param>
+        /// <param name="columnId">The id of the column</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        IObservable<ProjectColumn> Get(int id);
+        IObservable<ProjectColumn> Get(int columnId);
 
         /// <summary>
         /// Creates a column.
@@ -56,9 +56,9 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/projects/columns/#update-a-project-column">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="id">The id of the column</param>
+        /// <param name="columnId">The id of the column</param>
         /// <param name="projectColumnUpdate">New values to update the column with</param>
-        IObservable<ProjectColumn> Update(int id, ProjectColumnUpdate projectColumnUpdate);
+        IObservable<ProjectColumn> Update(int columnId, ProjectColumnUpdate projectColumnUpdate);
 
         /// <summary>
         /// Deletes a column.
@@ -66,8 +66,8 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/projects/columns/#delete-a-project-column">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="id">The id of the column</param>
-        IObservable<bool> Delete(int id);
+        /// <param name="columnId">The id of the column</param>
+        IObservable<bool> Delete(int columnId);
 
         /// <summary>
         /// Moves a column.
@@ -75,8 +75,8 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/projects/columns/#move-a-project-column">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="id">The id of the column</param>
+        /// <param name="columnId">The id of the column</param>
         /// <param name="position">The position to move the column</param>
-        IObservable<bool> Move(int id, ProjectColumnMove position);
+        IObservable<bool> Move(int columnId, ProjectColumnMove position);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableProjectsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableProjectsClient.cs
@@ -141,9 +141,9 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/projects/#get-a-project">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="id">The Id of the project</param>
+        /// <param name="projectId">The Id of the project</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        IObservable<Project> Get(int id);
+        IObservable<Project> Get(int projectId);
 
         /// <summary>
         /// Creates a project for the specified repository.
@@ -171,9 +171,9 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/projects/#update-a-project">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="id">The Id of the project</param>
+        /// <param name="projectId">The Id of the project</param>
         /// <param name="projectUpdate">The modified project</param>
-        IObservable<Project> Update(int id, ProjectUpdate projectUpdate);
+        IObservable<Project> Update(int projectId, ProjectUpdate projectUpdate);
 
         /// <summary>
         /// Deletes a project.
@@ -181,8 +181,8 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/projects/#delete-a-project">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="id">The Id of the project</param>
-        IObservable<bool> Delete(int id);
+        /// <param name="projectId">The Id of the project</param>
+        IObservable<bool> Delete(int projectId);
 
         /// <summary>
         /// A client for GitHub's Project Cards API.

--- a/Octokit.Reactive/Clients/IObservablePullRequestReviewCommentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservablePullRequestReviewCommentsClient.cs
@@ -17,16 +17,16 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
-        IObservable<PullRequestReviewComment> GetAll(string owner, string name, int number);
+        /// <param name="pullRequestNumber">The pull request number</param>
+        IObservable<PullRequestReviewComment> GetAll(string owner, string name, int pullRequestNumber);
 
         /// <summary>
         /// Gets review comments for a specified pull request.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
-        IObservable<PullRequestReviewComment> GetAll(long repositoryId, int number);
+        /// <param name="pullRequestNumber">The pull request number</param>
+        IObservable<PullRequestReviewComment> GetAll(long repositoryId, int pullRequestNumber);
 
         /// <summary>
         /// Gets review comments for a specified pull request.
@@ -34,18 +34,18 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<PullRequestReviewComment> GetAll(string owner, string name, int number, ApiOptions options);
+        IObservable<PullRequestReviewComment> GetAll(string owner, string name, int pullRequestNumber, ApiOptions options);
 
         /// <summary>
         /// Gets review comments for a specified pull request.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<PullRequestReviewComment> GetAll(long repositoryId, int number, ApiOptions options);
+        IObservable<PullRequestReviewComment> GetAll(long repositoryId, int pullRequestNumber, ApiOptions options);
 
         /// <summary>
         /// Gets a list of the pull request review comments in a specified repository.
@@ -138,18 +138,18 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#create-a-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The Pull Request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="comment">The comment</param>
-        IObservable<PullRequestReviewComment> Create(string owner, string name, int number, PullRequestReviewCommentCreate comment);
+        IObservable<PullRequestReviewComment> Create(string owner, string name, int pullRequestNumber, PullRequestReviewCommentCreate comment);
 
         /// <summary>
         /// Creates a comment on a pull request review.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#create-a-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The Pull Request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="comment">The comment</param>
-        IObservable<PullRequestReviewComment> Create(long repositoryId, int number, PullRequestReviewCommentCreate comment);
+        IObservable<PullRequestReviewComment> Create(long repositoryId, int pullRequestNumber, PullRequestReviewCommentCreate comment);
 
         /// <summary>
         /// Creates a comment on a pull request review as a reply to another comment.
@@ -157,18 +157,18 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#create-a-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="comment">The comment</param>
-        IObservable<PullRequestReviewComment> CreateReply(string owner, string name, int number, PullRequestReviewCommentReplyCreate comment);
+        IObservable<PullRequestReviewComment> CreateReply(string owner, string name, int pullRequestNumber, PullRequestReviewCommentReplyCreate comment);
 
         /// <summary>
         /// Creates a comment on a pull request review as a reply to another comment.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#create-a-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="comment">The comment</param>
-        IObservable<PullRequestReviewComment> CreateReply(long repositoryId, int number, PullRequestReviewCommentReplyCreate comment);
+        IObservable<PullRequestReviewComment> CreateReply(long repositoryId, int pullRequestNumber, PullRequestReviewCommentReplyCreate comment);
 
         /// <summary>
         /// Edits a comment on a pull request review.

--- a/Octokit.Reactive/Clients/IObservablePullRequestReviewRequestsClient.cs
+++ b/Octokit.Reactive/Clients/IObservablePullRequestReviewRequestsClient.cs
@@ -17,16 +17,16 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/review_requests/#list-review-requests</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
-        IObservable<RequestedReviews> Get(string owner, string name, int number);
+        /// <param name="pullRequestNumber">The pull request number</param>
+        IObservable<RequestedReviews> Get(string owner, string name, int pullRequestNumber);
 
         /// <summary>
         /// Gets review requests for a specified pull request.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/review_requests/#list-review-requests</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
-        IObservable<RequestedReviews> Get(long repositoryId, int number);
+        /// <param name="pullRequestNumber">The pull request number</param>
+        IObservable<RequestedReviews> Get(long repositoryId, int pullRequestNumber);
 
         /// <summary>
         /// Creates review requests on a pull request for specified users.
@@ -34,18 +34,18 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/review_requests/#create-a-review-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The Pull Request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="users">List of logins of user will be requested for review</param>
-        IObservable<PullRequest> Create(string owner, string name, int number, PullRequestReviewRequest users);
+        IObservable<PullRequest> Create(string owner, string name, int pullRequestNumber, PullRequestReviewRequest users);
 
         /// <summary>
         /// Creates review requests on a pull request for specified users.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/review_requests/#create-a-review-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The Pull Request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="users">List of logins of user will be requested for review</param>
-        IObservable<PullRequest> Create(long repositoryId, int number, PullRequestReviewRequest users);
+        IObservable<PullRequest> Create(long repositoryId, int pullRequestNumber, PullRequestReviewRequest users);
 
         /// <summary>
         /// Deletes review request for given users on a pull request.
@@ -53,17 +53,17 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/review_requests/#delete-a-review-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request review comment number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="users">List of logins of users that will be not longer requested for review</param>
-        IObservable<Unit> Delete(string owner, string name, int number, PullRequestReviewRequest users);
+        IObservable<Unit> Delete(string owner, string name, int pullRequestNumber, PullRequestReviewRequest users);
 
         /// <summary>
         /// Deletes review request for given users on a pull request.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/review_requests/#delete-a-review-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request review comment number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="users">List of logins of users that will be not longer requested for review</param>
-        IObservable<Unit> Delete(long repositoryId, int number, PullRequestReviewRequest users);
+        IObservable<Unit> Delete(long repositoryId, int pullRequestNumber, PullRequestReviewRequest users);
     }
 }

--- a/Octokit.Reactive/Clients/IObservablePullRequestReviewsClient.cs
+++ b/Octokit.Reactive/Clients/IObservablePullRequestReviewsClient.cs
@@ -17,16 +17,16 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
-        IObservable<PullRequestReview> GetAll(string owner, string name, int number);
+        /// <param name="pullRequestNumber">The pull request number</param>
+        IObservable<PullRequestReview> GetAll(string owner, string name, int pullRequestNumber);
 
         /// <summary>
         /// Gets reviews for a specified pull request.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
-        IObservable<PullRequestReview> GetAll(long repositoryId, int number);
+        /// <param name="pullRequestNumber">The pull request number</param>
+        IObservable<PullRequestReview> GetAll(long repositoryId, int pullRequestNumber);
 
         /// <summary>
         /// Gets reviews for a specified pull request.
@@ -34,18 +34,18 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<PullRequestReview> GetAll(string owner, string name, int number, ApiOptions options);
+        IObservable<PullRequestReview> GetAll(string owner, string name, int pullRequestNumber, ApiOptions options);
 
         /// <summary>
         /// Gets reviews for a specified pull request.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<PullRequestReview> GetAll(long repositoryId, int number, ApiOptions options);
+        IObservable<PullRequestReview> GetAll(long repositoryId, int pullRequestNumber, ApiOptions options);
 
         /// <summary>
         /// Gets a single pull request review by ID.
@@ -53,18 +53,18 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#get-a-single-review</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
-        IObservable<PullRequestReview> Get(string owner, string name, int number, long reviewId);
+        IObservable<PullRequestReview> Get(string owner, string name, int pullRequestNumber, long reviewId);
 
         /// <summary>
         /// Gets a single pull request review by ID.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#get-a-single-review</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
-        IObservable<PullRequestReview> Get(long repositoryId, int number, long reviewId);
+        IObservable<PullRequestReview> Get(long repositoryId, int pullRequestNumber, long reviewId);
 
         /// <summary>
         /// Creates a pull request review.
@@ -72,18 +72,18 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The Pull Request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="review">The review</param>
-        IObservable<PullRequestReview> Create(string owner, string name, int number, PullRequestReviewCreate review);
+        IObservable<PullRequestReview> Create(string owner, string name, int pullRequestNumber, PullRequestReviewCreate review);
 
         /// <summary>
         /// Creates a pull request review.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The Pull Request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="review">The review</param>
-        IObservable<PullRequestReview> Create(long repositoryId, int number, PullRequestReviewCreate review);
+        IObservable<PullRequestReview> Create(long repositoryId, int pullRequestNumber, PullRequestReviewCreate review);
 
         /// <summary>
         /// Deletes a pull request review.
@@ -91,18 +91,18 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#delete-a-pending-review</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
-        IObservable<Unit> Delete(string owner, string name, int number, long reviewId);
+        IObservable<Unit> Delete(string owner, string name, int pullRequestNumber, long reviewId);
 
         /// <summary>
         /// Deletes a pull request review.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#delete-a-pending-review</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
-        IObservable<Unit> Delete(long repositoryId, int number, long reviewId);
+        IObservable<Unit> Delete(long repositoryId, int pullRequestNumber, long reviewId);
 
         /// <summary>
         /// Submits a pull request review.
@@ -110,20 +110,20 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#submit-a-pull-request-review</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <param name="submitMessage">The message and event being submitted for the review</param>
-        IObservable<PullRequestReview> Submit(string owner, string name, int number, long reviewId, PullRequestReviewSubmit submitMessage);
+        IObservable<PullRequestReview> Submit(string owner, string name, int pullRequestNumber, long reviewId, PullRequestReviewSubmit submitMessage);
 
         /// <summary>
         /// Submits a pull request review.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#submit-a-pull-request-review</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <param name="submitMessage">The message and event being submitted for the review</param>
-        IObservable<PullRequestReview> Submit(long repositoryId, int number, long reviewId, PullRequestReviewSubmit submitMessage);
+        IObservable<PullRequestReview> Submit(long repositoryId, int pullRequestNumber, long reviewId, PullRequestReviewSubmit submitMessage);
 
         /// <summary>
         /// Dismisses a pull request review.
@@ -131,20 +131,20 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#dismiss-a-pull-request-review</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <param name="dismissMessage">The message indicating why the review was dismissed</param>
-        IObservable<PullRequestReview> Dismiss(string owner, string name, int number, long reviewId, PullRequestReviewDismiss dismissMessage);
+        IObservable<PullRequestReview> Dismiss(string owner, string name, int pullRequestNumber, long reviewId, PullRequestReviewDismiss dismissMessage);
 
         /// <summary>
         /// Dismisses a pull request review.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#dismiss-a-pull-request-review</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <param name="dismissMessage">The message indicating why the review was dismissed</param>
-        IObservable<PullRequestReview> Dismiss(long repositoryId, int number, long reviewId, PullRequestReviewDismiss dismissMessage);
+        IObservable<PullRequestReview> Dismiss(long repositoryId, int pullRequestNumber, long reviewId, PullRequestReviewDismiss dismissMessage);
 
         /// <summary>
         /// Lists comments for a single review
@@ -152,18 +152,18 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#get-comments-for-a-single-review</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
-        IObservable<PullRequestReviewComment> GetAllComments(string owner, string name, int number, long reviewId);
+        IObservable<PullRequestReviewComment> GetAllComments(string owner, string name, int pullRequestNumber, long reviewId);
 
         /// <summary>
         /// Dismisses a pull request review.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#get-comments-for-a-single-review</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
-        IObservable<PullRequestReviewComment> GetAllComments(long repositoryId, int number, long reviewId);
+        IObservable<PullRequestReviewComment> GetAllComments(long repositoryId, int pullRequestNumber, long reviewId);
 
         /// <summary>
         /// Lists comments for a single review
@@ -171,19 +171,19 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#get-comments-for-a-single-review</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<PullRequestReviewComment> GetAllComments(string owner, string name, int number, long reviewId, ApiOptions options);
+        IObservable<PullRequestReviewComment> GetAllComments(string owner, string name, int pullRequestNumber, long reviewId, ApiOptions options);
 
         /// <summary>
         /// Dismisses a pull request review.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#get-comments-for-a-single-review</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<PullRequestReviewComment> GetAllComments(long repositoryId, int number, long reviewId, ApiOptions options);
+        IObservable<PullRequestReviewComment> GetAllComments(long repositoryId, int pullRequestNumber, long reviewId, ApiOptions options);
     }
 }

--- a/Octokit.Reactive/Clients/IObservablePullRequestsClient.cs
+++ b/Octokit.Reactive/Clients/IObservablePullRequestsClient.cs
@@ -39,10 +39,10 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the pull request</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        IObservable<PullRequest> Get(string owner, string name, int number);
+        IObservable<PullRequest> Get(string owner, string name, int pullRequestNumber);
 
         /// <summary>
         /// Gets a single Pull Request by number.
@@ -51,10 +51,10 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/pulls/#get-a-single-pull-request
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the pull request</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        IObservable<PullRequest> Get(long repositoryId, int number);
+        IObservable<PullRequest> Get(long repositoryId, int pullRequestNumber);
 
         /// <summary>
         /// Gets all open pull requests for the repository.
@@ -163,20 +163,20 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/#update-a-pull-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The PullRequest number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
-        IObservable<PullRequest> Update(string owner, string name, int number, PullRequestUpdate pullRequestUpdate);
+        IObservable<PullRequest> Update(string owner, string name, int pullRequestNumber, PullRequestUpdate pullRequestUpdate);
 
         /// <summary>
         /// Update a pull request for the specified repository.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/#update-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The PullRequest number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
-        IObservable<PullRequest> Update(long repositoryId, int number, PullRequestUpdate pullRequestUpdate);
+        IObservable<PullRequest> Update(long repositoryId, int pullRequestNumber, PullRequestUpdate pullRequestUpdate);
 
         /// <summary>
         /// Merge a pull request.
@@ -184,18 +184,18 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/#merge-a-pull-request-merge-buttontrade</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
-        IObservable<PullRequestMerge> Merge(string owner, string name, int number, MergePullRequest mergePullRequest);
+        IObservable<PullRequestMerge> Merge(string owner, string name, int pullRequestNumber, MergePullRequest mergePullRequest);
 
         /// <summary>
         /// Merge a pull request.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/#merge-a-pull-request-merge-buttontrade</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
-        IObservable<PullRequestMerge> Merge(long repositoryId, int number, MergePullRequest mergePullRequest);
+        IObservable<PullRequestMerge> Merge(long repositoryId, int pullRequestNumber, MergePullRequest mergePullRequest);
 
         /// <summary>
         /// Gets the pull request merge status.
@@ -203,16 +203,16 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
-        IObservable<bool> Merged(string owner, string name, int number);
+        /// <param name="pullRequestNumber">The pull request number</param>
+        IObservable<bool> Merged(string owner, string name, int pullRequestNumber);
 
         /// <summary>
         /// Gets the pull request merge status.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
-        IObservable<bool> Merged(long repositoryId, int number);
+        /// <param name="pullRequestNumber">The pull request number</param>
+        IObservable<bool> Merged(long repositoryId, int pullRequestNumber);
 
         /// <summary>
         /// Gets the list of commits on a pull request.
@@ -220,16 +220,16 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/#list-commits-on-a-pull-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
-        IObservable<PullRequestCommit> Commits(string owner, string name, int number);
+        /// <param name="pullRequestNumber">The pull request number</param>
+        IObservable<PullRequestCommit> Commits(string owner, string name, int pullRequestNumber);
 
         /// <summary>
         /// Gets the list of commits on a pull request.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/#list-commits-on-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
-        IObservable<PullRequestCommit> Commits(long repositoryId, int number);
+        /// <param name="pullRequestNumber">The pull request number</param>
+        IObservable<PullRequestCommit> Commits(long repositoryId, int pullRequestNumber);
 
         /// <summary>
         /// Get the list of files on a pull request.
@@ -237,9 +237,9 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<PullRequestFile> Files(string owner, string name, int number, ApiOptions options);
+        IObservable<PullRequestFile> Files(string owner, string name, int pullRequestNumber, ApiOptions options);
 
         /// <summary>
         /// Get the list of files on a pull request.
@@ -247,24 +247,24 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
-        IObservable<PullRequestFile> Files(string owner, string name, int number);
+        /// <param name="pullRequestNumber">The pull request number</param>
+        IObservable<PullRequestFile> Files(string owner, string name, int pullRequestNumber);
 
         /// <summary>
         /// Get the list of files on a pull request.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<PullRequestFile> Files(long repositoryId, int number, ApiOptions options);
+        IObservable<PullRequestFile> Files(long repositoryId, int pullRequestNumber, ApiOptions options);
 
         /// <summary>
         /// Get the list of files on a pull request.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
-        IObservable<PullRequestFile> Files(long repositoryId, int number);
+        /// <param name="pullRequestNumber">The pull request number</param>
+        IObservable<PullRequestFile> Files(long repositoryId, int pullRequestNumber);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableReleasesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableReleasesClient.cs
@@ -330,8 +330,8 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
-        /// <param name="id">The id of the <see cref="ReleaseAsset"/>.</param>
-        IObservable<Unit> DeleteAsset(string owner, string name, int id);
+        /// <param name="assetId">The id of the <see cref="ReleaseAsset"/>.</param>
+        IObservable<Unit> DeleteAsset(string owner, string name, int assetId);
 
         /// <summary>
         /// Deletes the specified <see cref="ReleaseAsset"/> from the specified repository
@@ -340,7 +340,7 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/repos/releases/#delete-a-release-asset">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="id">The id of the <see cref="ReleaseAsset"/>.</param>
-        IObservable<Unit> DeleteAsset(long repositoryId, int id);
+        /// <param name="assetId">The id of the <see cref="ReleaseAsset"/>.</param>
+        IObservable<Unit> DeleteAsset(long repositoryId, int assetId);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepositoryDeployKeysClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryDeployKeysClient.cs
@@ -20,9 +20,9 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
-        /// <param name="number">The id of the deploy key.</param>
+        /// <param name="deployKeyId">The id of the deploy key.</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        IObservable<DeployKey> Get(string owner, string name, int number);
+        IObservable<DeployKey> Get(string owner, string name, int deployKeyId);
 
         /// <summary>
         /// Get a single deploy key by number for a repository.
@@ -31,9 +31,9 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/repos/keys/#get"> API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
-        /// <param name="number">The id of the deploy key.</param>
+        /// <param name="deployKeyId">The id of the deploy key.</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        IObservable<DeployKey> Get(long repositoryId, int number);
+        IObservable<DeployKey> Get(long repositoryId, int deployKeyId);
 
         /// <summary>
         /// Get all deploy keys for a repository.
@@ -104,8 +104,8 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
-        /// <param name="number">The id of the deploy key to delete.</param>
-        IObservable<Unit> Delete(string owner, string name, int number);
+        /// <param name="deployKeyId">The id of the deploy key to delete.</param>
+        IObservable<Unit> Delete(string owner, string name, int deployKeyId);
 
         /// <summary>
         /// Deletes a deploy key from a repository.
@@ -114,7 +114,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/repos/keys/#delete"> API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
-        /// <param name="number">The id of the deploy key to delete.</param>
-        IObservable<Unit> Delete(long repositoryId, int number);
+        /// <param name="deployKeyId">The id of the deploy key to delete.</param>
+        IObservable<Unit> Delete(long repositoryId, int deployKeyId);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableAssigneesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableAssigneesClient.cs
@@ -92,15 +92,15 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="assignees">List of names of assignees to add</param>
-        public IObservable<Issue> AddAssignees(string owner, string name, int number, AssigneesUpdate assignees)
+        public IObservable<Issue> AddAssignees(string owner, string name, int issueNumber, AssigneesUpdate assignees)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(assignees, nameof(assignees));
 
-            return _client.AddAssignees(owner, name, number, assignees).ToObservable();
+            return _client.AddAssignees(owner, name, issueNumber, assignees).ToObservable();
         }
 
         /// <summary>
@@ -108,16 +108,16 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="assignees">List of assignees to remove </param>
         /// <returns></returns>
-        public IObservable<Issue> RemoveAssignees(string owner, string name, int number, AssigneesUpdate assignees)
+        public IObservable<Issue> RemoveAssignees(string owner, string name, int issueNumber, AssigneesUpdate assignees)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(assignees, nameof(assignees));
 
-            return _client.RemoveAssignees(owner, name, number, assignees).ToObservable();
+            return _client.RemoveAssignees(owner, name, issueNumber, assignees).ToObservable();
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableIssueCommentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueCommentsClient.cs
@@ -171,13 +171,13 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
-        public IObservable<IssueComment> GetAllForIssue(string owner, string name, int number)
+        /// <param name="issueNumber">The issue number</param>
+        public IObservable<IssueComment> GetAllForIssue(string owner, string name, int issueNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return GetAllForIssue(owner, name, number, ApiOptions.None);
+            return GetAllForIssue(owner, name, issueNumber, ApiOptions.None);
         }
 
         /// <summary>
@@ -185,10 +185,10 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
-        public IObservable<IssueComment> GetAllForIssue(long repositoryId, int number)
+        /// <param name="issueNumber">The issue number</param>
+        public IObservable<IssueComment> GetAllForIssue(long repositoryId, int issueNumber)
         {
-            return GetAllForIssue(repositoryId, number, ApiOptions.None);
+            return GetAllForIssue(repositoryId, issueNumber, ApiOptions.None);
         }
 
         /// <summary>
@@ -197,15 +197,15 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<IssueComment> GetAllForIssue(string owner, string name, int number, ApiOptions options)
+        public IObservable<IssueComment> GetAllForIssue(string owner, string name, int issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return GetAllForIssue(owner, name, number, new IssueCommentRequest(), options);
+            return GetAllForIssue(owner, name, issueNumber, new IssueCommentRequest(), options);
         }
 
         /// <summary>
@@ -213,13 +213,13 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<IssueComment> GetAllForIssue(long repositoryId, int number, ApiOptions options)
+        public IObservable<IssueComment> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return GetAllForIssue(repositoryId, number, new IssueCommentRequest(), options);
+            return GetAllForIssue(repositoryId, issueNumber, new IssueCommentRequest(), options);
         }
 
         /// <summary>
@@ -228,15 +228,15 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
-        public IObservable<IssueComment> GetAllForIssue(string owner, string name, int number, IssueCommentRequest request)
+        public IObservable<IssueComment> GetAllForIssue(string owner, string name, int issueNumber, IssueCommentRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(request, nameof(request));
 
-            return GetAllForIssue(owner, name, number, request, ApiOptions.None);
+            return GetAllForIssue(owner, name, issueNumber, request, ApiOptions.None);
         }
 
         /// <summary>
@@ -244,13 +244,13 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
-        public IObservable<IssueComment> GetAllForIssue(long repositoryId, int number, IssueCommentRequest request)
+        public IObservable<IssueComment> GetAllForIssue(long repositoryId, int issueNumber, IssueCommentRequest request)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
 
-            return GetAllForIssue(repositoryId, number, request, ApiOptions.None);
+            return GetAllForIssue(repositoryId, issueNumber, request, ApiOptions.None);
         }
 
         /// <summary>
@@ -259,17 +259,17 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<IssueComment> GetAllForIssue(string owner, string name, int number, IssueCommentRequest request, ApiOptions options)
+        public IObservable<IssueComment> GetAllForIssue(string owner, string name, int issueNumber, IssueCommentRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(request, nameof(request));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return _connection.GetAndFlattenAllPages<IssueComment>(ApiUrls.IssueComments(owner, name, number), request.ToParametersDictionary(), options);
+            return _connection.GetAndFlattenAllPages<IssueComment>(ApiUrls.IssueComments(owner, name, issueNumber), request.ToParametersDictionary(), options);
 
         }
 
@@ -278,15 +278,15 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<IssueComment> GetAllForIssue(long repositoryId, int number, IssueCommentRequest request, ApiOptions options)
+        public IObservable<IssueComment> GetAllForIssue(long repositoryId, int issueNumber, IssueCommentRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return _connection.GetAndFlattenAllPages<IssueComment>(ApiUrls.IssueComments(repositoryId, number), request.ToParametersDictionary(), options);
+            return _connection.GetAndFlattenAllPages<IssueComment>(ApiUrls.IssueComments(repositoryId, issueNumber), request.ToParametersDictionary(), options);
         }
 
         /// <summary>
@@ -295,15 +295,15 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/comments/#create-a-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="newComment">The text of the new comment</param>
-        public IObservable<IssueComment> Create(string owner, string name, int number, string newComment)
+        public IObservable<IssueComment> Create(string owner, string name, int issueNumber, string newComment)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(newComment, nameof(newComment));
 
-            return _client.Create(owner, name, number, newComment).ToObservable();
+            return _client.Create(owner, name, issueNumber, newComment).ToObservable();
         }
 
         /// <summary>
@@ -311,13 +311,13 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#create-a-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="newComment">The text of the new comment</param>
-        public IObservable<IssueComment> Create(long repositoryId, int number, string newComment)
+        public IObservable<IssueComment> Create(long repositoryId, int issueNumber, string newComment)
         {
             Ensure.ArgumentNotNull(newComment, nameof(newComment));
 
-            return _client.Create(repositoryId, number, newComment).ToObservable();
+            return _client.Create(repositoryId, issueNumber, newComment).ToObservable();
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableIssueReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueReactionsClient.cs
@@ -30,10 +30,10 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue id</param>
-        public IObservable<Reaction> GetAll(string owner, string name, int number)
+        /// <param name="issueNumber">The issue number</param>
+        public IObservable<Reaction> GetAll(string owner, string name, int issueNumber)
         {
-            return GetAll(owner, name, number, ApiOptions.None);
+            return GetAll(owner, name, issueNumber, ApiOptions.None);
         }
 
         /// <summary>
@@ -42,15 +42,15 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue id</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<Reaction> GetAll(string owner, string name, int number, ApiOptions options)
+        public IObservable<Reaction> GetAll(string owner, string name, int issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.IssueReactions(owner, name, number), null, options);
+            return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.IssueReactions(owner, name, issueNumber), null, options);
         }
 
         /// <summary>
@@ -58,10 +58,10 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue id</param>
-        public IObservable<Reaction> GetAll(long repositoryId, int number)
+        /// <param name="issueNumber">The issue number</param>
+        public IObservable<Reaction> GetAll(long repositoryId, int issueNumber)
         {
-            return GetAll(repositoryId, number, ApiOptions.None);
+            return GetAll(repositoryId, issueNumber, ApiOptions.None);
         }
 
         /// <summary>
@@ -69,13 +69,13 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue id</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<Reaction> GetAll(long repositoryId, int number, ApiOptions options)
+        public IObservable<Reaction> GetAll(long repositoryId, int issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.IssueReactions(repositoryId, number), null, options);
+            return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.IssueReactions(repositoryId, issueNumber), null, options);
         }
 
         /// <summary>
@@ -84,15 +84,15 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue id</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="reaction">The reaction to create</param>
-        public IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction)
+        public IObservable<Reaction> Create(string owner, string name, int issueNumber, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(reaction, nameof(reaction));
 
-            return _client.Create(owner, name, number, reaction).ToObservable();
+            return _client.Create(owner, name, issueNumber, reaction).ToObservable();
         }
 
         /// <summary>
@@ -100,13 +100,13 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue id</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="reaction">The reaction to create </param>
-        public IObservable<Reaction> Create(long repositoryId, int number, NewReaction reaction)
+        public IObservable<Reaction> Create(long repositoryId, int issueNumber, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, nameof(reaction));
 
-            return _client.Create(repositoryId, number, reaction).ToObservable();
+            return _client.Create(repositoryId, issueNumber, reaction).ToObservable();
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableIssueTimelineClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueTimelineClient.cs
@@ -28,13 +28,13 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="repo">The name of the repository</param>
-        /// <param name="number">The issue number</param>
-        public IObservable<TimelineEventInfo> GetAllForIssue(string owner, string repo, int number)
+        /// <param name="issueNumber">The issue number</param>
+        public IObservable<TimelineEventInfo> GetAllForIssue(string owner, string repo, int issueNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(repo, nameof(repo));
 
-            return GetAllForIssue(owner, repo, number, ApiOptions.None);
+            return GetAllForIssue(owner, repo, issueNumber, ApiOptions.None);
         }
 
         /// <summary>
@@ -45,15 +45,15 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="repo">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<TimelineEventInfo> GetAllForIssue(string owner, string repo, int number, ApiOptions options)
+        public IObservable<TimelineEventInfo> GetAllForIssue(string owner, string repo, int issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(repo, nameof(repo));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return _connection.GetAndFlattenAllPages<TimelineEventInfo>(ApiUrls.IssueTimeline(owner, repo, number), null, options);
+            return _connection.GetAndFlattenAllPages<TimelineEventInfo>(ApiUrls.IssueTimeline(owner, repo, issueNumber), null, options);
         }
 
         /// <summary>
@@ -63,10 +63,10 @@ namespace Octokit.Reactive
         /// https://developer.github.com/v3/issues/timeline/#list-events-for-an-issue
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
-        public IObservable<TimelineEventInfo> GetAllForIssue(long repositoryId, int number)
+        /// <param name="issueNumber">The issue number</param>
+        public IObservable<TimelineEventInfo> GetAllForIssue(long repositoryId, int issueNumber)
         {
-            return GetAllForIssue(repositoryId, number, ApiOptions.None);
+            return GetAllForIssue(repositoryId, issueNumber, ApiOptions.None);
         }
 
         /// <summary>
@@ -76,13 +76,13 @@ namespace Octokit.Reactive
         /// https://developer.github.com/v3/issues/timeline/#list-events-for-an-issue
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<TimelineEventInfo> GetAllForIssue(long repositoryId, int number, ApiOptions options)
+        public IObservable<TimelineEventInfo> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return _connection.GetAndFlattenAllPages<TimelineEventInfo>(ApiUrls.IssueTimeline(repositoryId, number), null, options);
+            return _connection.GetAndFlattenAllPages<TimelineEventInfo>(ApiUrls.IssueTimeline(repositoryId, issueNumber), null, options);
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableIssuesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssuesClient.cs
@@ -27,8 +27,8 @@ namespace Octokit.Reactive
         public IObservableIssueCommentsClient Comment { get; private set; }
 
         /// <summary>
-        /// Client for reading various event information associated with issues/pull requests.  
-        /// This is useful both for display on issue/pull request information pages and also to 
+        /// Client for reading various event information associated with issues/pull requests.
+        /// This is useful both for display on issue/pull request information pages and also to
         /// determine who should be notified of comments.
         /// </summary>
         public IObservableIssuesEventsClient Events { get; private set; }
@@ -76,13 +76,13 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
-        public IObservable<Issue> Get(string owner, string name, int number)
+        /// <param name="issueNumber">The issue number</param>
+        public IObservable<Issue> Get(string owner, string name, int issueNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return _client.Get(owner, name, number).ToObservable();
+            return _client.Get(owner, name, issueNumber).ToObservable();
         }
 
         /// <summary>
@@ -92,10 +92,10 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/#get-a-single-issue
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
-        public IObservable<Issue> Get(long repositoryId, int number)
+        /// <param name="issueNumber">The issue number</param>
+        public IObservable<Issue> Get(long repositoryId, int issueNumber)
         {
-            return _client.Get(repositoryId, number).ToObservable();
+            return _client.Get(repositoryId, issueNumber).ToObservable();
         }
 
         /// <summary>
@@ -128,7 +128,7 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
-        /// Gets all issues across all the authenticated user’s visible repositories including owned repositories, 
+        /// Gets all issues across all the authenticated user’s visible repositories including owned repositories,
         /// member repositories, and organization repositories.
         /// </summary>
         /// <remarks>
@@ -143,7 +143,7 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
-        /// Gets all issues across all the authenticated user’s visible repositories including owned repositories, 
+        /// Gets all issues across all the authenticated user’s visible repositories including owned repositories,
         /// member repositories, and organization repositories.
         /// </summary>
         /// <remarks>
@@ -451,16 +451,16 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/#create-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        public IObservable<Issue> Update(string owner, string name, int number, IssueUpdate issueUpdate)
+        public IObservable<Issue> Update(string owner, string name, int issueNumber, IssueUpdate issueUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(issueUpdate, nameof(issueUpdate));
 
-            return _client.Update(owner, name, number, issueUpdate).ToObservable();
+            return _client.Update(owner, name, issueNumber, issueUpdate).ToObservable();
         }
 
         /// <summary>
@@ -469,16 +469,16 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/#create-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        public IObservable<Issue> Update(long repositoryId, int number, IssueUpdate issueUpdate)
+        public IObservable<Issue> Update(long repositoryId, int issueNumber, IssueUpdate issueUpdate)
         {
             Ensure.ArgumentNotNull(issueUpdate, nameof(issueUpdate));
 
-            return _client.Update(repositoryId, number, issueUpdate).ToObservable();
+            return _client.Update(repositoryId, issueNumber, issueUpdate).ToObservable();
         }
 
-        
+
     }
 }

--- a/Octokit.Reactive/Clients/ObservableIssuesEventsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssuesEventsClient.cs
@@ -31,13 +31,13 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
-        public IObservable<IssueEvent> GetAllForIssue(string owner, string name, int number)
+        /// <param name="issueNumber">The issue number</param>
+        public IObservable<IssueEvent> GetAllForIssue(string owner, string name, int issueNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return GetAllForIssue(owner, name, number, ApiOptions.None);
+            return GetAllForIssue(owner, name, issueNumber, ApiOptions.None);
         }
 
         /// <summary>
@@ -47,10 +47,10 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/events/#list-events-for-an-issue
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
-        public IObservable<IssueEvent> GetAllForIssue(long repositoryId, int number)
+        /// <param name="issueNumber">The issue number</param>
+        public IObservable<IssueEvent> GetAllForIssue(long repositoryId, int issueNumber)
         {
-            return GetAllForIssue(repositoryId, number, ApiOptions.None);
+            return GetAllForIssue(repositoryId, issueNumber, ApiOptions.None);
         }
 
         /// <summary>
@@ -61,15 +61,15 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<IssueEvent> GetAllForIssue(string owner, string name, int number, ApiOptions options)
+        public IObservable<IssueEvent> GetAllForIssue(string owner, string name, int issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return _connection.GetAndFlattenAllPages<IssueEvent>(ApiUrls.IssuesEvents(owner, name, number), options);
+            return _connection.GetAndFlattenAllPages<IssueEvent>(ApiUrls.IssuesEvents(owner, name, issueNumber), options);
         }
 
         /// <summary>
@@ -79,13 +79,13 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/events/#list-events-for-an-issue
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<IssueEvent> GetAllForIssue(long repositoryId, int number, ApiOptions options)
+        public IObservable<IssueEvent> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return _connection.GetAndFlattenAllPages<IssueEvent>(ApiUrls.IssuesEvents(repositoryId, number), options);
+            return _connection.GetAndFlattenAllPages<IssueEvent>(ApiUrls.IssuesEvents(repositoryId, issueNumber), options);
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableIssuesLabelsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssuesLabelsClient.cs
@@ -33,13 +33,13 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
-        public IObservable<Label> GetAllForIssue(string owner, string name, int number)
+        /// <param name="issueNumber">The issue number</param>
+        public IObservable<Label> GetAllForIssue(string owner, string name, int issueNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return GetAllForIssue(owner, name, number, ApiOptions.None);
+            return GetAllForIssue(owner, name, issueNumber, ApiOptions.None);
         }
 
         /// <summary>
@@ -49,10 +49,10 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-labels-on-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the issue</param>
-        public IObservable<Label> GetAllForIssue(long repositoryId, int number)
+        /// <param name="issueNumber">The issue number</param>
+        public IObservable<Label> GetAllForIssue(long repositoryId, int issueNumber)
         {
-            return GetAllForIssue(repositoryId, number, ApiOptions.None);
+            return GetAllForIssue(repositoryId, issueNumber, ApiOptions.None);
         }
 
         /// <summary>
@@ -63,15 +63,15 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<Label> GetAllForIssue(string owner, string name, int number, ApiOptions options)
+        public IObservable<Label> GetAllForIssue(string owner, string name, int issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return _connection.GetAndFlattenAllPages<Label>(ApiUrls.IssueLabels(owner, name, number), options);
+            return _connection.GetAndFlattenAllPages<Label>(ApiUrls.IssueLabels(owner, name, issueNumber), options);
         }
 
         /// <summary>
@@ -81,13 +81,13 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-labels-on-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<Label> GetAllForIssue(long repositoryId, int number, ApiOptions options)
+        public IObservable<Label> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return _connection.GetAndFlattenAllPages<Label>(ApiUrls.IssueLabels(repositoryId, number), options);
+            return _connection.GetAndFlattenAllPages<Label>(ApiUrls.IssueLabels(repositoryId, issueNumber), options);
         }
 
         /// <summary>
@@ -159,13 +159,13 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the milestone</param>
-        public IObservable<Label> GetAllForMilestone(string owner, string name, int number)
+        /// <param name="milestoneNumber">The number of the milestone</param>
+        public IObservable<Label> GetAllForMilestone(string owner, string name, int milestoneNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return GetAllForMilestone(owner, name, number, ApiOptions.None);
+            return GetAllForMilestone(owner, name, milestoneNumber, ApiOptions.None);
         }
 
         /// <summary>
@@ -175,10 +175,10 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the milestone</param>
-        public IObservable<Label> GetAllForMilestone(long repositoryId, int number)
+        /// <param name="milestoneNumber">The number of the milestone</param>
+        public IObservable<Label> GetAllForMilestone(long repositoryId, int milestoneNumber)
         {
-            return GetAllForMilestone(repositoryId, number, ApiOptions.None);
+            return GetAllForMilestone(repositoryId, milestoneNumber, ApiOptions.None);
         }
 
         /// <summary>
@@ -189,15 +189,15 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the milestone</param>
+        /// <param name="milestoneNumber">The number of the milestone</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<Label> GetAllForMilestone(string owner, string name, int number, ApiOptions options)
+        public IObservable<Label> GetAllForMilestone(string owner, string name, int milestoneNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return _connection.GetAndFlattenAllPages<Label>(ApiUrls.MilestoneLabels(owner, name, number), options);
+            return _connection.GetAndFlattenAllPages<Label>(ApiUrls.MilestoneLabels(owner, name, milestoneNumber), options);
         }
 
         /// <summary>
@@ -207,13 +207,13 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the milestone</param>
+        /// <param name="milestoneNumber">The number of the milestone</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<Label> GetAllForMilestone(long repositoryId, int number, ApiOptions options)
+        public IObservable<Label> GetAllForMilestone(long repositoryId, int milestoneNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return _connection.GetAndFlattenAllPages<Label>(ApiUrls.MilestoneLabels(repositoryId, number), options);
+            return _connection.GetAndFlattenAllPages<Label>(ApiUrls.MilestoneLabels(repositoryId, milestoneNumber), options);
         }
 
         /// <summary>
@@ -360,15 +360,15 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="labels">The names of the labels to add</param>
-        public IObservable<Label> AddToIssue(string owner, string name, int number, string[] labels)
+        public IObservable<Label> AddToIssue(string owner, string name, int issueNumber, string[] labels)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(labels, nameof(labels));
 
-            return _client.AddToIssue(owner, name, number, labels)
+            return _client.AddToIssue(owner, name, issueNumber, labels)
                 .ToObservable()
                 .SelectMany(x => x); // HACK: POST is not compatible with GetAndFlattenPages
         }
@@ -380,13 +380,13 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#add-labels-to-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="labels">The names of the labels to add</param>
-        public IObservable<Label> AddToIssue(long repositoryId, int number, string[] labels)
+        public IObservable<Label> AddToIssue(long repositoryId, int issueNumber, string[] labels)
         {
             Ensure.ArgumentNotNull(labels, nameof(labels));
 
-            return _client.AddToIssue(repositoryId, number, labels)
+            return _client.AddToIssue(repositoryId, issueNumber, labels)
                 .ToObservable()
                 .SelectMany(x => x); // HACK: POST is not compatible with GetAndFlattenPages
         }
@@ -399,15 +399,15 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="labelName">The name of the label to remove</param>
-        public IObservable<Label> RemoveFromIssue(string owner, string name, int number, string labelName)
+        public IObservable<Label> RemoveFromIssue(string owner, string name, int issueNumber, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNullOrEmptyString(labelName, nameof(labelName));
 
-            return _client.RemoveFromIssue(owner, name, number, labelName)
+            return _client.RemoveFromIssue(owner, name, issueNumber, labelName)
                 .ToObservable()
                 .SelectMany(x => x); // HACK: DELETE is not compatible with GetAndFlattenPages
         }
@@ -419,13 +419,13 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#remove-a-label-from-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="labelName">The name of the label to remove</param>
-        public IObservable<Label> RemoveFromIssue(long repositoryId, int number, string labelName)
+        public IObservable<Label> RemoveFromIssue(long repositoryId, int issueNumber, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(labelName, nameof(labelName));
 
-            return _client.RemoveFromIssue(repositoryId, number, labelName)
+            return _client.RemoveFromIssue(repositoryId, issueNumber, labelName)
                 .ToObservable()
                 .SelectMany(x => x); // HACK: DELETE is not compatible with GetAndFlattenPages
         }
@@ -438,15 +438,15 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="labels">The names of the labels to set</param>
-        public IObservable<Label> ReplaceAllForIssue(string owner, string name, int number, string[] labels)
+        public IObservable<Label> ReplaceAllForIssue(string owner, string name, int issueNumber, string[] labels)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(labels, nameof(labels));
 
-            return _client.ReplaceAllForIssue(owner, name, number, labels)
+            return _client.ReplaceAllForIssue(owner, name, issueNumber, labels)
                 .ToObservable()
                 .SelectMany(x => x);  // HACK: PUT is not compatible with GetAndFlattenPages
         }
@@ -458,13 +458,13 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#replace-all-labels-for-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="labels">The names of the labels to set</param>
-        public IObservable<Label> ReplaceAllForIssue(long repositoryId, int number, string[] labels)
+        public IObservable<Label> ReplaceAllForIssue(long repositoryId, int issueNumber, string[] labels)
         {
             Ensure.ArgumentNotNull(labels, nameof(labels));
 
-            return _client.ReplaceAllForIssue(repositoryId, number, labels)
+            return _client.ReplaceAllForIssue(repositoryId, issueNumber, labels)
                 .ToObservable()
                 .SelectMany(x => x);  // HACK: PUT is not compatible with GetAndFlattenPages
         }
@@ -477,13 +477,13 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
-        public IObservable<Unit> RemoveAllFromIssue(string owner, string name, int number)
+        /// <param name="issueNumber">The issue number</param>
+        public IObservable<Unit> RemoveAllFromIssue(string owner, string name, int issueNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return _client.RemoveAllFromIssue(owner, name, number).ToObservable();
+            return _client.RemoveAllFromIssue(owner, name, issueNumber).ToObservable();
         }
 
         /// <summary>
@@ -493,10 +493,10 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#remove-all-labels-from-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the issue</param>
-        public IObservable<Unit> RemoveAllFromIssue(long repositoryId, int number)
+        /// <param name="issueNumber">The issue number</param>
+        public IObservable<Unit> RemoveAllFromIssue(long repositoryId, int issueNumber)
         {
-            return _client.RemoveAllFromIssue(repositoryId, number).ToObservable();
+            return _client.RemoveAllFromIssue(repositoryId, issueNumber).ToObservable();
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableLockUnlockClient.cs
+++ b/Octokit.Reactive/Clients/ObservableLockUnlockClient.cs
@@ -24,14 +24,14 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="lockReason">The reason for locking the issue</param>
-        public IObservable<Unit> Lock(string owner, string name, int number, LockReason? lockReason = null)
+        public IObservable<Unit> Lock(string owner, string name, int issueNumber, LockReason? lockReason = null)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return _client.Lock(owner, name, number, lockReason).ToObservable();
+            return _client.Lock(owner, name, issueNumber, lockReason).ToObservable();
         }
 
         /// <summary>
@@ -39,11 +39,11 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="lockReason">The reason for locking the issue</param>
-        public IObservable<Unit> Lock(long repositoryId, int number, LockReason? lockReason = null)
+        public IObservable<Unit> Lock(long repositoryId, int issueNumber, LockReason? lockReason = null)
         {
-            return _client.Lock(repositoryId, number, lockReason).ToObservable();
+            return _client.Lock(repositoryId, issueNumber, lockReason).ToObservable();
         }
 
         /// <summary>
@@ -52,13 +52,13 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
-        public IObservable<Unit> Unlock(string owner, string name, int number)
+        /// <param name="issueNumber">The issue number</param>
+        public IObservable<Unit> Unlock(string owner, string name, int issueNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return _client.Unlock(owner, name, number).ToObservable();
+            return _client.Unlock(owner, name, issueNumber).ToObservable();
         }
 
         /// <summary>
@@ -66,10 +66,10 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
-        public IObservable<Unit> Unlock(long repositoryId, int number)
+        /// <param name="issueNumber">The issue number</param>
+        public IObservable<Unit> Unlock(long repositoryId, int issueNumber)
         {
-            return _client.Unlock(repositoryId, number).ToObservable();
+            return _client.Unlock(repositoryId, issueNumber).ToObservable();
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableMilestonesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableMilestonesClient.cs
@@ -31,12 +31,12 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/milestones/#get-a-single-milestone
         /// </remarks>
         /// <returns></returns>
-        public IObservable<Milestone> Get(string owner, string name, int number)
+        public IObservable<Milestone> Get(string owner, string name, int milestoneNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return _client.Get(owner, name, number).ToObservable();
+            return _client.Get(owner, name, milestoneNumber).ToObservable();
         }
 
         /// <summary>
@@ -46,9 +46,9 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/milestones/#get-a-single-milestone
         /// </remarks>
         /// <returns></returns>
-        public IObservable<Milestone> Get(long repositoryId, int number)
+        public IObservable<Milestone> Get(long repositoryId, int milestoneNumber)
         {
-            return _client.Get(repositoryId, number).ToObservable();
+            return _client.Get(repositoryId, milestoneNumber).ToObservable();
         }
 
         /// <summary>
@@ -232,17 +232,17 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/milestones/#update-a-milestone</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The Milestone number</param>
+        /// <param name="milestoneNumber">The Milestone number</param>
         /// <param name="milestoneUpdate">An <see cref="MilestoneUpdate"/> instance describing the changes to make to the Milestone
         /// </param>
         /// <returns></returns>
-        public IObservable<Milestone> Update(string owner, string name, int number, MilestoneUpdate milestoneUpdate)
+        public IObservable<Milestone> Update(string owner, string name, int milestoneNumber, MilestoneUpdate milestoneUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(milestoneUpdate, nameof(milestoneUpdate));
 
-            return _client.Update(owner, name, number, milestoneUpdate).ToObservable();
+            return _client.Update(owner, name, milestoneNumber, milestoneUpdate).ToObservable();
         }
 
         /// <summary>
@@ -251,15 +251,15 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/milestones/#update-a-milestone</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The Milestone number</param>
+        /// <param name="milestoneNumber">The Milestone number</param>
         /// <param name="milestoneUpdate">An <see cref="MilestoneUpdate"/> instance describing the changes to make to the Milestone
         /// </param>
         /// <returns></returns>
-        public IObservable<Milestone> Update(long repositoryId, int number, MilestoneUpdate milestoneUpdate)
+        public IObservable<Milestone> Update(long repositoryId, int milestoneNumber, MilestoneUpdate milestoneUpdate)
         {
             Ensure.ArgumentNotNull(milestoneUpdate, nameof(milestoneUpdate));
 
-            return _client.Update(repositoryId, number, milestoneUpdate).ToObservable();
+            return _client.Update(repositoryId, milestoneNumber, milestoneUpdate).ToObservable();
         }
 
         /// <summary>
@@ -269,14 +269,14 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/milestones/#delete-a-milestone</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The milestone number</param>
+        /// <param name="milestoneNumber">The Milestone number</param>
         /// <returns></returns>
-        public IObservable<Unit> Delete(string owner, string name, int number)
+        public IObservable<Unit> Delete(string owner, string name, int milestoneNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return _client.Delete(owner, name, number).ToObservable();
+            return _client.Delete(owner, name, milestoneNumber).ToObservable();
         }
 
         /// <summary>
@@ -285,11 +285,11 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/milestones/#delete-a-milestone</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The milestone number</param>
+        /// <param name="milestoneNumber">The Milestone number</param>
         /// <returns></returns>
-        public IObservable<Unit> Delete(long repositoryId, int number)
+        public IObservable<Unit> Delete(long repositoryId, int milestoneNumber)
         {
-            return _client.Delete(repositoryId, number).ToObservable();
+            return _client.Delete(repositoryId, milestoneNumber).ToObservable();
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableNotificationsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableNotificationsClient.cs
@@ -263,54 +263,54 @@ namespace Octokit.Reactive
         /// <summary>
         /// Retrives a single <see cref="Notification"/> by Id.
         /// </summary>
-        /// <param name="id">The Id of the notification to retrieve.</param>
+        /// <param name="notificationId">The Id of the notification to retrieve.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#view-a-single-thread</remarks>
-        public IObservable<Notification> Get(int id)
+        public IObservable<Notification> Get(int notificationId)
         {
-            return _notificationsClient.Get(id).ToObservable();
+            return _notificationsClient.Get(notificationId).ToObservable();
         }
 
         /// <summary>
         /// Marks a single notification as read.
         /// </summary>
-        /// <param name="id">The id of the notification.</param>
+        /// <param name="notificationId">The id of the notification.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-a-thread-as-read</remarks>
-        public IObservable<Unit> MarkAsRead(int id)
+        public IObservable<Unit> MarkAsRead(int notificationId)
         {
-            return _notificationsClient.MarkAsRead(id).ToObservable();
+            return _notificationsClient.MarkAsRead(notificationId).ToObservable();
         }
 
         /// <summary>
         /// Retrives a <see cref="ThreadSubscription"/> for the provided thread id.
         /// </summary>
-        /// <param name="id">The Id of the thread to retrieve subscription status.</param>
+        /// <param name="threadId">The Id of the thread to retrieve subscription status.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#get-a-thread-subscription</remarks>
-        public IObservable<ThreadSubscription> GetThreadSubscription(int id)
+        public IObservable<ThreadSubscription> GetThreadSubscription(int threadId)
         {
-            return _notificationsClient.GetThreadSubscription(id).ToObservable();
+            return _notificationsClient.GetThreadSubscription(threadId).ToObservable();
         }
 
         /// <summary>
         /// Sets the authenticated user's subscription settings for a given thread.
         /// </summary>
-        /// <param name="id">The Id of the thread to update.</param>
+        /// <param name="threadId">The Id of the thread to update.</param>
         /// <param name="threadSubscription">The subscription parameters to set.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#set-a-thread-subscription</remarks>
-        public IObservable<ThreadSubscription> SetThreadSubscription(int id, NewThreadSubscription threadSubscription)
+        public IObservable<ThreadSubscription> SetThreadSubscription(int threadId, NewThreadSubscription threadSubscription)
         {
             Ensure.ArgumentNotNull(threadSubscription, nameof(threadSubscription));
 
-            return _notificationsClient.SetThreadSubscription(id, threadSubscription).ToObservable();
+            return _notificationsClient.SetThreadSubscription(threadId, threadSubscription).ToObservable();
         }
 
         /// <summary>
         /// Deletes the authenticated user's subscription to a given thread.
         /// </summary>
-        /// <param name="id">The Id of the thread to delete subscription from.</param>
+        /// <param name="threadId">The Id of the thread to delete subscription from.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#delete-a-thread-subscription</remarks>
-        public IObservable<Unit> DeleteThreadSubscription(int id)
+        public IObservable<Unit> DeleteThreadSubscription(int threadId)
         {
-            return _notificationsClient.DeleteThreadSubscription(id).ToObservable();
+            return _notificationsClient.DeleteThreadSubscription(threadId).ToObservable();
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableProjectColumnsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableProjectColumnsClient.cs
@@ -53,10 +53,10 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/projects/columns/#get-a-project-column">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="id">The id of the column</param>
-        public IObservable<ProjectColumn> Get(int id)
+        /// <param name="columnId">The id of the column</param>
+        public IObservable<ProjectColumn> Get(int columnId)
         {
-            return _client.Get(id).ToObservable();
+            return _client.Get(columnId).ToObservable();
         }
 
         /// <summary>
@@ -80,13 +80,13 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/projects/columns/#update-a-project-column">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="id">The id of the column</param>
+        /// <param name="columnId">The id of the column</param>
         /// <param name="projectColumnUpdate">New values to update the column with</param>
-        public IObservable<ProjectColumn> Update(int id, ProjectColumnUpdate projectColumnUpdate)
+        public IObservable<ProjectColumn> Update(int columnId, ProjectColumnUpdate projectColumnUpdate)
         {
             Ensure.ArgumentNotNull(projectColumnUpdate, nameof(projectColumnUpdate));
 
-            return _client.Update(id, projectColumnUpdate).ToObservable();
+            return _client.Update(columnId, projectColumnUpdate).ToObservable();
         }
 
         /// <summary>
@@ -95,10 +95,10 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/projects/columns/#delete-a-project-column">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="id">The id of the column</param>
-        public IObservable<bool> Delete(int id)
+        /// <param name="columnId">The id of the column</param>
+        public IObservable<bool> Delete(int columnId)
         {
-            return _client.Delete(id).ToObservable();
+            return _client.Delete(columnId).ToObservable();
         }
 
         /// <summary>
@@ -107,13 +107,13 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/projects/#move-a-column">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="id">The id of the column</param>
+        /// <param name="columnId">The id of the column</param>
         /// <param name="position">The position to move the column</param>
-        public IObservable<bool> Move(int id, ProjectColumnMove position)
+        public IObservable<bool> Move(int columnId, ProjectColumnMove position)
         {
             Ensure.ArgumentNotNull(position, nameof(position));
 
-            return _client.Move(id, position).ToObservable();
+            return _client.Move(columnId, position).ToObservable();
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableProjectsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableProjectsClient.cs
@@ -270,13 +270,13 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/projects/#update-a-project">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="id">The Id of the project</param>
+        /// <param name="projectId">The Id of the project</param>
         /// <param name="projectUpdate">The modified project</param>
-        public IObservable<Project> Update(int id, ProjectUpdate projectUpdate)
+        public IObservable<Project> Update(int projectId, ProjectUpdate projectUpdate)
         {
             Ensure.ArgumentNotNull(projectUpdate, nameof(projectUpdate));
 
-            return _client.Update(id, projectUpdate).ToObservable();
+            return _client.Update(projectId, projectUpdate).ToObservable();
         }
 
         /// <summary>
@@ -285,10 +285,10 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/projects/#delete-a-project">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="id">The Id of the project</param>
-        public IObservable<bool> Delete(int id)
+        /// <param name="projectId">The Id of the project</param>
+        public IObservable<bool> Delete(int projectId)
         {
-            return _client.Delete(id).ToObservable();
+            return _client.Delete(projectId).ToObservable();
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservablePullRequestReviewCommentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePullRequestReviewCommentsClient.cs
@@ -30,13 +30,13 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
-        public IObservable<PullRequestReviewComment> GetAll(string owner, string name, int number)
+        /// <param name="pullRequestNumber">The pull request number</param>
+        public IObservable<PullRequestReviewComment> GetAll(string owner, string name, int pullRequestNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return GetAll(owner, name, number, ApiOptions.None);
+            return GetAll(owner, name, pullRequestNumber, ApiOptions.None);
         }
 
         /// <summary>
@@ -44,10 +44,10 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
-        public IObservable<PullRequestReviewComment> GetAll(long repositoryId, int number)
+        /// <param name="pullRequestNumber">The pull request number</param>
+        public IObservable<PullRequestReviewComment> GetAll(long repositoryId, int pullRequestNumber)
         {
-            return GetAll(repositoryId, number, ApiOptions.None);
+            return GetAll(repositoryId, pullRequestNumber, ApiOptions.None);
         }
 
         /// <summary>
@@ -56,15 +56,15 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<PullRequestReviewComment> GetAll(string owner, string name, int number, ApiOptions options)
+        public IObservable<PullRequestReviewComment> GetAll(string owner, string name, int pullRequestNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return _connection.GetAndFlattenAllPages<PullRequestReviewComment>(ApiUrls.PullRequestReviewComments(owner, name, number), null, options);
+            return _connection.GetAndFlattenAllPages<PullRequestReviewComment>(ApiUrls.PullRequestReviewComments(owner, name, pullRequestNumber), null, options);
         }
 
         /// <summary>
@@ -72,13 +72,13 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<PullRequestReviewComment> GetAll(long repositoryId, int number, ApiOptions options)
+        public IObservable<PullRequestReviewComment> GetAll(long repositoryId, int pullRequestNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return _connection.GetAndFlattenAllPages<PullRequestReviewComment>(ApiUrls.PullRequestReviewComments(repositoryId, number), options);
+            return _connection.GetAndFlattenAllPages<PullRequestReviewComment>(ApiUrls.PullRequestReviewComments(repositoryId, pullRequestNumber), options);
         }
 
         /// <summary>
@@ -228,15 +228,15 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#create-a-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The Pull Request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="comment">The comment</param>
-        public IObservable<PullRequestReviewComment> Create(string owner, string name, int number, PullRequestReviewCommentCreate comment)
+        public IObservable<PullRequestReviewComment> Create(string owner, string name, int pullRequestNumber, PullRequestReviewCommentCreate comment)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(comment, nameof(comment));
 
-            return _client.Create(owner, name, number, comment).ToObservable();
+            return _client.Create(owner, name, pullRequestNumber, comment).ToObservable();
         }
 
         /// <summary>
@@ -244,13 +244,13 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#create-a-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The Pull Request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="comment">The comment</param>
-        public IObservable<PullRequestReviewComment> Create(long repositoryId, int number, PullRequestReviewCommentCreate comment)
+        public IObservable<PullRequestReviewComment> Create(long repositoryId, int pullRequestNumber, PullRequestReviewCommentCreate comment)
         {
             Ensure.ArgumentNotNull(comment, nameof(comment));
 
-            return _client.Create(repositoryId, number, comment).ToObservable();
+            return _client.Create(repositoryId, pullRequestNumber, comment).ToObservable();
         }
 
         /// <summary>
@@ -259,15 +259,15 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#create-a-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="comment">The comment</param>
-        public IObservable<PullRequestReviewComment> CreateReply(string owner, string name, int number, PullRequestReviewCommentReplyCreate comment)
+        public IObservable<PullRequestReviewComment> CreateReply(string owner, string name, int pullRequestNumber, PullRequestReviewCommentReplyCreate comment)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(comment, nameof(comment));
 
-            return _client.CreateReply(owner, name, number, comment).ToObservable();
+            return _client.CreateReply(owner, name, pullRequestNumber, comment).ToObservable();
         }
 
         /// <summary>
@@ -275,13 +275,13 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#create-a-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="comment">The comment</param>
-        public IObservable<PullRequestReviewComment> CreateReply(long repositoryId, int number, PullRequestReviewCommentReplyCreate comment)
+        public IObservable<PullRequestReviewComment> CreateReply(long repositoryId, int pullRequestNumber, PullRequestReviewCommentReplyCreate comment)
         {
             Ensure.ArgumentNotNull(comment, nameof(comment));
 
-            return _client.CreateReply(repositoryId, number, comment).ToObservable();
+            return _client.CreateReply(repositoryId, pullRequestNumber, comment).ToObservable();
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservablePullRequestReviewRequestsClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePullRequestReviewRequestsClient.cs
@@ -24,13 +24,13 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/review_requests/#list-review-requests</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
-        public IObservable<RequestedReviews> Get(string owner, string name, int number)
+        /// <param name="pullRequestNumber">The pull request number</param>
+        public IObservable<RequestedReviews> Get(string owner, string name, int pullRequestNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return _client.Get(owner, name, number).ToObservable();
+            return _client.Get(owner, name, pullRequestNumber).ToObservable();
         }
 
         /// <summary>
@@ -38,10 +38,10 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/review_requests/#list-review-requests</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
-        public IObservable<RequestedReviews> Get(long repositoryId, int number)
+        /// <param name="pullRequestNumber">The pull request number</param>
+        public IObservable<RequestedReviews> Get(long repositoryId, int pullRequestNumber)
         {
-            return _client.Get(repositoryId, number).ToObservable();
+            return _client.Get(repositoryId, pullRequestNumber).ToObservable();
         }
 
         /// <summary>
@@ -50,15 +50,15 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/review_requests/#create-a-review-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The Pull Request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="users">List of logins of user will be requested for review</param>
-        public IObservable<PullRequest> Create(string owner, string name, int number, PullRequestReviewRequest users)
+        public IObservable<PullRequest> Create(string owner, string name, int pullRequestNumber, PullRequestReviewRequest users)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(users, nameof(users));
 
-            return _client.Create(owner, name, number, users).ToObservable();
+            return _client.Create(owner, name, pullRequestNumber, users).ToObservable();
         }
 
         /// <summary>
@@ -66,13 +66,13 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/review_requests/#create-a-review-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The Pull Request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="users">List of logins of user will be requested for review</param>
-        public IObservable<PullRequest> Create(long repositoryId, int number, PullRequestReviewRequest users)
+        public IObservable<PullRequest> Create(long repositoryId, int pullRequestNumber, PullRequestReviewRequest users)
         {
             Ensure.ArgumentNotNull(users, nameof(users));
 
-            return _client.Create(repositoryId, number, users).ToObservable();
+            return _client.Create(repositoryId, pullRequestNumber, users).ToObservable();
         }
 
         /// <summary>
@@ -81,15 +81,15 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/review_requests/#delete-a-review-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request review comment number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="users">List of logins of users that will be not longer requested for review</param>
-        public IObservable<Unit> Delete(string owner, string name, int number, PullRequestReviewRequest users)
+        public IObservable<Unit> Delete(string owner, string name, int pullRequestNumber, PullRequestReviewRequest users)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(users, nameof(users));
 
-            return _client.Delete(owner, name, number, users).ToObservable();
+            return _client.Delete(owner, name, pullRequestNumber, users).ToObservable();
         }
 
         /// <summary>
@@ -97,13 +97,13 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/review_requests/#delete-a-review-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request review comment number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="users">List of logins of users that will be not longer requested for review</param>
-        public IObservable<Unit> Delete(long repositoryId, int number, PullRequestReviewRequest users)
+        public IObservable<Unit> Delete(long repositoryId, int pullRequestNumber, PullRequestReviewRequest users)
         {
             Ensure.ArgumentNotNull(users, nameof(users));
 
-            return _client.Delete(repositoryId, number, users).ToObservable();
+            return _client.Delete(repositoryId, pullRequestNumber, users).ToObservable();
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservablePullRequestReviewsClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePullRequestReviewsClient.cs
@@ -30,14 +30,14 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The Pull Request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="review">The review</param>
-        public IObservable<PullRequestReview> Create(string owner, string name, int number, PullRequestReviewCreate review)
+        public IObservable<PullRequestReview> Create(string owner, string name, int pullRequestNumber, PullRequestReviewCreate review)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(review, nameof(review));
-            return _client.Create(owner, name, number, review).ToObservable();
+            return _client.Create(owner, name, pullRequestNumber, review).ToObservable();
         }
 
         /// <summary>
@@ -45,13 +45,13 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The Pull Request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="review">The review</param>
-        public IObservable<PullRequestReview> Create(long repositoryId, int number, PullRequestReviewCreate review)
+        public IObservable<PullRequestReview> Create(long repositoryId, int pullRequestNumber, PullRequestReviewCreate review)
         {
             Ensure.ArgumentNotNull(review, nameof(review));
 
-            return _client.Create(repositoryId, number, review).ToObservable();
+            return _client.Create(repositoryId, pullRequestNumber, review).ToObservable();
         }
 
         /// <summary>
@@ -60,14 +60,14 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#delete-a-pending-review</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
-        public IObservable<Unit> Delete(string owner, string name, int number, long reviewId)
+        public IObservable<Unit> Delete(string owner, string name, int pullRequestNumber, long reviewId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return _client.Delete(owner, name, number, reviewId).ToObservable();
+            return _client.Delete(owner, name, pullRequestNumber, reviewId).ToObservable();
         }
 
         /// <summary>
@@ -75,11 +75,11 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#delete-a-pending-review</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
-        public IObservable<Unit> Delete(long repositoryId, int number, long reviewId)
+        public IObservable<Unit> Delete(long repositoryId, int pullRequestNumber, long reviewId)
         {
-            return _client.Delete(repositoryId, number, reviewId).ToObservable();
+            return _client.Delete(repositoryId, pullRequestNumber, reviewId).ToObservable();
         }
 
         /// <summary>
@@ -88,16 +88,16 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#dismiss-a-pull-request-review</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <param name="dismissMessage">The message indicating why the review was dismissed</param>
-        public IObservable<PullRequestReview> Dismiss(string owner, string name, int number, long reviewId, PullRequestReviewDismiss dismissMessage)
+        public IObservable<PullRequestReview> Dismiss(string owner, string name, int pullRequestNumber, long reviewId, PullRequestReviewDismiss dismissMessage)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(dismissMessage, nameof(dismissMessage));
 
-            return _client.Dismiss(owner, name, number, reviewId, dismissMessage).ToObservable();
+            return _client.Dismiss(owner, name, pullRequestNumber, reviewId, dismissMessage).ToObservable();
         }
 
         /// <summary>
@@ -105,14 +105,14 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#dismiss-a-pull-request-review</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <param name="dismissMessage">The message indicating why the review was dismissed</param>
-        public IObservable<PullRequestReview> Dismiss(long repositoryId, int number, long reviewId, PullRequestReviewDismiss dismissMessage)
+        public IObservable<PullRequestReview> Dismiss(long repositoryId, int pullRequestNumber, long reviewId, PullRequestReviewDismiss dismissMessage)
         {
             Ensure.ArgumentNotNull(dismissMessage, nameof(dismissMessage));
 
-            return GetAll(repositoryId, number);
+            return GetAll(repositoryId, pullRequestNumber);
         }
 
         /// <summary>
@@ -121,13 +121,13 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
-        public IObservable<PullRequestReview> GetAll(string owner, string name, int number)
+        /// <param name="pullRequestNumber">The pull request number</param>
+        public IObservable<PullRequestReview> GetAll(string owner, string name, int pullRequestNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return GetAll(owner, name, number, ApiOptions.None);
+            return GetAll(owner, name, pullRequestNumber, ApiOptions.None);
         }
 
         /// <summary>
@@ -135,10 +135,10 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
-        public IObservable<PullRequestReview> GetAll(long repositoryId, int number)
+        /// <param name="pullRequestNumber">The pull request number</param>
+        public IObservable<PullRequestReview> GetAll(long repositoryId, int pullRequestNumber)
         {
-            return GetAll(repositoryId, number, ApiOptions.None);
+            return GetAll(repositoryId, pullRequestNumber, ApiOptions.None);
         }
 
         /// <summary>
@@ -147,15 +147,15 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<PullRequestReview> GetAll(string owner, string name, int number, ApiOptions options)
+        public IObservable<PullRequestReview> GetAll(string owner, string name, int pullRequestNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return _connection.GetAndFlattenAllPages<PullRequestReview>(ApiUrls.PullRequestReviews(owner, name, number), null, null, options);
+            return _connection.GetAndFlattenAllPages<PullRequestReview>(ApiUrls.PullRequestReviews(owner, name, pullRequestNumber), null, null, options);
         }
 
         /// <summary>
@@ -163,13 +163,13 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<PullRequestReview> GetAll(long repositoryId, int number, ApiOptions options)
+        public IObservable<PullRequestReview> GetAll(long repositoryId, int pullRequestNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return _connection.GetAndFlattenAllPages<PullRequestReview>(ApiUrls.PullRequestReviews(repositoryId, number), null, null, options);
+            return _connection.GetAndFlattenAllPages<PullRequestReview>(ApiUrls.PullRequestReviews(repositoryId, pullRequestNumber), null, null, options);
         }
 
         /// <summary>
@@ -178,14 +178,14 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#get-a-single-review</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
-        public IObservable<PullRequestReview> Get(string owner, string name, int number, long reviewId)
+        public IObservable<PullRequestReview> Get(string owner, string name, int pullRequestNumber, long reviewId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return _client.Get(owner, name, number, reviewId).ToObservable();
+            return _client.Get(owner, name, pullRequestNumber, reviewId).ToObservable();
         }
 
         /// <summary>
@@ -193,11 +193,11 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#get-a-single-review</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
-        public IObservable<PullRequestReview> Get(long repositoryId, int number, long reviewId)
+        public IObservable<PullRequestReview> Get(long repositoryId, int pullRequestNumber, long reviewId)
         {
-            return _client.Get(repositoryId, number, reviewId).ToObservable();
+            return _client.Get(repositoryId, pullRequestNumber, reviewId).ToObservable();
         }
 
         /// <summary>
@@ -206,16 +206,16 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#submit-a-pull-request-review</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <param name="submitMessage">The message and event being submitted for the review</param>
-        public IObservable<PullRequestReview> Submit(string owner, string name, int number, long reviewId, PullRequestReviewSubmit submitMessage)
+        public IObservable<PullRequestReview> Submit(string owner, string name, int pullRequestNumber, long reviewId, PullRequestReviewSubmit submitMessage)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(submitMessage, nameof(submitMessage));
 
-            return _client.Submit(owner, name, number, reviewId, submitMessage).ToObservable();
+            return _client.Submit(owner, name, pullRequestNumber, reviewId, submitMessage).ToObservable();
         }
 
         /// <summary>
@@ -223,14 +223,14 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#submit-a-pull-request-review</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <param name="submitMessage">The message and event being submitted for the review</param>
-        public IObservable<PullRequestReview> Submit(long repositoryId, int number, long reviewId, PullRequestReviewSubmit submitMessage)
+        public IObservable<PullRequestReview> Submit(long repositoryId, int pullRequestNumber, long reviewId, PullRequestReviewSubmit submitMessage)
         {
             Ensure.ArgumentNotNull(submitMessage, nameof(submitMessage));
 
-            return _client.Submit(repositoryId, number, reviewId, submitMessage).ToObservable();
+            return _client.Submit(repositoryId, pullRequestNumber, reviewId, submitMessage).ToObservable();
         }
 
         /// <summary>
@@ -239,11 +239,11 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#get-comments-for-a-single-review</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
-        public IObservable<PullRequestReviewComment> GetAllComments(string owner, string name, int number, long reviewId)
+        public IObservable<PullRequestReviewComment> GetAllComments(string owner, string name, int pullRequestNumber, long reviewId)
         {
-            return GetAllComments(owner, name, number, reviewId, ApiOptions.None);
+            return GetAllComments(owner, name, pullRequestNumber, reviewId, ApiOptions.None);
         }
 
         /// <summary>
@@ -251,11 +251,11 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#get-comments-for-a-single-review</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
-        public IObservable<PullRequestReviewComment> GetAllComments(long repositoryId, int number, long reviewId)
+        public IObservable<PullRequestReviewComment> GetAllComments(long repositoryId, int pullRequestNumber, long reviewId)
         {
-            return GetAllComments(repositoryId, number, reviewId, ApiOptions.None);
+            return GetAllComments(repositoryId, pullRequestNumber, reviewId, ApiOptions.None);
         }
 
         /// <summary>
@@ -264,16 +264,16 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#get-comments-for-a-single-review</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<PullRequestReviewComment> GetAllComments(string owner, string name, int number, long reviewId, ApiOptions options)
+        public IObservable<PullRequestReviewComment> GetAllComments(string owner, string name, int pullRequestNumber, long reviewId, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return _connection.GetAndFlattenAllPages<PullRequestReviewComment>(ApiUrls.PullRequestReviewComments(owner, name, number, reviewId), options);
+            return _connection.GetAndFlattenAllPages<PullRequestReviewComment>(ApiUrls.PullRequestReviewComments(owner, name, pullRequestNumber, reviewId), options);
         }
 
         /// <summary>
@@ -281,14 +281,14 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#get-comments-for-a-single-review</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<PullRequestReviewComment> GetAllComments(long repositoryId, int number, long reviewId, ApiOptions options)
+        public IObservable<PullRequestReviewComment> GetAllComments(long repositoryId, int pullRequestNumber, long reviewId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return _connection.GetAndFlattenAllPages<PullRequestReviewComment>(ApiUrls.PullRequestReviewComments(repositoryId, number, reviewId), options);
+            return _connection.GetAndFlattenAllPages<PullRequestReviewComment>(ApiUrls.PullRequestReviewComments(repositoryId, pullRequestNumber, reviewId), options);
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservablePullRequestsClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePullRequestsClient.cs
@@ -53,12 +53,12 @@ namespace Octokit.Reactive
         /// <remarks>
         /// http://developer.github.com/v3/pulls/#get-a-single-pull-request
         /// </remarks>
-        public IObservable<PullRequest> Get(string owner, string name, int number)
+        public IObservable<PullRequest> Get(string owner, string name, int pullRequestNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return _client.Get(owner, name, number).ToObservable();
+            return _client.Get(owner, name, pullRequestNumber).ToObservable();
         }
 
         /// <summary>
@@ -68,10 +68,10 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/pulls/#get-a-single-pull-request
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the pull request</param>
-        public IObservable<PullRequest> Get(long repositoryId, int number)
+        /// <param name="pullRequestNumber">The number of the pull request</param>
+        public IObservable<PullRequest> Get(long repositoryId, int pullRequestNumber)
         {
-            return _client.Get(repositoryId, number).ToObservable();
+            return _client.Get(repositoryId, pullRequestNumber).ToObservable();
         }
 
         /// <summary>
@@ -242,16 +242,16 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/#update-a-pull-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The PullRequest number</param>
+        /// <param name="pullRequestNumber">The PullRequest number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
-        public IObservable<PullRequest> Update(string owner, string name, int number, PullRequestUpdate pullRequestUpdate)
+        public IObservable<PullRequest> Update(string owner, string name, int pullRequestNumber, PullRequestUpdate pullRequestUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(pullRequestUpdate, nameof(pullRequestUpdate));
 
-            return _client.Update(owner, name, number, pullRequestUpdate).ToObservable();
+            return _client.Update(owner, name, pullRequestNumber, pullRequestUpdate).ToObservable();
         }
 
         /// <summary>
@@ -259,14 +259,14 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/#update-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The PullRequest number</param>
+        /// <param name="pullRequestNumber">The PullRequest number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
-        public IObservable<PullRequest> Update(long repositoryId, int number, PullRequestUpdate pullRequestUpdate)
+        public IObservable<PullRequest> Update(long repositoryId, int pullRequestNumber, PullRequestUpdate pullRequestUpdate)
         {
             Ensure.ArgumentNotNull(pullRequestUpdate, nameof(pullRequestUpdate));
 
-            return _client.Update(repositoryId, number, pullRequestUpdate).ToObservable();
+            return _client.Update(repositoryId, pullRequestNumber, pullRequestUpdate).ToObservable();
         }
 
         /// <summary>
@@ -275,15 +275,15 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/#merge-a-pull-request-merge-buttontrade</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
-        public IObservable<PullRequestMerge> Merge(string owner, string name, int number, MergePullRequest mergePullRequest)
+        public IObservable<PullRequestMerge> Merge(string owner, string name, int pullRequestNumber, MergePullRequest mergePullRequest)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(mergePullRequest, nameof(mergePullRequest));
 
-            return _client.Merge(owner, name, number, mergePullRequest).ToObservable();
+            return _client.Merge(owner, name, pullRequestNumber, mergePullRequest).ToObservable();
         }
 
         /// <summary>
@@ -291,13 +291,13 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/#merge-a-pull-request-merge-buttontrade</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
-        public IObservable<PullRequestMerge> Merge(long repositoryId, int number, MergePullRequest mergePullRequest)
+        public IObservable<PullRequestMerge> Merge(long repositoryId, int pullRequestNumber, MergePullRequest mergePullRequest)
         {
             Ensure.ArgumentNotNull(mergePullRequest, nameof(mergePullRequest));
 
-            return _client.Merge(repositoryId, number, mergePullRequest).ToObservable();
+            return _client.Merge(repositoryId, pullRequestNumber, mergePullRequest).ToObservable();
         }
 
         /// <summary>
@@ -306,13 +306,13 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
-        public IObservable<bool> Merged(string owner, string name, int number)
+        /// <param name="pullRequestNumber">The pull request number</param>
+        public IObservable<bool> Merged(string owner, string name, int pullRequestNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return _client.Merged(owner, name, number).ToObservable();
+            return _client.Merged(owner, name, pullRequestNumber).ToObservable();
         }
 
         /// <summary>
@@ -320,10 +320,10 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
-        public IObservable<bool> Merged(long repositoryId, int number)
+        /// <param name="pullRequestNumber">The pull request number</param>
+        public IObservable<bool> Merged(long repositoryId, int pullRequestNumber)
         {
-            return _client.Merged(repositoryId, number).ToObservable();
+            return _client.Merged(repositoryId, pullRequestNumber).ToObservable();
         }
 
         /// <summary>
@@ -332,13 +332,13 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/#list-commits-on-a-pull-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
-        public IObservable<PullRequestCommit> Commits(string owner, string name, int number)
+        /// <param name="pullRequestNumber">The pull request number</param>
+        public IObservable<PullRequestCommit> Commits(string owner, string name, int pullRequestNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return _connection.GetAndFlattenAllPages<PullRequestCommit>(ApiUrls.PullRequestCommits(owner, name, number));
+            return _connection.GetAndFlattenAllPages<PullRequestCommit>(ApiUrls.PullRequestCommits(owner, name, pullRequestNumber));
         }
 
         /// <summary>
@@ -346,10 +346,10 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/#list-commits-on-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
-        public IObservable<PullRequestCommit> Commits(long repositoryId, int number)
+        /// <param name="pullRequestNumber">The pull request number</param>
+        public IObservable<PullRequestCommit> Commits(long repositoryId, int pullRequestNumber)
         {
-            return _connection.GetAndFlattenAllPages<PullRequestCommit>(ApiUrls.PullRequestCommits(repositoryId, number));
+            return _connection.GetAndFlattenAllPages<PullRequestCommit>(ApiUrls.PullRequestCommits(repositoryId, pullRequestNumber));
         }
 
         /// <summary>
@@ -358,14 +358,14 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<PullRequestFile> Files(string owner, string name, int number, ApiOptions options)
+        public IObservable<PullRequestFile> Files(string owner, string name, int pullRequestNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return _connection.GetAndFlattenAllPages<PullRequestFile>(ApiUrls.PullRequestFiles(owner, name, number), options);
+            return _connection.GetAndFlattenAllPages<PullRequestFile>(ApiUrls.PullRequestFiles(owner, name, pullRequestNumber), options);
         }
 
         /// <summary>
@@ -374,10 +374,10 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
-        public IObservable<PullRequestFile> Files(string owner, string name, int number)
+        /// <param name="pullRequestNumber">The pull request number</param>
+        public IObservable<PullRequestFile> Files(string owner, string name, int pullRequestNumber)
         {
-            return Files(owner, name, number, ApiOptions.None);
+            return Files(owner, name, pullRequestNumber, ApiOptions.None);
         }
 
         /// <summary>
@@ -385,11 +385,11 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<PullRequestFile> Files(long repositoryId, int number, ApiOptions options)
+        public IObservable<PullRequestFile> Files(long repositoryId, int pullRequestNumber, ApiOptions options)
         {
-            return _connection.GetAndFlattenAllPages<PullRequestFile>(ApiUrls.PullRequestFiles(repositoryId, number), options);
+            return _connection.GetAndFlattenAllPages<PullRequestFile>(ApiUrls.PullRequestFiles(repositoryId, pullRequestNumber), options);
         }
 
         /// <summary>
@@ -397,10 +397,10 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
-        public IObservable<PullRequestFile> Files(long repositoryId, int number)
+        /// <param name="pullRequestNumber">The pull request number</param>
+        public IObservable<PullRequestFile> Files(long repositoryId, int pullRequestNumber)
         {
-            return Files(repositoryId, number, ApiOptions.None);
+            return Files(repositoryId, pullRequestNumber, ApiOptions.None);
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableReleasesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableReleasesClient.cs
@@ -489,13 +489,13 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
-        /// <param name="id">The id of the <see cref="ReleaseAsset"/>.</param>
-        public IObservable<Unit> DeleteAsset(string owner, string name, int id)
+        /// <param name="assetId">The id of the <see cref="ReleaseAsset"/>.</param>
+        public IObservable<Unit> DeleteAsset(string owner, string name, int assetId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return _client.DeleteAsset(owner, name, id).ToObservable();
+            return _client.DeleteAsset(owner, name, assetId).ToObservable();
         }
 
         /// <summary>
@@ -505,10 +505,10 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/repos/releases/#delete-a-release-asset">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="id">The id of the <see cref="ReleaseAsset"/>.</param>
-        public IObservable<Unit> DeleteAsset(long repositoryId, int id)
+        /// <param name="assetId">The id of the <see cref="ReleaseAsset"/>.</param>
+        public IObservable<Unit> DeleteAsset(long repositoryId, int assetId)
         {
-            return _client.DeleteAsset(repositoryId, id).ToObservable();
+            return _client.DeleteAsset(repositoryId, assetId).ToObservable();
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableRepositoryDeployKeysClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryDeployKeysClient.cs
@@ -32,13 +32,13 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
-        /// <param name="number">The id of the deploy key.</param>
-        public IObservable<DeployKey> Get(string owner, string name, int number)
+        /// <param name="deployKeyId">The id of the deploy key.</param>
+        public IObservable<DeployKey> Get(string owner, string name, int deployKeyId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return _client.Get(owner, name, number).ToObservable();
+            return _client.Get(owner, name, deployKeyId).ToObservable();
         }
 
         /// <summary>
@@ -48,10 +48,10 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/repos/keys/#get"> API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
-        /// <param name="number">The id of the deploy key.</param>
-        public IObservable<DeployKey> Get(long repositoryId, int number)
+        /// <param name="deployKeyId">The id of the deploy key.</param>
+        public IObservable<DeployKey> Get(long repositoryId, int deployKeyId)
         {
-            return _client.Get(repositoryId, number).ToObservable();
+            return _client.Get(repositoryId, deployKeyId).ToObservable();
         }
 
         /// <summary>
@@ -170,13 +170,13 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
-        /// <param name="number">The id of the deploy key to delete.</param>
-        public IObservable<Unit> Delete(string owner, string name, int number)
+        /// <param name="deployKeyId">The id of the deploy key to delete.</param>
+        public IObservable<Unit> Delete(string owner, string name, int deployKeyId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return _client.Delete(owner, name, number).ToObservable();
+            return _client.Delete(owner, name, deployKeyId).ToObservable();
         }
 
         /// <summary>
@@ -186,10 +186,10 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/repos/keys/#delete"> API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
-        /// <param name="number">The id of the deploy key to delete.</param>
-        public IObservable<Unit> Delete(long repositoryId, int number)
+        /// <param name="deployKeyId">The id of the deploy key to delete.</param>
+        public IObservable<Unit> Delete(long repositoryId, int deployKeyId)
         {
-            return _client.Delete(repositoryId, number).ToObservable();
+            return _client.Delete(repositoryId, deployKeyId).ToObservable();
         }
     }
 }

--- a/Octokit.Tests.Integration/Clients/IssueCommentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssueCommentsClientTests.cs
@@ -16,7 +16,7 @@ public class IssueCommentsClientTests
 
         const string owner = "octokit";
         const string name = "octokit.net";
-        const int id = 12067722;
+        const long id = 12067722;
         const long repositoryId = 7528679;
 
         public TheGetMethod()
@@ -260,7 +260,7 @@ public class IssueCommentsClientTests
 
         const string owner = "octokit";
         const string name = "octokit.net";
-        const int number = 1115;
+        const int issueNumber = 1115;
         const long repositoryId = 7528679;
 
         public TheGetAllForIssueMethod()
@@ -273,7 +273,7 @@ public class IssueCommentsClientTests
         [IntegrationTest]
         public async Task ReturnsIssueComments()
         {
-            var issueComments = await _issueCommentsClient.GetAllForIssue(owner, name, number);
+            var issueComments = await _issueCommentsClient.GetAllForIssue(owner, name, issueNumber);
 
             Assert.NotEmpty(issueComments);
         }
@@ -281,7 +281,7 @@ public class IssueCommentsClientTests
         [IntegrationTest]
         public async Task ReturnsIssueCommentsWithRepositoryId()
         {
-            var issueComments = await _issueCommentsClient.GetAllForIssue(repositoryId, number);
+            var issueComments = await _issueCommentsClient.GetAllForIssue(repositoryId, issueNumber);
 
             Assert.NotEmpty(issueComments);
         }
@@ -295,7 +295,7 @@ public class IssueCommentsClientTests
                 PageCount = 1
             };
 
-            var issueComments = await _issueCommentsClient.GetAllForIssue(owner, name, number, options);
+            var issueComments = await _issueCommentsClient.GetAllForIssue(owner, name, issueNumber, options);
 
             Assert.Equal(5, issueComments.Count);
         }
@@ -309,7 +309,7 @@ public class IssueCommentsClientTests
                 PageCount = 1
             };
 
-            var issueComments = await _issueCommentsClient.GetAllForIssue(repositoryId, number, options);
+            var issueComments = await _issueCommentsClient.GetAllForIssue(repositoryId, issueNumber, options);
 
             Assert.Equal(5, issueComments.Count);
         }
@@ -324,7 +324,7 @@ public class IssueCommentsClientTests
                 StartPage = 2
             };
 
-            var issueComments = await _issueCommentsClient.GetAllForIssue(owner, name, number, options);
+            var issueComments = await _issueCommentsClient.GetAllForIssue(owner, name, issueNumber, options);
 
             Assert.Equal(5, issueComments.Count);
         }
@@ -339,7 +339,7 @@ public class IssueCommentsClientTests
                 StartPage = 2
             };
 
-            var issueComments = await _issueCommentsClient.GetAllForIssue(repositoryId, number, options);
+            var issueComments = await _issueCommentsClient.GetAllForIssue(repositoryId, issueNumber, options);
 
             Assert.Equal(5, issueComments.Count);
         }
@@ -353,7 +353,7 @@ public class IssueCommentsClientTests
                 PageCount = 1
             };
 
-            var firstPageIssueComments = await _issueCommentsClient.GetAllForIssue(owner, name, number, startOptions);
+            var firstPageIssueComments = await _issueCommentsClient.GetAllForIssue(owner, name, issueNumber, startOptions);
 
             var skipStartOptions = new ApiOptions
             {
@@ -362,7 +362,7 @@ public class IssueCommentsClientTests
                 StartPage = 2
             };
 
-            var secondPageIssueComments = await _issueCommentsClient.GetAllForIssue(owner, name, number, skipStartOptions);
+            var secondPageIssueComments = await _issueCommentsClient.GetAllForIssue(owner, name, issueNumber, skipStartOptions);
 
             Assert.NotEqual(firstPageIssueComments[0].Id, secondPageIssueComments[0].Id);
             Assert.NotEqual(firstPageIssueComments[1].Id, secondPageIssueComments[1].Id);
@@ -380,7 +380,7 @@ public class IssueCommentsClientTests
                 PageCount = 1
             };
 
-            var firstPageIssueComments = await _issueCommentsClient.GetAllForIssue(repositoryId, number, startOptions);
+            var firstPageIssueComments = await _issueCommentsClient.GetAllForIssue(repositoryId, issueNumber, startOptions);
 
             var skipStartOptions = new ApiOptions
             {
@@ -389,7 +389,7 @@ public class IssueCommentsClientTests
                 StartPage = 2
             };
 
-            var secondPageIssueComments = await _issueCommentsClient.GetAllForIssue(repositoryId, number, skipStartOptions);
+            var secondPageIssueComments = await _issueCommentsClient.GetAllForIssue(repositoryId, issueNumber, skipStartOptions);
 
             Assert.NotEqual(firstPageIssueComments[0].Id, secondPageIssueComments[0].Id);
             Assert.NotEqual(firstPageIssueComments[1].Id, secondPageIssueComments[1].Id);
@@ -594,11 +594,11 @@ public class IssueCommentsClientTests
         return issue.Number;
     }
 
-    async static Task<long> HelperCreateIssueCommentWithReactions(string owner, string repo, int number)
+    async static Task<long> HelperCreateIssueCommentWithReactions(string owner, string repo, int issueNumber)
     {
         var github = Helper.GetAuthenticatedClient();
 
-        var issueComment = await github.Issue.Comment.Create(owner, repo, number, "A test issue comment");
+        var issueComment = await github.Issue.Comment.Create(owner, repo, issueNumber, "A test issue comment");
         Assert.NotNull(issueComment);
 
         foreach (ReactionType reactionType in Enum.GetValues(typeof(ReactionType)))

--- a/Octokit.Tests.Integration/Clients/PullRequestReviewCommentReactionsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestReviewCommentReactionsClientTests.cs
@@ -408,9 +408,9 @@ public class PullRequestReviewCommentReactionsClientTests : IDisposable
         return createdCommit;
     }
 
-    async Task<PullRequestReviewComment> CreateComment(string body, int position, string commitId, int number)
+    async Task<PullRequestReviewComment> CreateComment(string body, int position, string commitId, int pullRequestNumber)
     {
-        return await CreateComment(body, position, _context.RepositoryName, commitId, number);
+        return await CreateComment(body, position, _context.RepositoryName, commitId, pullRequestNumber);
     }
 
     async Task<PullRequestReviewComment> CreateComment(string body, int position, string repoName, string pullRequestCommitId, int pullRequestNumber)

--- a/Octokit.Tests.Integration/Clients/PullRequestReviewCommentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestReviewCommentsClientTests.cs
@@ -785,14 +785,14 @@ public class PullRequestReviewCommentsClientTests : IDisposable
         _context.Dispose();
     }
 
-    async Task<PullRequestReviewComment> CreateComment(string body, int position, string commitId, int number)
+    async Task<PullRequestReviewComment> CreateComment(string body, int position, string commitId, int pullRequestNumber)
     {
-        return await CreateComment(body, position, _context.RepositoryName, commitId, number);
+        return await CreateComment(body, position, _context.RepositoryName, commitId, pullRequestNumber);
     }
 
-    async Task<PullRequestReviewComment> CreateCommentWithRepositoryId(string body, int position, string commitId, int number)
+    async Task<PullRequestReviewComment> CreateCommentWithRepositoryId(string body, int position, string commitId, int pullRequestNumber)
     {
-        return await CreateComment(body, position, _context.Repository.Id, commitId, number);
+        return await CreateComment(body, position, _context.Repository.Id, commitId, pullRequestNumber);
     }
 
     async Task<PullRequestReviewComment> CreateComment(string body, int position, string repoName, string pullRequestCommitId, int pullRequestNumber)

--- a/Octokit.Tests.Integration/Helpers/RepositorySetupHelper.cs
+++ b/Octokit.Tests.Integration/Helpers/RepositorySetupHelper.cs
@@ -69,7 +69,7 @@ namespace Octokit.Tests.Integration.Helpers
             return createdPullRequest;
         }
 
-        public static async Task<PullRequestReview> CreatePullRequestReview(this IGitHubClient client, Repository repository, int number, string body, PullRequestReviewEvent? @event = null, string commitId = null, List<DraftPullRequestReviewComment> comments = null)
+        public static async Task<PullRequestReview> CreatePullRequestReview(this IGitHubClient client, Repository repository, int pullRequestNumber, string body, PullRequestReviewEvent? @event = null, string commitId = null, List<DraftPullRequestReviewComment> comments = null)
         {
             var review = new PullRequestReviewCreate()
             {
@@ -79,7 +79,7 @@ namespace Octokit.Tests.Integration.Helpers
                 Comments = comments
             };
 
-            var createdReview = await client.PullRequest.Review.Create(repository.Owner.Login, repository.Name, number, review);
+            var createdReview = await client.PullRequest.Review.Create(repository.Owner.Login, repository.Name, pullRequestNumber, review);
 
             return createdReview;
         }

--- a/Octokit/Clients/AssigneesClient.cs
+++ b/Octokit/Clients/AssigneesClient.cs
@@ -105,17 +105,17 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="assignees">List of names of assignees to add</param>
         /// <returns></returns>
         [ManualRoute("POST", "/repos/{owner}/{repo}/issues/{issue_number}/assignees")]
-        public Task<Issue> AddAssignees(string owner, string name, int number, AssigneesUpdate assignees)
+        public Task<Issue> AddAssignees(string owner, string name, int issueNumber, AssigneesUpdate assignees)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(assignees, nameof(assignees));
 
-            return ApiConnection.Post<Issue>(ApiUrls.IssueAssignees(owner, name, number), assignees);
+            return ApiConnection.Post<Issue>(ApiUrls.IssueAssignees(owner, name, issueNumber), assignees);
         }
 
         /// <summary>
@@ -123,17 +123,17 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="assignees">List of assignees to remove</param>
         /// <returns></returns>
         [ManualRoute("DELETE", "/repos/{owner}/{repo}/issues/{issue_number}/assignees")]
-        public Task<Issue> RemoveAssignees(string owner, string name, int number, AssigneesUpdate assignees)
+        public Task<Issue> RemoveAssignees(string owner, string name, int issueNumber, AssigneesUpdate assignees)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(assignees, nameof(assignees));
 
-            return ApiConnection.Delete<Issue>(ApiUrls.IssueAssignees(owner, name, number), assignees);
+            return ApiConnection.Delete<Issue>(ApiUrls.IssueAssignees(owner, name, issueNumber), assignees);
         }
 
         /// <summary>

--- a/Octokit/Clients/IAssigneesClient.cs
+++ b/Octokit/Clients/IAssigneesClient.cs
@@ -52,20 +52,20 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="assignees">List of names of assignees to add</param>
         /// <returns></returns>
-        Task<Issue> AddAssignees(string owner, string name, int number, AssigneesUpdate assignees);
+        Task<Issue> AddAssignees(string owner, string name, int issueNumber, AssigneesUpdate assignees);
 
         /// <summary>
         /// Remove assignees from a specified Issue.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="assignees">List of assignees to remove</param>
         /// <returns></returns>
-        Task<Issue> RemoveAssignees(string owner, string name, int number, AssigneesUpdate assignees);
+        Task<Issue> RemoveAssignees(string owner, string name, int issueNumber, AssigneesUpdate assignees);
 
         /// <summary>
         /// Checks to see if a user is an assignee for a repository.

--- a/Octokit/Clients/IIssueCommentsClient.cs
+++ b/Octokit/Clients/IIssueCommentsClient.cs
@@ -107,16 +107,16 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
-        Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int number);
+        /// <param name="issueNumber">The issue number</param>
+        Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int issueNumber);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
-        Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int number);
+        /// <param name="issueNumber">The issue number</param>
+        Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int issueNumber);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
@@ -124,18 +124,18 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int number, ApiOptions options);
+        Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int issueNumber, ApiOptions options);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int number, ApiOptions options);
+        Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
@@ -143,18 +143,18 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
-        Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int number, IssueCommentRequest request);
+        Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int issueNumber, IssueCommentRequest request);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
-        Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int number, IssueCommentRequest request);
+        Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int issueNumber, IssueCommentRequest request);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
@@ -162,20 +162,20 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int number, IssueCommentRequest request, ApiOptions options);
+        Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int issueNumber, IssueCommentRequest request, ApiOptions options);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int number, IssueCommentRequest request, ApiOptions options);
+        Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int issueNumber, IssueCommentRequest request, ApiOptions options);
 
         /// <summary>
         /// Creates a new Issue Comment for a specified Issue.
@@ -183,18 +183,18 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#create-a-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The number of the issue</param>
         /// <param name="newComment">The new comment to add to the issue</param>
-        Task<IssueComment> Create(string owner, string name, int number, string newComment);
+        Task<IssueComment> Create(string owner, string name, int issueNumber, string newComment);
 
         /// <summary>
         /// Creates a new Issue Comment for a specified Issue.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#create-a-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The number of the issue</param>
         /// <param name="newComment">The new comment to add to the issue</param>
-        Task<IssueComment> Create(long repositoryId, int number, string newComment);
+        Task<IssueComment> Create(long repositoryId, int issueNumber, string newComment);
 
         /// <summary>
         /// Updates a specified Issue Comment.

--- a/Octokit/Clients/IIssueReactionsClient.cs
+++ b/Octokit/Clients/IIssueReactionsClient.cs
@@ -17,8 +17,8 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue id</param>
-        Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number);
+        /// <param name="issueNumber">The issue number</param>
+        Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int issueNumber);
 
         /// <summary>
         /// Get all reactions for a specified Issue
@@ -26,26 +26,26 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue id</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number, ApiOptions options);
+        Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int issueNumber, ApiOptions options);
 
         /// <summary>
         /// Get all reactions for a specified Issue
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue id</param>
-        Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number);
+        /// <param name="issueNumber">The issue number</param>
+        Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int issueNumber);
 
         /// <summary>
         /// Get all reactions for a specified Issue
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue id</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number, ApiOptions options);
+        Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int issueNumber, ApiOptions options);
 
         /// <summary>
         /// Creates a reaction for a specified Issue
@@ -53,18 +53,18 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue id</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="reaction">The reaction to create</param>
-        Task<Reaction> Create(string owner, string name, int number, NewReaction reaction);
+        Task<Reaction> Create(string owner, string name, int issueNumber, NewReaction reaction);
 
         /// <summary>
         /// Creates a reaction for a specified Issue
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue id</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="reaction">The reaction to create</param>
-        Task<Reaction> Create(long repositoryId, int number, NewReaction reaction);
+        Task<Reaction> Create(long repositoryId, int issueNumber, NewReaction reaction);
 
         /// <summary>
         /// Deletes a reaction for a specified Issue

--- a/Octokit/Clients/IIssueTimelineClient.cs
+++ b/Octokit/Clients/IIssueTimelineClient.cs
@@ -19,8 +19,8 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="repo">The name of the repository</param>
-        /// <param name="number">The issue number</param>
-        Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(string owner, string repo, int number);
+        /// <param name="issueNumber">The issue number</param>
+        Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(string owner, string repo, int issueNumber);
 
         /// <summary>
         /// Gets all the various events that have occurred around an issue or pull request.
@@ -30,9 +30,9 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="repo">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API repsonse</param>
-        Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(string owner, string repo, int number, ApiOptions options);
+        Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(string owner, string repo, int issueNumber, ApiOptions options);
 
         /// <summary>
         /// Gets all the various events that have occurred around an issue or pull request.
@@ -41,8 +41,8 @@ namespace Octokit
         /// https://developer.github.com/v3/issues/timeline/#list-events-for-an-issue
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
-        Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(long repositoryId, int number);
+        /// <param name="issueNumber">The issue number</param>
+        Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(long repositoryId, int issueNumber);
 
         /// <summary>
         /// Gets all the various events that have occurred around an issue or pull request.
@@ -51,8 +51,8 @@ namespace Octokit
         /// https://developer.github.com/v3/issues/timeline/#list-events-for-an-issue
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(long repositoryId, int number, ApiOptions options);
+        Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options);
     }
 }

--- a/Octokit/Clients/IIssuesClient.cs
+++ b/Octokit/Clients/IIssuesClient.cs
@@ -18,8 +18,8 @@ namespace Octokit
         IAssigneesClient Assignee { get; }
 
         /// <summary>
-        /// Client for reading various event information associated with issues/pull requests.  
-        /// This is useful both for display on issue/pull request information pages and also to 
+        /// Client for reading various event information associated with issues/pull requests.
+        /// This is useful both for display on issue/pull request information pages and also to
         /// determine who should be notified of comments.
         /// </summary>
         IIssuesEventsClient Events { get; }
@@ -51,10 +51,10 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        Task<Issue> Get(string owner, string name, int number);
+        Task<Issue> Get(string owner, string name, int issueNumber);
 
         /// <summary>
         /// Gets a single Issue by number.
@@ -63,10 +63,10 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/#get-a-single-issue
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        Task<Issue> Get(long repositoryId, int number);
+        Task<Issue> Get(long repositoryId, int issueNumber);
 
         /// <summary>
         /// Gets all open issues assigned to the authenticated user across all the authenticated user’s visible
@@ -90,7 +90,7 @@ namespace Octokit
         Task<IReadOnlyList<Issue>> GetAllForCurrent(ApiOptions options);
 
         /// <summary>
-        /// Gets all issues across all the authenticated user’s visible repositories including owned repositories, 
+        /// Gets all issues across all the authenticated user’s visible repositories including owned repositories,
         /// member repositories, and organization repositories.
         /// </summary>
         /// <remarks>
@@ -100,7 +100,7 @@ namespace Octokit
         Task<IReadOnlyList<Issue>> GetAllForCurrent(IssueRequest request);
 
         /// <summary>
-        /// Gets all issues across all the authenticated user’s visible repositories including owned repositories, 
+        /// Gets all issues across all the authenticated user’s visible repositories including owned repositories,
         /// member repositories, and organization repositories.
         /// </summary>
         /// <param name="options">Options for changing the API response</param>
@@ -300,10 +300,10 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/#edit-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        Task<Issue> Update(string owner, string name, int number, IssueUpdate issueUpdate);
+        Task<Issue> Update(string owner, string name, int issueNumber, IssueUpdate issueUpdate);
 
         /// <summary>
         /// Updates an issue for the specified repository. Any user with pull access to a repository can update an
@@ -311,10 +311,10 @@ namespace Octokit
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/#edit-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        Task<Issue> Update(long repositoryId, int number, IssueUpdate issueUpdate);
+        Task<Issue> Update(long repositoryId, int issueNumber, IssueUpdate issueUpdate);
 
     }
 }

--- a/Octokit/Clients/IIssuesEventsClient.cs
+++ b/Octokit/Clients/IIssuesEventsClient.cs
@@ -20,8 +20,8 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
-        Task<IReadOnlyList<IssueEvent>> GetAllForIssue(string owner, string name, int number);
+        /// <param name="issueNumber">The issue number</param>
+        Task<IReadOnlyList<IssueEvent>> GetAllForIssue(string owner, string name, int issueNumber);
 
         /// <summary>
         /// Gets all events for the issue.
@@ -30,8 +30,8 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/events/#list-events-for-an-issue
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
-        Task<IReadOnlyList<IssueEvent>> GetAllForIssue(long repositoryId, int number);
+        /// <param name="issueNumber">The issue number</param>
+        Task<IReadOnlyList<IssueEvent>> GetAllForIssue(long repositoryId, int issueNumber);
 
         /// <summary>
         /// Gets all events for the issue.
@@ -41,9 +41,9 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<IssueEvent>> GetAllForIssue(string owner, string name, int number, ApiOptions options);
+        Task<IReadOnlyList<IssueEvent>> GetAllForIssue(string owner, string name, int issueNumber, ApiOptions options);
 
         /// <summary>
         /// Gets all events for the issue.
@@ -52,9 +52,9 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/events/#list-events-for-an-issue
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<IssueEvent>> GetAllForIssue(long repositoryId, int number, ApiOptions options);
+        Task<IReadOnlyList<IssueEvent>> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options);
 
         /// <summary>
         /// Gets all events for the repository.

--- a/Octokit/Clients/IIssuesLabelsClient.cs
+++ b/Octokit/Clients/IIssuesLabelsClient.cs
@@ -20,8 +20,8 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
-        Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int number);
+        /// <param name="issueNumber">The number of the issue</param>
+        Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int issueNumber);
 
         /// <summary>
         /// Gets all  labels for the issue.
@@ -30,8 +30,8 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-labels-on-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the issue</param>
-        Task<IReadOnlyList<Label>> GetAllForIssue(long repositoryId, int number);
+        /// <param name="issueNumber">The number of the issue</param>
+        Task<IReadOnlyList<Label>> GetAllForIssue(long repositoryId, int issueNumber);
 
         /// <summary>
         /// Gets all  labels for the issue.
@@ -41,9 +41,9 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int number, ApiOptions options);
+        Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int issueNumber, ApiOptions options);
 
         /// <summary>
         /// Gets all  labels for the issue.
@@ -52,9 +52,9 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-labels-on-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<Label>> GetAllForIssue(long repositoryId, int number, ApiOptions options);
+        Task<IReadOnlyList<Label>> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options);
 
         /// <summary>
         /// Gets all  labels for the repository.
@@ -104,8 +104,8 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the milestone</param>
-        Task<IReadOnlyList<Label>> GetAllForMilestone(string owner, string name, int number);
+        /// <param name="milestoneNumber">The number of the milestone</param>
+        Task<IReadOnlyList<Label>> GetAllForMilestone(string owner, string name, int milestoneNumber);
 
         /// <summary>
         /// Gets labels for every issue in a milestone
@@ -114,8 +114,8 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the milestone</param>
-        Task<IReadOnlyList<Label>> GetAllForMilestone(long repositoryId, int number);
+        /// <param name="milestoneNumber">The number of the milestone</param>
+        Task<IReadOnlyList<Label>> GetAllForMilestone(long repositoryId, int milestoneNumber);
 
         /// <summary>
         /// Gets labels for every issue in a milestone
@@ -125,9 +125,9 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the milestone</param>
+        /// <param name="milestoneNumber">The number of the milestone</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<Label>> GetAllForMilestone(string owner, string name, int number, ApiOptions options);
+        Task<IReadOnlyList<Label>> GetAllForMilestone(string owner, string name, int milestoneNumber, ApiOptions options);
 
         /// <summary>
         /// Gets labels for every issue in a milestone
@@ -136,9 +136,9 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the milestone</param>
+        /// <param name="milestoneNumber">The number of the milestone</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<Label>> GetAllForMilestone(long repositoryId, int number, ApiOptions options);
+        Task<IReadOnlyList<Label>> GetAllForMilestone(long repositoryId, int milestoneNumber, ApiOptions options);
 
         /// <summary>
         /// Gets a single Label by name.
@@ -238,9 +238,9 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The number of the issue</param>
         /// <param name="labels">The names of the labels to add</param>
-        Task<IReadOnlyList<Label>> AddToIssue(string owner, string name, int number, string[] labels);
+        Task<IReadOnlyList<Label>> AddToIssue(string owner, string name, int issueNumber, string[] labels);
 
         /// <summary>
         /// Adds a label to an issue
@@ -249,9 +249,9 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/issues/labels/#add-labels-to-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The number of the issue</param>
         /// <param name="labels">The names of the labels to add</param>
-        Task<IReadOnlyList<Label>> AddToIssue(long repositoryId, int number, string[] labels);
+        Task<IReadOnlyList<Label>> AddToIssue(long repositoryId, int issueNumber, string[] labels);
 
         /// <summary>
         /// Removes a label from an issue
@@ -261,9 +261,9 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The number of the issue</param>
         /// <param name="labelName">The name of the label to remove</param>
-        Task<IReadOnlyList<Label>> RemoveFromIssue(string owner, string name, int number, string labelName);
+        Task<IReadOnlyList<Label>> RemoveFromIssue(string owner, string name, int issueNumber, string labelName);
 
         /// <summary>
         /// Removes a label from an issue
@@ -272,9 +272,9 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/issues/labels/#remove-a-label-from-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The number of the issue</param>
         /// <param name="labelName">The name of the label to remove</param>
-        Task<IReadOnlyList<Label>> RemoveFromIssue(long repositoryId, int number, string labelName);
+        Task<IReadOnlyList<Label>> RemoveFromIssue(long repositoryId, int issueNumber, string labelName);
 
         /// <summary>
         /// Replaces all labels on the specified issues with the provided labels
@@ -284,9 +284,9 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The number of the issue</param>
         /// <param name="labels">The names of the labels to set</param>
-        Task<IReadOnlyList<Label>> ReplaceAllForIssue(string owner, string name, int number, string[] labels);
+        Task<IReadOnlyList<Label>> ReplaceAllForIssue(string owner, string name, int issueNumber, string[] labels);
 
         /// <summary>
         /// Replaces all labels on the specified issues with the provided labels
@@ -295,9 +295,9 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/issues/labels/#replace-all-labels-for-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The number of the issue</param>
         /// <param name="labels">The names of the labels to set</param>
-        Task<IReadOnlyList<Label>> ReplaceAllForIssue(long repositoryId, int number, string[] labels);
+        Task<IReadOnlyList<Label>> ReplaceAllForIssue(long repositoryId, int issueNumber, string[] labels);
 
         /// <summary>
         /// Removes all labels from an issue
@@ -307,8 +307,8 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
-        Task RemoveAllFromIssue(string owner, string name, int number);
+        /// <param name="issueNumber">The number of the issue</param>
+        Task RemoveAllFromIssue(string owner, string name, int issueNumber);
 
         /// <summary>
         /// Removes all labels from an issue
@@ -317,7 +317,7 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/issues/labels/#remove-all-labels-from-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the issue</param>
-        Task RemoveAllFromIssue(long repositoryId, int number);
+        /// <param name="issueNumber">The number of the issue</param>
+        Task RemoveAllFromIssue(long repositoryId, int issueNumber);
     }
 }

--- a/Octokit/Clients/ILockUnlockClient.cs
+++ b/Octokit/Clients/ILockUnlockClient.cs
@@ -13,18 +13,18 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="lockReason">The reason for locking the issue</param>
-        Task Lock(string owner, string name, int number, LockReason? lockReason = null);
+        Task Lock(string owner, string name, int issueNumber, LockReason? lockReason = null);
 
         /// <summary>
         /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue or pull request's conversation.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="lockReason">The reason for locking the issue</param>
-        Task Lock(long repositoryId, int number, LockReason? lockReason = null);
+        Task Lock(long repositoryId, int issueNumber, LockReason? lockReason = null);
 
         /// <summary>
         /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue or pull request's conversation.
@@ -32,16 +32,16 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
-        Task Unlock(string owner, string name, int number);
+        /// <param name="issueNumber">The issue number</param>
+        Task Unlock(string owner, string name, int issueNumber);
 
         /// <summary>
         /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue or pull request's conversation.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
-        Task Unlock(long repositoryId, int number);
+        /// <param name="issueNumber">The issue number</param>
+        Task Unlock(long repositoryId, int issueNumber);
 
     }
 }

--- a/Octokit/Clients/IMilestonesClient.cs
+++ b/Octokit/Clients/IMilestonesClient.cs
@@ -21,7 +21,7 @@ namespace Octokit
         /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        Task<Milestone> Get(string owner, string name, int number);
+        Task<Milestone> Get(string owner, string name, int milestoneNumber);
 
         /// <summary>
         /// Gets a single Milestone by number.
@@ -32,7 +32,7 @@ namespace Octokit
         /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        Task<Milestone> Get(long repositoryId, int number);
+        Task<Milestone> Get(long repositoryId, int milestoneNumber);
 
         /// <summary>
         /// Gets all open milestones for the repository.
@@ -154,11 +154,11 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/milestones/#update-a-milestone</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The Milestone number</param>
+        /// <param name="milestoneNumber">The milestone number</param>
         /// <param name="milestoneUpdate">An <see cref="MilestoneUpdate"/> instance describing the changes to make to the Milestone
         /// </param>
         /// <returns></returns>
-        Task<Milestone> Update(string owner, string name, int number, MilestoneUpdate milestoneUpdate);
+        Task<Milestone> Update(string owner, string name, int milestoneNumber, MilestoneUpdate milestoneUpdate);
 
         /// <summary>
         /// Creates a milestone for the specified repository. Any user with pull access to a repository can create an
@@ -166,11 +166,11 @@ namespace Octokit
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/milestones/#update-a-milestone</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The Milestone number</param>
+        /// <param name="milestoneNumber">The milestone number</param>
         /// <param name="milestoneUpdate">An <see cref="MilestoneUpdate"/> instance describing the changes to make to the Milestone
         /// </param>
         /// <returns></returns>
-        Task<Milestone> Update(long repositoryId, int number, MilestoneUpdate milestoneUpdate);
+        Task<Milestone> Update(long repositoryId, int milestoneNumber, MilestoneUpdate milestoneUpdate);
 
         /// <summary>
         /// Deletes a milestone for the specified repository. Any user with pull access to a repository can create an
@@ -179,9 +179,9 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/milestones/#delete-a-milestone</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The milestone number</param>
+        /// <param name="milestoneNumber">The milestone number</param>
         /// <returns></returns>
-        Task Delete(string owner, string name, int number);
+        Task Delete(string owner, string name, int milestoneNumber);
 
         /// <summary>
         /// Deletes a milestone for the specified repository. Any user with pull access to a repository can create an
@@ -189,8 +189,8 @@ namespace Octokit
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/milestones/#delete-a-milestone</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The milestone number</param>
+        /// <param name="milestoneNumber">The milestone number</param>
         /// <returns></returns>
-        Task Delete(long repositoryId, int number);
+        Task Delete(long repositoryId, int milestoneNumber);
     }
 }

--- a/Octokit/Clients/INotificationsClient.cs
+++ b/Octokit/Clients/INotificationsClient.cs
@@ -160,38 +160,38 @@ namespace Octokit
         /// <summary>
         /// Retrives a single <see cref="Notification"/> by Id.
         /// </summary>
-        /// <param name="id">The Id of the notification to retrieve.</param>
+        /// <param name="notificationId">The Id of the notification to retrieve.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#view-a-single-thread</remarks>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        Task<Notification> Get(int id);
+        Task<Notification> Get(int notificationId);
 
         /// <summary>
         /// Marks a single notification as read.
         /// </summary>
-        /// <param name="id">The id of the notification.</param>
+        /// <param name="notificationId">The id of the notification.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-a-thread-as-read</remarks>
-        Task MarkAsRead(int id);
+        Task MarkAsRead(int notificationId);
 
         /// <summary>
         /// Retrives a <see cref="ThreadSubscription"/> for the provided thread id.
         /// </summary>
-        /// <param name="id">The Id of the thread to retrieve subscription status.</param>
+        /// <param name="threadId">The Id of the thread to retrieve subscription status.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#get-a-thread-subscription</remarks>
-        Task<ThreadSubscription> GetThreadSubscription(int id);
+        Task<ThreadSubscription> GetThreadSubscription(int threadId);
 
         /// <summary>
         /// Sets the authenticated user's subscription settings for a given thread.
         /// </summary>
-        /// <param name="id">The Id of the thread to update.</param>
+        /// <param name="threadId">The Id of the thread to update.</param>
         /// <param name="threadSubscription">The subscription parameters to set.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#set-a-thread-subscription</remarks>
-        Task<ThreadSubscription> SetThreadSubscription(int id, NewThreadSubscription threadSubscription);
+        Task<ThreadSubscription> SetThreadSubscription(int threadId, NewThreadSubscription threadSubscription);
 
         /// <summary>
         /// Deletes the authenticated user's subscription to a given thread.
         /// </summary>
-        /// <param name="id">The Id of the thread to delete subscription from.</param>
+        /// <param name="threadId">The Id of the thread to delete subscription from.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#delete-a-thread-subscription</remarks>
-        Task DeleteThreadSubscription(int id);
+        Task DeleteThreadSubscription(int threadId);
     }
 }

--- a/Octokit/Clients/IProjectColumnsClient.cs
+++ b/Octokit/Clients/IProjectColumnsClient.cs
@@ -37,9 +37,9 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/projects/columns/#get-a-project-column">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="id">The id of the column</param>
+        /// <param name="columnId">The id of the column</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        Task<ProjectColumn> Get(int id);
+        Task<ProjectColumn> Get(int columnId);
 
         /// <summary>
         /// Creates a column.
@@ -57,9 +57,9 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/projects/columns/#update-a-project-column">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="id">The id of the column</param>
+        /// <param name="columnId">The id of the column</param>
         /// <param name="projectColumnUpdate">New values to update the column with</param>
-        Task<ProjectColumn> Update(int id, ProjectColumnUpdate projectColumnUpdate);
+        Task<ProjectColumn> Update(int columnId, ProjectColumnUpdate projectColumnUpdate);
 
         /// <summary>
         /// Deletes a column.
@@ -67,8 +67,8 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/projects/columns/#delete-a-project-column">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="id">The id of the column</param>
-        Task<bool> Delete(int id);
+        /// <param name="columnId">The id of the column</param>
+        Task<bool> Delete(int columnId);
 
         /// <summary>
         /// Moves a column.
@@ -76,8 +76,8 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/projects/columns/#move-a-project-column">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="id">The id of the column</param>
+        /// <param name="columnId">The id of the column</param>
         /// <param name="position">The position to move the column</param>
-        Task<bool> Move(int id, ProjectColumnMove position);
+        Task<bool> Move(int columnId, ProjectColumnMove position);
     }
 }

--- a/Octokit/Clients/IProjectsClient.cs
+++ b/Octokit/Clients/IProjectsClient.cs
@@ -142,9 +142,9 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/projects/#get-a-project">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="id">The Id of the project</param>
+        /// <param name="projectId">The Id of the project</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        Task<Project> Get(int id);
+        Task<Project> Get(int projectId);
 
         /// <summary>
         /// Creates a project for this repository.
@@ -172,9 +172,9 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/projects/#update-a-project">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="id">The Id of the project</param>
+        /// <param name="projectId">The Id of the project</param>
         /// <param name="projectUpdate">The modified project</param>
-        Task<Project> Update(int id, ProjectUpdate projectUpdate);
+        Task<Project> Update(int projectId, ProjectUpdate projectUpdate);
 
         /// <summary>
         /// Deletes a project.
@@ -182,8 +182,8 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/projects/#delete-a-project">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="id">The Id of the project</param>
-        Task<bool> Delete(int id);
+        /// <param name="projectId">The Id of the project</param>
+        Task<bool> Delete(int projectId);
 
         /// <summary>
         /// A client for GitHub's Project Cards API.

--- a/Octokit/Clients/IPullRequestReviewCommentsClient.cs
+++ b/Octokit/Clients/IPullRequestReviewCommentsClient.cs
@@ -17,16 +17,16 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
-        Task<IReadOnlyList<PullRequestReviewComment>> GetAll(string owner, string name, int number);
+        /// <param name="pullRequestNumber">The pull request number</param>
+        Task<IReadOnlyList<PullRequestReviewComment>> GetAll(string owner, string name, int pullRequestNumber);
 
         /// <summary>
         /// Gets review comments for a specified pull request.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
-        Task<IReadOnlyList<PullRequestReviewComment>> GetAll(long repositoryId, int number);
+        /// <param name="pullRequestNumber">The pull request number</param>
+        Task<IReadOnlyList<PullRequestReviewComment>> GetAll(long repositoryId, int pullRequestNumber);
 
         /// <summary>
         /// Gets review comments for a specified pull request.
@@ -34,18 +34,18 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<PullRequestReviewComment>> GetAll(string owner, string name, int number, ApiOptions options);
+        Task<IReadOnlyList<PullRequestReviewComment>> GetAll(string owner, string name, int pullRequestNumber, ApiOptions options);
 
         /// <summary>
         /// Gets review comments for a specified pull request.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<PullRequestReviewComment>> GetAll(long repositoryId, int number, ApiOptions options);
+        Task<IReadOnlyList<PullRequestReviewComment>> GetAll(long repositoryId, int pullRequestNumber, ApiOptions options);
 
         /// <summary>
         /// Gets a list of the pull request review comments in a specified repository.
@@ -138,18 +138,18 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#create-a-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The Pull Request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="comment">The comment</param>
-        Task<PullRequestReviewComment> Create(string owner, string name, int number, PullRequestReviewCommentCreate comment);
+        Task<PullRequestReviewComment> Create(string owner, string name, int pullRequestNumber, PullRequestReviewCommentCreate comment);
 
         /// <summary>
         /// Creates a comment on a pull request review.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#create-a-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The Pull Request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="comment">The comment</param>
-        Task<PullRequestReviewComment> Create(long repositoryId, int number, PullRequestReviewCommentCreate comment);
+        Task<PullRequestReviewComment> Create(long repositoryId, int pullRequestNumber, PullRequestReviewCommentCreate comment);
 
         /// <summary>
         /// Creates a comment on a pull request review as a reply to another comment.
@@ -157,18 +157,18 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#create-a-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="comment">The comment</param>
-        Task<PullRequestReviewComment> CreateReply(string owner, string name, int number, PullRequestReviewCommentReplyCreate comment);
+        Task<PullRequestReviewComment> CreateReply(string owner, string name, int pullRequestNumber, PullRequestReviewCommentReplyCreate comment);
 
         /// <summary>
         /// Creates a comment on a pull request review as a reply to another comment.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#create-a-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="comment">The comment</param>
-        Task<PullRequestReviewComment> CreateReply(long repositoryId, int number, PullRequestReviewCommentReplyCreate comment);
+        Task<PullRequestReviewComment> CreateReply(long repositoryId, int pullRequestNumber, PullRequestReviewCommentReplyCreate comment);
 
         /// <summary>
         /// Edits a comment on a pull request review.

--- a/Octokit/Clients/IPullRequestReviewRequestsClient.cs
+++ b/Octokit/Clients/IPullRequestReviewRequestsClient.cs
@@ -16,16 +16,16 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/pulls/review_requests/#list-review-requests</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
-        Task<RequestedReviews> Get(string owner, string name, int number);
+        /// <param name="pullRequestNumber">The pull request number</param>
+        Task<RequestedReviews> Get(string owner, string name, int pullRequestNumber);
 
         /// <summary>
         /// Gets review requests for a specified pull request.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/review_requests/#list-review-requests</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
-        Task<RequestedReviews> Get(long repositoryId, int number);
+        /// <param name="pullRequestNumber">The pull request number</param>
+        Task<RequestedReviews> Get(long repositoryId, int pullRequestNumber);
 
         /// <summary>
         /// Creates review requests on a pull request for specified users.
@@ -33,18 +33,18 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/pulls/review_requests/#create-a-review-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The Pull Request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="users">List of logins of user will be requested for review</param>
-        Task<PullRequest> Create(string owner, string name, int number, PullRequestReviewRequest users);
+        Task<PullRequest> Create(string owner, string name, int pullRequestNumber, PullRequestReviewRequest users);
 
         /// <summary>
         /// Creates review requests on a pull request for specified users.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/review_requests/#create-a-review-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The Pull Request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="users">List of logins of user will be requested for review</param>
-        Task<PullRequest> Create(long repositoryId, int number, PullRequestReviewRequest users);
+        Task<PullRequest> Create(long repositoryId, int pullRequestNumber, PullRequestReviewRequest users);
 
         /// <summary>
         /// Deletes review request for given users on a pull request.
@@ -52,17 +52,17 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/pulls/review_requests/#delete-a-review-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request review comment number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="users">List of logins of users that will be not longer requested for review</param>
-        Task Delete(string owner, string name, int number, PullRequestReviewRequest users);
+        Task Delete(string owner, string name, int pullRequestNumber, PullRequestReviewRequest users);
 
         /// <summary>
         /// Deletes review request for given users on a pull request.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/review_requests/#delete-a-review-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request review comment number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="users">List of logins of users that will be not longer requested for review</param>
-        Task Delete(long repositoryId, int number, PullRequestReviewRequest users);
+        Task Delete(long repositoryId, int pullRequestNumber, PullRequestReviewRequest users);
     }
 }

--- a/Octokit/Clients/IPullRequestReviewsClient.cs
+++ b/Octokit/Clients/IPullRequestReviewsClient.cs
@@ -17,16 +17,16 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
-        Task<IReadOnlyList<PullRequestReview>> GetAll(string owner, string name, int number);
+        /// <param name="pullRequestNumber">The pull request number</param>
+        Task<IReadOnlyList<PullRequestReview>> GetAll(string owner, string name, int pullRequestNumber);
 
         /// <summary>
         /// Gets reviews for a specified pull request.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
-        Task<IReadOnlyList<PullRequestReview>> GetAll(long repositoryId, int number);
+        /// <param name="pullRequestNumber">The pull request number</param>
+        Task<IReadOnlyList<PullRequestReview>> GetAll(long repositoryId, int pullRequestNumber);
 
         /// <summary>
         /// Gets reviews for a specified pull request.
@@ -34,18 +34,18 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<PullRequestReview>> GetAll(string owner, string name, int number, ApiOptions options);
+        Task<IReadOnlyList<PullRequestReview>> GetAll(string owner, string name, int pullRequestNumber, ApiOptions options);
 
         /// <summary>
         /// Gets reviews for a specified pull request.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<PullRequestReview>> GetAll(long repositoryId, int number, ApiOptions options);
+        Task<IReadOnlyList<PullRequestReview>> GetAll(long repositoryId, int pullRequestNumber, ApiOptions options);
 
         /// <summary>
         /// Gets a single pull request review by ID.
@@ -53,18 +53,18 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#get-a-single-review</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
-        Task<PullRequestReview> Get(string owner, string name, int number, long reviewId);
+        Task<PullRequestReview> Get(string owner, string name, int pullRequestNumber, long reviewId);
 
         /// <summary>
         /// Gets a single pull request review by ID.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#get-a-single-review</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
-        Task<PullRequestReview> Get(long repositoryId, int number, long reviewId);
+        Task<PullRequestReview> Get(long repositoryId, int pullRequestNumber, long reviewId);
 
         /// <summary>
         /// Creates a pull request review.
@@ -72,18 +72,18 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The Pull Request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="review">The review</param>
-        Task<PullRequestReview> Create(string owner, string name, int number, PullRequestReviewCreate review);
+        Task<PullRequestReview> Create(string owner, string name, int pullRequestNumber, PullRequestReviewCreate review);
 
         /// <summary>
         /// Creates a pull request review.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The Pull Request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="review">The review</param>
-        Task<PullRequestReview> Create(long repositoryId, int number, PullRequestReviewCreate review);
+        Task<PullRequestReview> Create(long repositoryId, int pullRequestNumber, PullRequestReviewCreate review);
 
         /// <summary>
         /// Deletes a pull request review.
@@ -91,18 +91,18 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#delete-a-pending-review</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
-        Task Delete(string owner, string name, int number, long reviewId);
+        Task Delete(string owner, string name, int pullRequestNumber, long reviewId);
 
         /// <summary>
         /// Deletes a pull request review.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#delete-a-pending-review</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
-        Task Delete(long repositoryId, int number, long reviewId);
+        Task Delete(long repositoryId, int pullRequestNumber, long reviewId);
 
         /// <summary>
         /// Submits a pull request review.
@@ -110,20 +110,20 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#submit-a-pull-request-review</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <param name="submitMessage">The message and event being submitted for the review</param>
-        Task<PullRequestReview> Submit(string owner, string name, int number, long reviewId, PullRequestReviewSubmit submitMessage);
+        Task<PullRequestReview> Submit(string owner, string name, int pullRequestNumber, long reviewId, PullRequestReviewSubmit submitMessage);
 
         /// <summary>
         /// Submits a pull request review.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#submit-a-pull-request-review</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <param name="submitMessage">The message and event being submitted for the review</param>
-        Task<PullRequestReview> Submit(long repositoryId, int number, long reviewId, PullRequestReviewSubmit submitMessage);
+        Task<PullRequestReview> Submit(long repositoryId, int pullRequestNumber, long reviewId, PullRequestReviewSubmit submitMessage);
 
         /// <summary>
         /// Dismisses a pull request review.
@@ -131,20 +131,20 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#dismiss-a-pull-request-review</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <param name="dismissMessage">The message indicating why the review was dismissed</param>
-        Task<PullRequestReview> Dismiss(string owner, string name, int number, long reviewId, PullRequestReviewDismiss dismissMessage);
+        Task<PullRequestReview> Dismiss(string owner, string name, int pullRequestNumber, long reviewId, PullRequestReviewDismiss dismissMessage);
 
         /// <summary>
         /// Dismisses a pull request review.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#dismiss-a-pull-request-review</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <param name="dismissMessage">The message indicating why the review was dismissed</param>
-        Task<PullRequestReview> Dismiss(long repositoryId, int number, long reviewId, PullRequestReviewDismiss dismissMessage);
+        Task<PullRequestReview> Dismiss(long repositoryId, int pullRequestNumber, long reviewId, PullRequestReviewDismiss dismissMessage);
 
         /// <summary>
         /// Lists comments for a single review
@@ -152,18 +152,18 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#get-comments-for-a-single-review</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
-        Task<IReadOnlyList<PullRequestReviewComment>> GetAllComments(string owner, string name, int number, long reviewId);
+        Task<IReadOnlyList<PullRequestReviewComment>> GetAllComments(string owner, string name, int pullRequestNumber, long reviewId);
 
         /// <summary>
         /// Lists comments for a single review
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#get-comments-for-a-single-review</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
-        Task<IReadOnlyList<PullRequestReviewComment>> GetAllComments(long repositoryId, int number, long reviewId);
+        Task<IReadOnlyList<PullRequestReviewComment>> GetAllComments(long repositoryId, int pullRequestNumber, long reviewId);
 
         /// <summary>
         /// Lists comments for a single review
@@ -171,19 +171,19 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#get-comments-for-a-single-review</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<PullRequestReviewComment>> GetAllComments(string owner, string name, int number, long reviewId, ApiOptions options);
+        Task<IReadOnlyList<PullRequestReviewComment>> GetAllComments(string owner, string name, int pullRequestNumber, long reviewId, ApiOptions options);
 
         /// <summary>
         /// Lists comments for a single review
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#get-comments-for-a-single-review</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<PullRequestReviewComment>> GetAllComments(long repositoryId, int number, long reviewId, ApiOptions options);
+        Task<IReadOnlyList<PullRequestReviewComment>> GetAllComments(long repositoryId, int pullRequestNumber, long reviewId, ApiOptions options);
     }
 }

--- a/Octokit/Clients/IPullRequestsClient.cs
+++ b/Octokit/Clients/IPullRequestsClient.cs
@@ -41,7 +41,7 @@ namespace Octokit
         /// </remarks>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        Task<PullRequest> Get(string owner, string name, int number);
+        Task<PullRequest> Get(string owner, string name, int pullRequestNumber);
 
         /// <summary>
         /// Get a pull request by number.
@@ -51,7 +51,7 @@ namespace Octokit
         /// </remarks>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        Task<PullRequest> Get(long repositoryId, int number);
+        Task<PullRequest> Get(long repositoryId, int pullRequestNumber);
 
         /// <summary>
         /// Get all open pull requests for the repository.
@@ -155,25 +155,25 @@ namespace Octokit
         Task<PullRequest> Create(long repositoryId, NewPullRequest newPullRequest);
 
         /// <summary>
-        /// Create a pull request for the specified repository. 
+        /// Create a pull request for the specified repository.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/#update-a-pull-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The PullRequest number</param>
+        /// <param name="pullRequestNumber">The PullRequest number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
-        Task<PullRequest> Update(string owner, string name, int number, PullRequestUpdate pullRequestUpdate);
+        Task<PullRequest> Update(string owner, string name, int pullRequestNumber, PullRequestUpdate pullRequestUpdate);
 
         /// <summary>
-        /// Create a pull request for the specified repository. 
+        /// Create a pull request for the specified repository.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/#update-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The PullRequest number</param>
+        /// <param name="pullRequestNumber">The PullRequest number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
-        Task<PullRequest> Update(long repositoryId, int number, PullRequestUpdate pullRequestUpdate);
+        Task<PullRequest> Update(long repositoryId, int pullRequestNumber, PullRequestUpdate pullRequestUpdate);
 
         /// <summary>
         /// Merge a pull request.
@@ -181,18 +181,18 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/#merge-a-pull-request-merge-buttontrade</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
-        Task<PullRequestMerge> Merge(string owner, string name, int number, MergePullRequest mergePullRequest);
+        Task<PullRequestMerge> Merge(string owner, string name, int pullRequestNumber, MergePullRequest mergePullRequest);
 
         /// <summary>
         /// Merge a pull request.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/#merge-a-pull-request-merge-buttontrade</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
-        Task<PullRequestMerge> Merge(long repositoryId, int number, MergePullRequest mergePullRequest);
+        Task<PullRequestMerge> Merge(long repositoryId, int pullRequestNumber, MergePullRequest mergePullRequest);
 
         /// <summary>
         /// Get the pull request merge status.
@@ -200,16 +200,16 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
-        Task<bool> Merged(string owner, string name, int number);
+        /// <param name="pullRequestNumber">The pull request number</param>
+        Task<bool> Merged(string owner, string name, int pullRequestNumber);
 
         /// <summary>
         /// Get the pull request merge status.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
-        Task<bool> Merged(long repositoryId, int number);
+        /// <param name="pullRequestNumber">The pull request number</param>
+        Task<bool> Merged(long repositoryId, int pullRequestNumber);
 
         /// <summary>
         /// Get the list of commits on a pull request.
@@ -217,16 +217,16 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/#list-commits-on-a-pull-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
-        Task<IReadOnlyList<PullRequestCommit>> Commits(string owner, string name, int number);
+        /// <param name="pullRequestNumber">The pull request number</param>
+        Task<IReadOnlyList<PullRequestCommit>> Commits(string owner, string name, int pullRequestNumber);
 
         /// <summary>
         /// Get the list of commits on a pull request.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/#list-commits-on-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
-        Task<IReadOnlyList<PullRequestCommit>> Commits(long repositoryId, int number);
+        /// <param name="pullRequestNumber">The pull request number</param>
+        Task<IReadOnlyList<PullRequestCommit>> Commits(long repositoryId, int pullRequestNumber);
 
         /// <summary>
         /// Get the list of files on a pull request.
@@ -234,9 +234,9 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<PullRequestFile>> Files(string owner, string name, int number, ApiOptions options);
+        Task<IReadOnlyList<PullRequestFile>> Files(string owner, string name, int pullRequestNumber, ApiOptions options);
 
         /// <summary>
         /// Get the list of files on a pull request.
@@ -244,24 +244,24 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
-        Task<IReadOnlyList<PullRequestFile>> Files(string owner, string name, int number);
+        /// <param name="pullRequestNumber">The pull request number</param>
+        Task<IReadOnlyList<PullRequestFile>> Files(string owner, string name, int pullRequestNumber);
 
         /// <summary>
         /// Get the list of files on a pull request.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<PullRequestFile>> Files(long repositoryId, int number, ApiOptions options);
+        Task<IReadOnlyList<PullRequestFile>> Files(long repositoryId, int pullRequestNumber, ApiOptions options);
 
         /// <summary>
         /// Get the list of files on a pull request.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
-        Task<IReadOnlyList<PullRequestFile>> Files(long repositoryId, int number);
+        /// <param name="pullRequestNumber">The pull request number</param>
+        Task<IReadOnlyList<PullRequestFile>> Files(long repositoryId, int pullRequestNumber);
     }
 }

--- a/Octokit/Clients/IReleasesClient.cs
+++ b/Octokit/Clients/IReleasesClient.cs
@@ -330,8 +330,8 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
-        /// <param name="id">The id of the <see cref="ReleaseAsset"/>.</param>
-        Task DeleteAsset(string owner, string name, int id);
+        /// <param name="releaseAssetId">The id of the <see cref="ReleaseAsset"/>.</param>
+        Task DeleteAsset(string owner, string name, int releaseAssetId);
 
         /// <summary>
         /// Deletes the specified <see cref="ReleaseAsset"/> from the specified repository
@@ -340,7 +340,7 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/repos/releases/#delete-a-release-asset">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="id">The id of the <see cref="ReleaseAsset"/>.</param>
-        Task DeleteAsset(long repositoryId, int id);
+        /// <param name="releaseAssetId">The id of the <see cref="ReleaseAsset"/>.</param>
+        Task DeleteAsset(long repositoryId, int releaseAssetId);
     }
 }

--- a/Octokit/Clients/IReleasesClient.cs
+++ b/Octokit/Clients/IReleasesClient.cs
@@ -330,8 +330,8 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
-        /// <param name="releaseAssetId">The id of the <see cref="ReleaseAsset"/>.</param>
-        Task DeleteAsset(string owner, string name, int releaseAssetId);
+        /// <param name="assetId">The id of the <see cref="ReleaseAsset"/>.</param>
+        Task DeleteAsset(string owner, string name, int assetId);
 
         /// <summary>
         /// Deletes the specified <see cref="ReleaseAsset"/> from the specified repository
@@ -340,7 +340,7 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/repos/releases/#delete-a-release-asset">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="releaseAssetId">The id of the <see cref="ReleaseAsset"/>.</param>
-        Task DeleteAsset(long repositoryId, int releaseAssetId);
+        /// <param name="assetId">The id of the <see cref="ReleaseAsset"/>.</param>
+        Task DeleteAsset(long repositoryId, int assetId);
     }
 }

--- a/Octokit/Clients/IRepositoryDeployKeysClient.cs
+++ b/Octokit/Clients/IRepositoryDeployKeysClient.cs
@@ -20,9 +20,9 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
-        /// <param name="number">The id of the deploy key.</param>
+        /// <param name="deployKeyId">The id of the deploy key.</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        Task<DeployKey> Get(string owner, string name, int number);
+        Task<DeployKey> Get(string owner, string name, int deployKeyId);
 
         /// <summary>
         /// Get a single deploy key by number for a repository.
@@ -31,9 +31,9 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/keys/#get"> API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
-        /// <param name="number">The id of the deploy key.</param>
+        /// <param name="deployKeyId">The id of the deploy key.</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        Task<DeployKey> Get(long repositoryId, int number);
+        Task<DeployKey> Get(long repositoryId, int deployKeyId);
 
         /// <summary>
         /// Get all deploy keys for a repository.
@@ -104,8 +104,8 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
-        /// <param name="number">The id of the deploy key to delete.</param>
-        Task Delete(string owner, string name, int number);
+        /// <param name="deployKeyId">The id of the deploy key to delete.</param>
+        Task Delete(string owner, string name, int deployKeyId);
 
         /// <summary>
         /// Deletes a deploy key from a repository.
@@ -114,7 +114,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/keys/#delete"> API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
-        /// <param name="number">The id of the deploy key to delete.</param>
-        Task Delete(long repositoryId, int number);
+        /// <param name="deployKeyId">The id of the deploy key to delete.</param>
+        Task Delete(long repositoryId, int deployKeyId);
     }
 }

--- a/Octokit/Clients/IssueCommentsClient.cs
+++ b/Octokit/Clients/IssueCommentsClient.cs
@@ -176,14 +176,14 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{number]/comments")]
-        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int number)
+        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int issueNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return GetAllForIssue(owner, name, number, ApiOptions.None);
+            return GetAllForIssue(owner, name, issueNumber, ApiOptions.None);
         }
 
         /// <summary>
@@ -191,11 +191,11 @@ namespace Octokit
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         [ManualRoute("GET", "/repositories/{id}/issues/{number}/comments")]
-        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int number)
+        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int issueNumber)
         {
-            return GetAllForIssue(repositoryId, number, ApiOptions.None);
+            return GetAllForIssue(repositoryId, issueNumber, ApiOptions.None);
         }
 
         /// <summary>
@@ -204,16 +204,16 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{number]/comments")]
-        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int number, ApiOptions options)
+        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return GetAllForIssue(owner, name, number, new IssueCommentRequest(), options);
+            return GetAllForIssue(owner, name, issueNumber, new IssueCommentRequest(), options);
         }
 
         /// <summary>
@@ -221,14 +221,14 @@ namespace Octokit
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/repositories/{id}/issues/{number}/comments")]
-        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int number, ApiOptions options)
+        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return GetAllForIssue(repositoryId, number, new IssueCommentRequest(), options);
+            return GetAllForIssue(repositoryId, issueNumber, new IssueCommentRequest(), options);
         }
 
         /// <summary>
@@ -237,16 +237,16 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{number]/comments")]
-        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int number, IssueCommentRequest request)
+        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int issueNumber, IssueCommentRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(request, nameof(request));
 
-            return GetAllForIssue(owner, name, number, request, ApiOptions.None);
+            return GetAllForIssue(owner, name, issueNumber, request, ApiOptions.None);
         }
 
         /// <summary>
@@ -254,14 +254,14 @@ namespace Octokit
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
         [ManualRoute("GET", "/repositories/{id}/issues/{number}/comments")]
-        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int number, IssueCommentRequest request)
+        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int issueNumber, IssueCommentRequest request)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
 
-            return GetAllForIssue(repositoryId, number, request, ApiOptions.None);
+            return GetAllForIssue(repositoryId, issueNumber, request, ApiOptions.None);
         }
 
         /// <summary>
@@ -270,18 +270,18 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{number]/comments")]
-        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int number, IssueCommentRequest request, ApiOptions options)
+        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int issueNumber, IssueCommentRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(request, nameof(request));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return ApiConnection.GetAll<IssueComment>(ApiUrls.IssueComments(owner, name, number), request.ToParametersDictionary(), options);
+            return ApiConnection.GetAll<IssueComment>(ApiUrls.IssueComments(owner, name, issueNumber), request.ToParametersDictionary(), options);
         }
 
         /// <summary>
@@ -289,16 +289,16 @@ namespace Octokit
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/repositories/{id}/issues/{number}/comments")]
-        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int number, IssueCommentRequest request, ApiOptions options)
+        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int issueNumber, IssueCommentRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return ApiConnection.GetAll<IssueComment>(ApiUrls.IssueComments(repositoryId, number), request.ToParametersDictionary(), options);
+            return ApiConnection.GetAll<IssueComment>(ApiUrls.IssueComments(repositoryId, issueNumber), request.ToParametersDictionary(), options);
         }
 
         /// <summary>
@@ -307,16 +307,16 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#create-a-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="newComment">The new comment to add to the issue</param>
         [ManualRoute("POST", "/repos/{owner}/{repo}/issues/{number]/comments")]
-        public Task<IssueComment> Create(string owner, string name, int number, string newComment)
+        public Task<IssueComment> Create(string owner, string name, int issueNumber, string newComment)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(newComment, nameof(newComment));
 
-            return ApiConnection.Post<IssueComment>(ApiUrls.IssueComments(owner, name, number), new BodyWrapper(newComment));
+            return ApiConnection.Post<IssueComment>(ApiUrls.IssueComments(owner, name, issueNumber), new BodyWrapper(newComment));
         }
 
         /// <summary>
@@ -324,14 +324,14 @@ namespace Octokit
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#create-a-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="newComment">The new comment to add to the issue</param>
         [ManualRoute("POST", "/repositories/{id}/issues/{number}/comments")]
-        public Task<IssueComment> Create(long repositoryId, int number, string newComment)
+        public Task<IssueComment> Create(long repositoryId, int issueNumber, string newComment)
         {
             Ensure.ArgumentNotNull(newComment, nameof(newComment));
 
-            return ApiConnection.Post<IssueComment>(ApiUrls.IssueComments(repositoryId, number), new BodyWrapper(newComment));
+            return ApiConnection.Post<IssueComment>(ApiUrls.IssueComments(repositoryId, issueNumber), new BodyWrapper(newComment));
         }
 
         /// <summary>

--- a/Octokit/Clients/IssueReactionsClient.cs
+++ b/Octokit/Clients/IssueReactionsClient.cs
@@ -22,11 +22,11 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue id</param>
+        /// <param name="issueNumber">The issue number</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{issue_number}/reactions")]
-        public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number)
+        public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int issueNumber)
         {
-            return GetAll(owner, name, number, ApiOptions.None);
+            return GetAll(owner, name, issueNumber, ApiOptions.None);
         }
 
         /// <summary>
@@ -35,16 +35,16 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue id</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{issue_number}/reactions")]
-        public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number, ApiOptions options)
+        public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return ApiConnection.GetAll<Reaction>(ApiUrls.IssueReactions(owner, name, number), null, options);
+            return ApiConnection.GetAll<Reaction>(ApiUrls.IssueReactions(owner, name, issueNumber), null, options);
         }
 
         /// <summary>
@@ -52,11 +52,11 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue id</param>
+        /// <param name="issueNumber">The issue number</param>
         [ManualRoute("GET", "/repositories/{id}/issues/{number}/reactions")]
-        public Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number)
+        public Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int issueNumber)
         {
-            return GetAll(repositoryId, number, ApiOptions.None);
+            return GetAll(repositoryId, issueNumber, ApiOptions.None);
         }
 
         /// <summary>
@@ -64,14 +64,14 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue id</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/repositories/{id}/issues/{number}/reactions")]
-        public Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number, ApiOptions options)
+        public Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return ApiConnection.GetAll<Reaction>(ApiUrls.IssueReactions(repositoryId, number), null, options);
+            return ApiConnection.GetAll<Reaction>(ApiUrls.IssueReactions(repositoryId, issueNumber), null, options);
         }
 
         /// <summary>
@@ -80,16 +80,16 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue id</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="reaction">The reaction to create</param>
         [ManualRoute("POST", "/repos/{owner}/{repo}/issues/{issue_number}/reactions")]
-        public Task<Reaction> Create(string owner, string name, int number, NewReaction reaction)
+        public Task<Reaction> Create(string owner, string name, int issueNumber, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(reaction, nameof(reaction));
 
-            return ApiConnection.Post<Reaction>(ApiUrls.IssueReactions(owner, name, number), reaction);
+            return ApiConnection.Post<Reaction>(ApiUrls.IssueReactions(owner, name, issueNumber), reaction);
         }
 
         /// <summary>
@@ -97,14 +97,14 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue id</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="reaction">The reaction to create</param>
         [ManualRoute("POST", "/repositories/{id}/issues/{number}/reactions")]
-        public Task<Reaction> Create(long repositoryId, int number, NewReaction reaction)
+        public Task<Reaction> Create(long repositoryId, int issueNumber, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, nameof(reaction));
 
-            return ApiConnection.Post<Reaction>(ApiUrls.IssueReactions(repositoryId, number), reaction);
+            return ApiConnection.Post<Reaction>(ApiUrls.IssueReactions(repositoryId, issueNumber), reaction);
         }
 
         /// <summary>

--- a/Octokit/Clients/IssueTimelineClient.cs
+++ b/Octokit/Clients/IssueTimelineClient.cs
@@ -23,14 +23,14 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="repo">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{issue_number}/timeline")]
-        public Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(string owner, string repo, int number)
+        public Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(string owner, string repo, int issueNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(repo, nameof(repo));
 
-            return GetAllForIssue(owner, repo, number, ApiOptions.None);
+            return GetAllForIssue(owner, repo, issueNumber, ApiOptions.None);
         }
 
         /// <summary>
@@ -41,16 +41,16 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="repo">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API repsonse</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{issue_number}/timeline")]
-        public Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(string owner, string repo, int number, ApiOptions options)
+        public Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(string owner, string repo, int issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(repo, nameof(repo));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return ApiConnection.GetAll<TimelineEventInfo>(ApiUrls.IssueTimeline(owner, repo, number), null, options);
+            return ApiConnection.GetAll<TimelineEventInfo>(ApiUrls.IssueTimeline(owner, repo, issueNumber), null, options);
         }
 
         /// <summary>
@@ -60,11 +60,11 @@ namespace Octokit
         /// https://developer.github.com/v3/issues/timeline/#list-events-for-an-issue
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         [ManualRoute("GET", "/repositories/{id}/issues/{number}/timeline")]
-        public Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(long repositoryId, int number)
+        public Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(long repositoryId, int issueNumber)
         {
-            return GetAllForIssue(repositoryId, number, ApiOptions.None);
+            return GetAllForIssue(repositoryId, issueNumber, ApiOptions.None);
         }
 
         /// <summary>
@@ -74,14 +74,14 @@ namespace Octokit
         /// https://developer.github.com/v3/issues/timeline/#list-events-for-an-issue
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/repositories/{id}/issues/{number}/timeline")]
-        public Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(long repositoryId, int number, ApiOptions options)
+        public Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return ApiConnection.GetAll<TimelineEventInfo>(ApiUrls.IssueTimeline(repositoryId, number), null, options);
+            return ApiConnection.GetAll<TimelineEventInfo>(ApiUrls.IssueTimeline(repositoryId, issueNumber), null, options);
         }
     }
 }

--- a/Octokit/Clients/IssuesClient.cs
+++ b/Octokit/Clients/IssuesClient.cs
@@ -71,14 +71,14 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{issue_number}")]
-        public Task<Issue> Get(string owner, string name, int number)
+        public Task<Issue> Get(string owner, string name, int issueNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return ApiConnection.Get<Issue>(ApiUrls.Issue(owner, name, number), null);
+            return ApiConnection.Get<Issue>(ApiUrls.Issue(owner, name, issueNumber), null);
         }
 
         /// <summary>
@@ -88,11 +88,11 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/#get-a-single-issue
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         [ManualRoute("GET", "/repositories/{id}/issues/{number}")]
-        public Task<Issue> Get(long repositoryId, int number)
+        public Task<Issue> Get(long repositoryId, int issueNumber)
         {
-            return ApiConnection.Get<Issue>(ApiUrls.Issue(repositoryId, number), null);
+            return ApiConnection.Get<Issue>(ApiUrls.Issue(repositoryId, issueNumber), null);
         }
 
         /// <summary>
@@ -469,17 +469,17 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/issues/#edit-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
         [ManualRoute("PATCH", "/repos/{owner}/{repo}/issues/{issue_number}")]
-        public Task<Issue> Update(string owner, string name, int number, IssueUpdate issueUpdate)
+        public Task<Issue> Update(string owner, string name, int issueNumber, IssueUpdate issueUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(issueUpdate, nameof(issueUpdate));
 
-            return ApiConnection.Patch<Issue>(ApiUrls.Issue(owner, name, number), issueUpdate);
+            return ApiConnection.Patch<Issue>(ApiUrls.Issue(owner, name, issueNumber), issueUpdate);
         }
 
         /// <summary>
@@ -488,15 +488,15 @@ namespace Octokit
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/#edit-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
         [ManualRoute("PATCH", "/repositories/{id}/issues/{number}")]
-        public Task<Issue> Update(long repositoryId, int number, IssueUpdate issueUpdate)
+        public Task<Issue> Update(long repositoryId, int issueNumber, IssueUpdate issueUpdate)
         {
             Ensure.ArgumentNotNull(issueUpdate, nameof(issueUpdate));
 
-            return ApiConnection.Patch<Issue>(ApiUrls.Issue(repositoryId, number), issueUpdate);
-        }        
+            return ApiConnection.Patch<Issue>(ApiUrls.Issue(repositoryId, issueNumber), issueUpdate);
+        }
     }
 }

--- a/Octokit/Clients/IssuesEventsClient.cs
+++ b/Octokit/Clients/IssuesEventsClient.cs
@@ -55,16 +55,16 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{issue_number}/events")]
-        public Task<IReadOnlyList<IssueEvent>> GetAllForIssue(string owner, string name, int number, ApiOptions options)
+        public Task<IReadOnlyList<IssueEvent>> GetAllForIssue(string owner, string name, int issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return ApiConnection.GetAll<IssueEvent>(ApiUrls.IssuesEvents(owner, name, number), null, options);
+            return ApiConnection.GetAll<IssueEvent>(ApiUrls.IssuesEvents(owner, name, issueNumber), null, options);
         }
 
         /// <summary>

--- a/Octokit/Clients/IssuesLabelsClient.cs
+++ b/Octokit/Clients/IssuesLabelsClient.cs
@@ -24,14 +24,14 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The number of the issue</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{issue_number}/labels")]
-        public Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int number)
+        public Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int issueNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return GetAllForIssue(owner, name, number, ApiOptions.None);
+            return GetAllForIssue(owner, name, issueNumber, ApiOptions.None);
         }
 
         /// <summary>
@@ -41,11 +41,11 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-labels-on-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The number of the issue</param>
         [ManualRoute("GET", "/repositories/{id}/issues/{number}/labels")]
-        public Task<IReadOnlyList<Label>> GetAllForIssue(long repositoryId, int number)
+        public Task<IReadOnlyList<Label>> GetAllForIssue(long repositoryId, int issueNumber)
         {
-            return GetAllForIssue(repositoryId, number, ApiOptions.None);
+            return GetAllForIssue(repositoryId, issueNumber, ApiOptions.None);
         }
 
         /// <summary>
@@ -56,16 +56,16 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{issue_number}/labels")]
-        public Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int number, ApiOptions options)
+        public Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return ApiConnection.GetAll<Label>(ApiUrls.IssueLabels(owner, name, number), options);
+            return ApiConnection.GetAll<Label>(ApiUrls.IssueLabels(owner, name, issueNumber), options);
         }
 
         /// <summary>
@@ -75,14 +75,14 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-labels-on-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/repositories/{id}/issues/{number}/labels")]
-        public Task<IReadOnlyList<Label>> GetAllForIssue(long repositoryId, int number, ApiOptions options)
+        public Task<IReadOnlyList<Label>> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return ApiConnection.GetAll<Label>(ApiUrls.IssueLabels(repositoryId, number), options);
+            return ApiConnection.GetAll<Label>(ApiUrls.IssueLabels(repositoryId, issueNumber), options);
         }
 
         /// <summary>
@@ -158,14 +158,14 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the milestone</param>
+        /// <param name="milestoneNumber">The number of the milestone</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/milestones/{milestone_number}/labels")]
-        public Task<IReadOnlyList<Label>> GetAllForMilestone(string owner, string name, int number)
+        public Task<IReadOnlyList<Label>> GetAllForMilestone(string owner, string name, int milestoneNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return GetAllForMilestone(owner, name, number, ApiOptions.None);
+            return GetAllForMilestone(owner, name, milestoneNumber, ApiOptions.None);
         }
 
         /// <summary>
@@ -175,11 +175,11 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the milestone</param>
+        /// <param name="milestoneNumber">The number of the milestone</param>
         [ManualRoute("GET", "/repositories/{id}/milestones/{milestone_number}/labels")]
-        public Task<IReadOnlyList<Label>> GetAllForMilestone(long repositoryId, int number)
+        public Task<IReadOnlyList<Label>> GetAllForMilestone(long repositoryId, int milestoneNumber)
         {
-            return GetAllForMilestone(repositoryId, number, ApiOptions.None);
+            return GetAllForMilestone(repositoryId, milestoneNumber, ApiOptions.None);
         }
 
         /// <summary>
@@ -190,16 +190,16 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the milestone</param>
+        /// <param name="milestoneNumber">The number of the milestone</param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/milestones/{milestone_number}/labels")]
-        public Task<IReadOnlyList<Label>> GetAllForMilestone(string owner, string name, int number, ApiOptions options)
+        public Task<IReadOnlyList<Label>> GetAllForMilestone(string owner, string name, int milestoneNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return ApiConnection.GetAll<Label>(ApiUrls.MilestoneLabels(owner, name, number), options);
+            return ApiConnection.GetAll<Label>(ApiUrls.MilestoneLabels(owner, name, milestoneNumber), options);
         }
 
         /// <summary>
@@ -209,14 +209,14 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the milestone</param>
+        /// <param name="milestoneNumber">The number of the milestone</param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/repositories/{id}/milestones/{milestone_number}/labels")]
-        public Task<IReadOnlyList<Label>> GetAllForMilestone(long repositoryId, int number, ApiOptions options)
+        public Task<IReadOnlyList<Label>> GetAllForMilestone(long repositoryId, int milestoneNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return ApiConnection.GetAll<Label>(ApiUrls.MilestoneLabels(repositoryId, number), options);
+            return ApiConnection.GetAll<Label>(ApiUrls.MilestoneLabels(repositoryId, milestoneNumber), options);
         }
 
         /// <summary>
@@ -375,16 +375,16 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The number of the issue</param>
         /// <param name="labels">The names of the labels to add</param>
         [ManualRoute("POST", "/repos/{owner}/{repo}/issues/{issue_number}/labels")]
-        public Task<IReadOnlyList<Label>> AddToIssue(string owner, string name, int number, string[] labels)
+        public Task<IReadOnlyList<Label>> AddToIssue(string owner, string name, int issueNumber, string[] labels)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(labels, nameof(labels));
 
-            return ApiConnection.Post<IReadOnlyList<Label>>(ApiUrls.IssueLabels(owner, name, number), labels);
+            return ApiConnection.Post<IReadOnlyList<Label>>(ApiUrls.IssueLabels(owner, name, issueNumber), labels);
         }
 
         /// <summary>
@@ -394,14 +394,14 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/issues/labels/#add-labels-to-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The number of the issue</param>
         /// <param name="labels">The names of the labels to add</param>
         [ManualRoute("POST", "/repositories/{id}/issues/{number}/labels")]
-        public Task<IReadOnlyList<Label>> AddToIssue(long repositoryId, int number, string[] labels)
+        public Task<IReadOnlyList<Label>> AddToIssue(long repositoryId, int issueNumber, string[] labels)
         {
             Ensure.ArgumentNotNull(labels, nameof(labels));
 
-            return ApiConnection.Post<IReadOnlyList<Label>>(ApiUrls.IssueLabels(repositoryId, number), labels);
+            return ApiConnection.Post<IReadOnlyList<Label>>(ApiUrls.IssueLabels(repositoryId, issueNumber), labels);
         }
 
         /// <summary>
@@ -412,16 +412,16 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The number of the issue</param>
         /// <param name="labelName">The name of the label to remove</param>
         [ManualRoute("DELETE", "/repos/{owner}/{repo}/issues/{issue_number}/labels")]
-        public Task<IReadOnlyList<Label>> RemoveFromIssue(string owner, string name, int number, string labelName)
+        public Task<IReadOnlyList<Label>> RemoveFromIssue(string owner, string name, int issueNumber, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNullOrEmptyString(labelName, nameof(labelName));
 
-            return ApiConnection.Delete<IReadOnlyList<Label>>(ApiUrls.IssueLabel(owner, name, number, labelName), new object());
+            return ApiConnection.Delete<IReadOnlyList<Label>>(ApiUrls.IssueLabel(owner, name, issueNumber, labelName), new object());
         }
 
         /// <summary>
@@ -431,14 +431,14 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/issues/labels/#remove-a-label-from-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The number of the issue</param>
         /// <param name="labelName">The name of the label to remove</param>
         [ManualRoute("DELETE", "/repositories/{id}/issues/{number}/labels")]
-        public Task<IReadOnlyList<Label>> RemoveFromIssue(long repositoryId, int number, string labelName)
+        public Task<IReadOnlyList<Label>> RemoveFromIssue(long repositoryId, int issueNumber, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(labelName, nameof(labelName));
 
-            return ApiConnection.Delete<IReadOnlyList<Label>>(ApiUrls.IssueLabel(repositoryId, number, labelName), new object());
+            return ApiConnection.Delete<IReadOnlyList<Label>>(ApiUrls.IssueLabel(repositoryId, issueNumber, labelName), new object());
         }
 
         /// <summary>
@@ -449,16 +449,16 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The number of the issue</param>
         /// <param name="labels">The names of the labels to set</param>
         [ManualRoute("PUT", "/repos/{owner}/{repo}/issues/{issue_number}/labels")]
-        public Task<IReadOnlyList<Label>> ReplaceAllForIssue(string owner, string name, int number, string[] labels)
+        public Task<IReadOnlyList<Label>> ReplaceAllForIssue(string owner, string name, int issueNumber, string[] labels)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(labels, nameof(labels));
 
-            return ApiConnection.Put<IReadOnlyList<Label>>(ApiUrls.IssueLabels(owner, name, number), labels);
+            return ApiConnection.Put<IReadOnlyList<Label>>(ApiUrls.IssueLabels(owner, name, issueNumber), labels);
         }
 
         /// <summary>
@@ -468,14 +468,14 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/issues/labels/#replace-all-labels-for-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The number of the issue</param>
         /// <param name="labels">The names of the labels to set</param>
         [ManualRoute("PUT", "/repositories/{id}/issues/{number}/labels")]
-        public Task<IReadOnlyList<Label>> ReplaceAllForIssue(long repositoryId, int number, string[] labels)
+        public Task<IReadOnlyList<Label>> ReplaceAllForIssue(long repositoryId, int issueNumber, string[] labels)
         {
             Ensure.ArgumentNotNull(labels, nameof(labels));
 
-            return ApiConnection.Put<IReadOnlyList<Label>>(ApiUrls.IssueLabels(repositoryId, number), labels);
+            return ApiConnection.Put<IReadOnlyList<Label>>(ApiUrls.IssueLabels(repositoryId, issueNumber), labels);
         }
 
         /// <summary>
@@ -486,14 +486,14 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The number of the issue</param>
         [ManualRoute("DELETE", "/repos/{owner}/{repo}/issues/{issue_number}/labels")]
-        public Task RemoveAllFromIssue(string owner, string name, int number)
+        public Task RemoveAllFromIssue(string owner, string name, int issueNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return ApiConnection.Delete(ApiUrls.IssueLabels(owner, name, number));
+            return ApiConnection.Delete(ApiUrls.IssueLabels(owner, name, issueNumber));
         }
 
         /// <summary>
@@ -503,11 +503,11 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/issues/labels/#remove-all-labels-from-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="issueNumber">The number of the issue</param>
         [ManualRoute("DELETE", "/repositories/{id}/issues/{number}/labels")]
-        public Task RemoveAllFromIssue(long repositoryId, int number)
+        public Task RemoveAllFromIssue(long repositoryId, int issueNumber)
         {
-            return ApiConnection.Delete(ApiUrls.IssueLabels(repositoryId, number));
+            return ApiConnection.Delete(ApiUrls.IssueLabels(repositoryId, issueNumber));
         }
     }
 }

--- a/Octokit/Clients/LockUnlockClient.cs
+++ b/Octokit/Clients/LockUnlockClient.cs
@@ -21,15 +21,15 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="lockReason">The reason for locking the issue</param>
         [ManualRoute("PUT", "/repos/{owner}/{repo}/issues/{issue_number}/lock")]
-        public Task Lock(string owner, string name, int number, LockReason? lockReason = null)
+        public Task Lock(string owner, string name, int issueNumber, LockReason? lockReason = null)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return ApiConnection.Put<Issue>(ApiUrls.IssueLock(owner, name, number), lockReason.HasValue ? new { LockReason = lockReason } : new object());
+            return ApiConnection.Put<Issue>(ApiUrls.IssueLock(owner, name, issueNumber), lockReason.HasValue ? new { LockReason = lockReason } : new object());
         }
 
         /// <summary>
@@ -37,12 +37,12 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="lockReason">The reason for locking the issue</param>
         [ManualRoute("PUT", "/repositories/{id}/issues/{number}/lock")]
-        public Task Lock(long repositoryId, int number, LockReason? lockReason = null)
+        public Task Lock(long repositoryId, int issueNumber, LockReason? lockReason = null)
         {
-            return ApiConnection.Put<Issue>(ApiUrls.IssueLock(repositoryId, number), lockReason.HasValue ? new { LockReaons = lockReason } : new object());
+            return ApiConnection.Put<Issue>(ApiUrls.IssueLock(repositoryId, issueNumber), lockReason.HasValue ? new { LockReaons = lockReason } : new object());
         }
 
         /// <summary>
@@ -51,14 +51,14 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         [ManualRoute("DELETE", "/repos/{owner}/{repo}/issues/{issue_number}/lock")]
-        public Task Unlock(string owner, string name, int number)
+        public Task Unlock(string owner, string name, int issueNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return ApiConnection.Delete(ApiUrls.IssueLock(owner, name, number));
+            return ApiConnection.Delete(ApiUrls.IssueLock(owner, name, issueNumber));
         }
 
         /// <summary>
@@ -66,11 +66,11 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         [ManualRoute("DELETE", "/repositories/{id}/issues/{number}/lock")]
-        public Task Unlock(long repositoryId, int number)
+        public Task Unlock(long repositoryId, int issueNumber)
         {
-            return ApiConnection.Delete(ApiUrls.IssueLock(repositoryId, number));
+            return ApiConnection.Delete(ApiUrls.IssueLock(repositoryId, issueNumber));
         }
     }
 }

--- a/Octokit/Clients/MilestonesClient.cs
+++ b/Octokit/Clients/MilestonesClient.cs
@@ -27,12 +27,12 @@ namespace Octokit
         /// </remarks>
         /// <returns></returns>
         [ManualRoute("GET", "/repos/{owner}/{repo}/milestones/{milestone_number}")]
-        public Task<Milestone> Get(string owner, string name, int number)
+        public Task<Milestone> Get(string owner, string name, int milestoneNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return ApiConnection.Get<Milestone>(ApiUrls.Milestone(owner, name, number));
+            return ApiConnection.Get<Milestone>(ApiUrls.Milestone(owner, name, milestoneNumber));
         }
 
         /// <summary>
@@ -43,9 +43,9 @@ namespace Octokit
         /// </remarks>
         /// <returns></returns>
         [ManualRoute("GET", "/repositories/{id}/milestones/{milestone_number}")]
-        public Task<Milestone> Get(long repositoryId, int number)
+        public Task<Milestone> Get(long repositoryId, int milestoneNumber)
         {
-            return ApiConnection.Get<Milestone>(ApiUrls.Milestone(repositoryId, number));
+            return ApiConnection.Get<Milestone>(ApiUrls.Milestone(repositoryId, milestoneNumber));
         }
 
         /// <summary>
@@ -239,18 +239,18 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/milestones/#update-a-milestone</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The Milestone number</param>
+        /// <param name="milestoneNumber">The Milestone number</param>
         /// <param name="milestoneUpdate">An <see cref="MilestoneUpdate"/> instance describing the changes to make to the Milestone
         /// </param>
         /// <returns></returns>
         [ManualRoute("PATCH", "/repos/{owner}/{repo}/milestones/{milestone_number}")]
-        public Task<Milestone> Update(string owner, string name, int number, MilestoneUpdate milestoneUpdate)
+        public Task<Milestone> Update(string owner, string name, int milestoneNumber, MilestoneUpdate milestoneUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(milestoneUpdate, nameof(milestoneUpdate));
 
-            return ApiConnection.Patch<Milestone>(ApiUrls.Milestone(owner, name, number), milestoneUpdate);
+            return ApiConnection.Patch<Milestone>(ApiUrls.Milestone(owner, name, milestoneNumber), milestoneUpdate);
         }
 
         /// <summary>
@@ -259,16 +259,16 @@ namespace Octokit
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/milestones/#update-a-milestone</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The Milestone number</param>
+        /// <param name="milestoneNumber">The Milestone number</param>
         /// <param name="milestoneUpdate">An <see cref="MilestoneUpdate"/> instance describing the changes to make to the Milestone
         /// </param>
         /// <returns></returns>
         [ManualRoute("PATCH", "/repositories/{id}/milestones/{milestone_number}")]
-        public Task<Milestone> Update(long repositoryId, int number, MilestoneUpdate milestoneUpdate)
+        public Task<Milestone> Update(long repositoryId, int milestoneNumber, MilestoneUpdate milestoneUpdate)
         {
             Ensure.ArgumentNotNull(milestoneUpdate, nameof(milestoneUpdate));
 
-            return ApiConnection.Patch<Milestone>(ApiUrls.Milestone(repositoryId, number), milestoneUpdate);
+            return ApiConnection.Patch<Milestone>(ApiUrls.Milestone(repositoryId, milestoneNumber), milestoneUpdate);
         }
 
         /// <summary>
@@ -278,15 +278,15 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/milestones/#delete-a-milestone</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The milestone number</param>
+        /// <param name="milestoneNumber">The milestone number</param>
         /// <returns></returns>
         [ManualRoute("DELETE", "/repos/{owner}/{repo}/milestones/{milestone_number}")]
-        public Task Delete(string owner, string name, int number)
+        public Task Delete(string owner, string name, int milestoneNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return ApiConnection.Delete(ApiUrls.Milestone(owner, name, number));
+            return ApiConnection.Delete(ApiUrls.Milestone(owner, name, milestoneNumber));
         }
 
         /// <summary>
@@ -295,12 +295,12 @@ namespace Octokit
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/milestones/#delete-a-milestone</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The milestone number</param>
+        /// <param name="milestoneNumber">The milestone number</param>
         /// <returns></returns>
         [ManualRoute("DELETE", "/repositories/{id}/milestones/{milestone_number}")]
-        public Task Delete(long repositoryId, int number)
+        public Task Delete(long repositoryId, int milestoneNumber)
         {
-            return ApiConnection.Delete(ApiUrls.Milestone(repositoryId, number));
+            return ApiConnection.Delete(ApiUrls.Milestone(repositoryId, milestoneNumber));
         }
     }
 }

--- a/Octokit/Clients/NotificationsClient.cs
+++ b/Octokit/Clients/NotificationsClient.cs
@@ -323,12 +323,12 @@ namespace Octokit
         /// <summary>
         /// Deletes the authenticated user's subscription to a given thread.
         /// </summary>
-        /// <param name="id">The Id of the thread to delete subscription from.</param>
+        /// <param name="threadId">The Id of the thread to delete subscription from.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#delete-a-thread-subscription</remarks>
         [ManualRoute("DELETE", "/notifications/threads/{thread_id}/subscription")]
-        public Task DeleteThreadSubscription(int id)
+        public Task DeleteThreadSubscription(int threadId)
         {
-            return ApiConnection.Delete(ApiUrls.NotificationSubscription(id));
+            return ApiConnection.Delete(ApiUrls.NotificationSubscription(threadId));
         }
     }
 }

--- a/Octokit/Clients/PullRequestReviewRequestsClient.cs
+++ b/Octokit/Clients/PullRequestReviewRequestsClient.cs
@@ -23,14 +23,14 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/pulls/review_requests/#list-review-requests</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers")]
-        public Task<RequestedReviews> Get(string owner, string name, int number)
+        public Task<RequestedReviews> Get(string owner, string name, int pullRequestNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return ApiConnection.Get<RequestedReviews>(ApiUrls.PullRequestReviewRequests(owner, name, number));
+            return ApiConnection.Get<RequestedReviews>(ApiUrls.PullRequestReviewRequests(owner, name, pullRequestNumber));
         }
 
         /// <summary>
@@ -38,11 +38,11 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/review_requests/#list-review-requests</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         [ManualRoute("GET", "/repositories/{id}/pulls/{number}/requested_reviewers")]
-        public Task<RequestedReviews> Get(long repositoryId, int number)
+        public Task<RequestedReviews> Get(long repositoryId, int pullRequestNumber)
         {
-            return ApiConnection.Get<RequestedReviews>(ApiUrls.PullRequestReviewRequests(repositoryId, number));
+            return ApiConnection.Get<RequestedReviews>(ApiUrls.PullRequestReviewRequests(repositoryId, pullRequestNumber));
         }
 
         /// <summary>
@@ -51,16 +51,16 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/pulls/review_requests/#create-a-review-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The Pull Request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="users">List of logins of user will be requested for review</param>
         [ManualRoute("POST", "/repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers")]
-        public Task<PullRequest> Create(string owner, string name, int number, PullRequestReviewRequest users)
+        public Task<PullRequest> Create(string owner, string name, int pullRequestNumber, PullRequestReviewRequest users)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(users, nameof(users));
 
-            var endpoint = ApiUrls.PullRequestReviewRequests(owner, name, number);
+            var endpoint = ApiUrls.PullRequestReviewRequests(owner, name, pullRequestNumber);
             return ApiConnection.Post<PullRequest>(endpoint, users);
         }
 
@@ -69,14 +69,14 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/review_requests/#create-a-review-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The Pull Request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="users">List of logins of user will be requested for review</param>
         [ManualRoute("POST", "/repositories/{id}/pulls/{number}/requested_reviewers")]
-        public Task<PullRequest> Create(long repositoryId, int number, PullRequestReviewRequest users)
+        public Task<PullRequest> Create(long repositoryId, int pullRequestNumber, PullRequestReviewRequest users)
         {
             Ensure.ArgumentNotNull(users, nameof(users));
 
-            var endpoint = ApiUrls.PullRequestReviewRequests(repositoryId, number);
+            var endpoint = ApiUrls.PullRequestReviewRequests(repositoryId, pullRequestNumber);
             return ApiConnection.Post<PullRequest>(endpoint, users);
         }
 
@@ -86,16 +86,16 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/pulls/review_requests/#delete-a-review-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request review comment number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="users">List of logins of users that will be not longer requested for review</param>
         [ManualRoute("DELETE", "/repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers")]
-        public Task Delete(string owner, string name, int number, PullRequestReviewRequest users)
+        public Task Delete(string owner, string name, int pullRequestNumber, PullRequestReviewRequest users)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(users, nameof(users));
 
-            return ApiConnection.Delete(ApiUrls.PullRequestReviewRequests(owner, name, number), users);
+            return ApiConnection.Delete(ApiUrls.PullRequestReviewRequests(owner, name, pullRequestNumber), users);
         }
 
         /// <summary>
@@ -103,14 +103,14 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/review_requests/#delete-a-review-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request review comment number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="users">List of logins of users that will be not longer requested for review</param>
         [ManualRoute("DELETE", "/repositories/{id}/pulls/{number}/requested_reviewers")]
-        public Task Delete(long repositoryId, int number, PullRequestReviewRequest users)
+        public Task Delete(long repositoryId, int pullRequestNumber, PullRequestReviewRequest users)
         {
             Ensure.ArgumentNotNull(users, nameof(users));
 
-            return ApiConnection.Delete(ApiUrls.PullRequestReviewRequests(repositoryId, number), users);
+            return ApiConnection.Delete(ApiUrls.PullRequestReviewRequests(repositoryId, pullRequestNumber), users);
         }
     }
 }

--- a/Octokit/Clients/PullRequestsClient.cs
+++ b/Octokit/Clients/PullRequestsClient.cs
@@ -48,12 +48,12 @@ namespace Octokit
         /// http://developer.github.com/v3/pulls/#get-a-single-pull-request
         /// </remarks>
         [ManualRoute("GET", "/repos/{owner}/{repo}/pulls/{pull_number}")]
-        public Task<PullRequest> Get(string owner, string name, int number)
+        public Task<PullRequest> Get(string owner, string name, int pullRequestNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return ApiConnection.Get<PullRequest>(ApiUrls.PullRequest(owner, name, number), null);
+            return ApiConnection.Get<PullRequest>(ApiUrls.PullRequest(owner, name, pullRequestNumber), null);
         }
 
         /// <summary>
@@ -63,9 +63,9 @@ namespace Octokit
         /// http://developer.github.com/v3/pulls/#get-a-single-pull-request
         /// </remarks>
         [ManualRoute("GET", "/repositories/{id}/pulls/{number}")]
-        public Task<PullRequest> Get(long repositoryId, int number)
+        public Task<PullRequest> Get(long repositoryId, int pullRequestNumber)
         {
-            return ApiConnection.Get<PullRequest>(ApiUrls.PullRequest(repositoryId, number), null);
+            return ApiConnection.Get<PullRequest>(ApiUrls.PullRequest(repositoryId, pullRequestNumber), null);
         }
 
         /// <summary>
@@ -244,17 +244,17 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/#update-a-pull-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The PullRequest number</param>
+        /// <param name="pullRequestNumber">The PullRequest number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
         [ManualRoute("PATCH", "/repos/{owner}/{repo}/pulls/{pull_number}")]
-        public Task<PullRequest> Update(string owner, string name, int number, PullRequestUpdate pullRequestUpdate)
+        public Task<PullRequest> Update(string owner, string name, int pullRequestNumber, PullRequestUpdate pullRequestUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(pullRequestUpdate, nameof(pullRequestUpdate));
 
-            return ApiConnection.Patch<PullRequest>(ApiUrls.PullRequest(owner, name, number), pullRequestUpdate);
+            return ApiConnection.Patch<PullRequest>(ApiUrls.PullRequest(owner, name, pullRequestNumber), pullRequestUpdate);
         }
 
         /// <summary>
@@ -262,27 +262,27 @@ namespace Octokit
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/#update-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The PullRequest number</param>
+        /// <param name="pullRequestNumber">The PullRequest number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
         [ManualRoute("PATCH", "/repositories/{id}/pulls/{number}")]
-        public Task<PullRequest> Update(long repositoryId, int number, PullRequestUpdate pullRequestUpdate)
+        public Task<PullRequest> Update(long repositoryId, int pullRequestNumber, PullRequestUpdate pullRequestUpdate)
         {
             Ensure.ArgumentNotNull(pullRequestUpdate, nameof(pullRequestUpdate));
 
-            return ApiConnection.Patch<PullRequest>(ApiUrls.PullRequest(repositoryId, number), pullRequestUpdate);
+            return ApiConnection.Patch<PullRequest>(ApiUrls.PullRequest(repositoryId, pullRequestNumber), pullRequestUpdate);
         }
 
         /// <summary>
         /// Merge a pull request.
         /// </summary>
-        /// <remarks>http://developer.github.com/v3/pulls/#merge-a-pull-request-merge-buttontrade</remarks>
+        /// <remarks>https://docs.github.com/en/rest/pulls/pulls#merge-a-pull-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The PullRequest number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
         [ManualRoute("PUT", "/repos/{owner}/{repo}/pulls/{pull_number}/merge")]
-        public async Task<PullRequestMerge> Merge(string owner, string name, int number, MergePullRequest mergePullRequest)
+        public async Task<PullRequestMerge> Merge(string owner, string name, int pullRequestNumber, MergePullRequest mergePullRequest)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -290,7 +290,7 @@ namespace Octokit
 
             try
             {
-                var endpoint = ApiUrls.MergePullRequest(owner, name, number);
+                var endpoint = ApiUrls.MergePullRequest(owner, name, pullRequestNumber);
                 return await ApiConnection.Put<PullRequestMerge>(endpoint, mergePullRequest).ConfigureAwait(false);
             }
             catch (ApiException ex)
@@ -314,16 +314,16 @@ namespace Octokit
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/#merge-a-pull-request-merge-buttontrade</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The PullRequest number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
         [ManualRoute("PUT", "/repositories/{id}/pulls/{number}/merge")]
-        public async Task<PullRequestMerge> Merge(long repositoryId, int number, MergePullRequest mergePullRequest)
+        public async Task<PullRequestMerge> Merge(long repositoryId, int pullRequestNumber, MergePullRequest mergePullRequest)
         {
             Ensure.ArgumentNotNull(mergePullRequest, nameof(mergePullRequest));
 
             try
             {
-                var endpoint = ApiUrls.MergePullRequest(repositoryId, number);
+                var endpoint = ApiUrls.MergePullRequest(repositoryId, pullRequestNumber);
                 return await ApiConnection.Put<PullRequestMerge>(endpoint, mergePullRequest).ConfigureAwait(false);
             }
             catch (ApiException ex)
@@ -348,16 +348,16 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The PullRequest number</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/pulls/{pull_number}/merge")]
-        public async Task<bool> Merged(string owner, string name, int number)
+        public async Task<bool> Merged(string owner, string name, int pullRequestNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
             try
             {
-                var endpoint = ApiUrls.MergePullRequest(owner, name, number);
+                var endpoint = ApiUrls.MergePullRequest(owner, name, pullRequestNumber);
                 var response = await Connection.Get<object>(endpoint, null, null).ConfigureAwait(false);
                 return response.HttpResponse.IsTrue();
             }
@@ -372,13 +372,13 @@ namespace Octokit
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The PullRequest number</param>
         [ManualRoute("GET", "/repositories/{id}/pulls/{number}/merge")]
-        public async Task<bool> Merged(long repositoryId, int number)
+        public async Task<bool> Merged(long repositoryId, int pullRequestNumber)
         {
             try
             {
-                var endpoint = ApiUrls.MergePullRequest(repositoryId, number);
+                var endpoint = ApiUrls.MergePullRequest(repositoryId, pullRequestNumber);
                 var response = await Connection.Get<object>(endpoint, null, null).ConfigureAwait(false);
                 return response.HttpResponse.IsTrue();
             }
@@ -394,14 +394,14 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/#list-commits-on-a-pull-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The PullRequest number</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/pulls/{pull_number}/commits")]
-        public Task<IReadOnlyList<PullRequestCommit>> Commits(string owner, string name, int number)
+        public Task<IReadOnlyList<PullRequestCommit>> Commits(string owner, string name, int pullRequestNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return ApiConnection.GetAll<PullRequestCommit>(ApiUrls.PullRequestCommits(owner, name, number));
+            return ApiConnection.GetAll<PullRequestCommit>(ApiUrls.PullRequestCommits(owner, name, pullRequestNumber));
         }
 
         /// <summary>
@@ -409,11 +409,11 @@ namespace Octokit
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/#list-commits-on-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The PullRequest number</param>
         [ManualRoute("GET", "/repositories/{id}/pulls/{number}/commits")]
-        public Task<IReadOnlyList<PullRequestCommit>> Commits(long repositoryId, int number)
+        public Task<IReadOnlyList<PullRequestCommit>> Commits(long repositoryId, int pullRequestNumber)
         {
-            return ApiConnection.GetAll<PullRequestCommit>(ApiUrls.PullRequestCommits(repositoryId, number));
+            return ApiConnection.GetAll<PullRequestCommit>(ApiUrls.PullRequestCommits(repositoryId, pullRequestNumber));
         }
 
         /// <summary>
@@ -422,11 +422,11 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The PullRequest number</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/pulls/{pull_number}/files")]
-        public Task<IReadOnlyList<PullRequestFile>> Files(string owner, string name, int number)
+        public Task<IReadOnlyList<PullRequestFile>> Files(string owner, string name, int pullRequestNumber)
         {
-            return Files(owner, name, number, ApiOptions.None);
+            return Files(owner, name, pullRequestNumber, ApiOptions.None);
         }
 
         /// <summary>
@@ -435,15 +435,15 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The PullRequest number</param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/pulls/{pull_number}/files")]
-        public Task<IReadOnlyList<PullRequestFile>> Files(string owner, string name, int number, ApiOptions options)
+        public Task<IReadOnlyList<PullRequestFile>> Files(string owner, string name, int pullRequestNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return ApiConnection.GetAll<PullRequestFile>(ApiUrls.PullRequestFiles(owner, name, number), options);
+            return ApiConnection.GetAll<PullRequestFile>(ApiUrls.PullRequestFiles(owner, name, pullRequestNumber), options);
         }
 
         /// <summary>
@@ -451,11 +451,11 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The PullRequest number</param>
         [ManualRoute("GET", "/repositories/{id}/pulls/{number}/files")]
-        public Task<IReadOnlyList<PullRequestFile>> Files(long repositoryId, int number)
+        public Task<IReadOnlyList<PullRequestFile>> Files(long repositoryId, int pullRequestNumber)
         {
-            return Files(repositoryId, number, ApiOptions.None);
+            return Files(repositoryId, pullRequestNumber, ApiOptions.None);
         }
 
         /// <summary>
@@ -463,12 +463,12 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The PullRequest number</param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/repositories/{id}/pulls/{number}/files")]
-        public Task<IReadOnlyList<PullRequestFile>> Files(long repositoryId, int number, ApiOptions options)
+        public Task<IReadOnlyList<PullRequestFile>> Files(long repositoryId, int pullRequestNumber, ApiOptions options)
         {
-            return ApiConnection.GetAll<PullRequestFile>(ApiUrls.PullRequestFiles(repositoryId, number), options);
+            return ApiConnection.GetAll<PullRequestFile>(ApiUrls.PullRequestFiles(repositoryId, pullRequestNumber), options);
         }
     }
 }

--- a/Octokit/Clients/RepositoryDeployKeysClient.cs
+++ b/Octokit/Clients/RepositoryDeployKeysClient.cs
@@ -29,14 +29,14 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
-        /// <param name="number">The id of the deploy key.</param>
+        /// <param name="deployKeyId">The id of the deploy key.</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/keys/{number}")]
-        public Task<DeployKey> Get(string owner, string name, int number)
+        public Task<DeployKey> Get(string owner, string name, int deployKeyId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return ApiConnection.Get<DeployKey>(ApiUrls.RepositoryDeployKey(owner, name, number));
+            return ApiConnection.Get<DeployKey>(ApiUrls.RepositoryDeployKey(owner, name, deployKeyId));
         }
 
         /// <summary>
@@ -46,11 +46,11 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/keys/#get"> API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
-        /// <param name="number">The id of the deploy key.</param>
+        /// <param name="deployKeyId">The id of the deploy key.</param>
         [ManualRoute("GET", "/repositories/{id}/keys/{number}")]
-        public Task<DeployKey> Get(long repositoryId, int number)
+        public Task<DeployKey> Get(long repositoryId, int deployKeyId)
         {
-            return ApiConnection.Get<DeployKey>(ApiUrls.RepositoryDeployKey(repositoryId, number));
+            return ApiConnection.Get<DeployKey>(ApiUrls.RepositoryDeployKey(repositoryId, deployKeyId));
         }
 
         /// <summary>
@@ -173,14 +173,14 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
-        /// <param name="number">The id of the deploy key to delete.</param>
+        /// <param name="deployKeyId">The id of the deploy key to delete.</param>
         [ManualRoute("DELETE", "/repositories/{id}/keys/{number}")]
-        public Task Delete(string owner, string name, int number)
+        public Task Delete(string owner, string name, int deployKeyId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return ApiConnection.Delete(ApiUrls.RepositoryDeployKey(owner, name, number));
+            return ApiConnection.Delete(ApiUrls.RepositoryDeployKey(owner, name, deployKeyId));
         }
 
         /// <summary>
@@ -190,11 +190,11 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/keys/#delete"> API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
-        /// <param name="number">The id of the deploy key to delete.</param>
+        /// <param name="deployKeyId">The id of the deploy key to delete.</param>
         [ManualRoute("DELETE", "/repositories/{id}/keys/{number}")]
-        public Task Delete(long repositoryId, int number)
+        public Task Delete(long repositoryId, int deployKeyId)
         {
-            return ApiConnection.Delete(ApiUrls.RepositoryDeployKey(repositoryId, number));
+            return ApiConnection.Delete(ApiUrls.RepositoryDeployKey(repositoryId, deployKeyId));
         }
     }
 }

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -559,11 +559,11 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <returns></returns>
-        public static Uri Issue(string owner, string name, int number)
+        public static Uri Issue(string owner, string name, int issueNumber)
         {
-            return "repos/{0}/{1}/issues/{2}".FormatUri(owner, name, number);
+            return "repos/{0}/{1}/issues/{2}".FormatUri(owner, name, issueNumber);
         }
 
         /// <summary>
@@ -571,11 +571,11 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <returns></returns>
-        public static Uri IssueLock(string owner, string name, int number)
+        public static Uri IssueLock(string owner, string name, int issueNumber)
         {
-            return "repos/{0}/{1}/issues/{2}/lock".FormatUri(owner, name, number);
+            return "repos/{0}/{1}/issues/{2}/lock".FormatUri(owner, name, issueNumber);
         }
 
         /// <summary>
@@ -583,22 +583,22 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <returns></returns>
-        public static Uri IssueReactions(string owner, string name, int number)
+        public static Uri IssueReactions(string owner, string name, int issueNumber)
         {
-            return "repos/{0}/{1}/issues/{2}/reactions".FormatUri(owner, name, number);
+            return "repos/{0}/{1}/issues/{2}/reactions".FormatUri(owner, name, issueNumber);
         }
 
         /// <summary>
         /// Returns the <see cref="Uri"/> for the reaction of a specified issue.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <returns></returns>
-        public static Uri IssueReactions(long repositoryId, int number)
+        public static Uri IssueReactions(long repositoryId, int issueNumber)
         {
-            return "repositories/{0}/issues/{1}/reactions".FormatUri(repositoryId, number);
+            return "repositories/{0}/issues/{1}/reactions".FormatUri(repositoryId, issueNumber);
         }
 
         /// <summary>
@@ -606,24 +606,24 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="reactionId">The reactionid for the issue</param>
         /// <returns></returns>
-        public static Uri IssueReaction(string owner, string name, int number, long reactionId)
+        public static Uri IssueReaction(string owner, string name, int issueNumber, long reactionId)
         {
-            return "repos/{0}/{1}/issues/{2}/reactions/{3}".FormatUri(owner, name, number, reactionId);
+            return "repos/{0}/{1}/issues/{2}/reactions/{3}".FormatUri(owner, name, issueNumber, reactionId);
         }
 
         /// <summary>
         /// Returns the <see cref="Uri"/> for the reaction of a specified issue.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="reactionId">The reactionid for the issue</param>
         /// <returns></returns>
-        public static Uri IssueReaction(long repositoryId, int number, long reactionId)
+        public static Uri IssueReaction(long repositoryId, int issueNumber, long reactionId)
         {
-            return "repositories/{0}/issues/{1}/reactions/{2}".FormatUri(repositoryId, number, reactionId);
+            return "repositories/{0}/issues/{1}/reactions/{2}".FormatUri(repositoryId, issueNumber, reactionId);
         }
 
         /// <summary>
@@ -631,22 +631,22 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="repo">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <returns></returns>
-        public static Uri IssueTimeline(string owner, string repo, int number)
+        public static Uri IssueTimeline(string owner, string repo, int issueNumber)
         {
-            return "repos/{0}/{1}/issues/{2}/timeline".FormatUri(owner, repo, number);
+            return "repos/{0}/{1}/issues/{2}/timeline".FormatUri(owner, repo, issueNumber);
         }
 
         /// <summary>
         /// Returns the <see cref="Uri"/> for the timeline of a specified issue.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <returns></returns>
-        public static Uri IssueTimeline(long repositoryId, int number)
+        public static Uri IssueTimeline(long repositoryId, int issueNumber)
         {
-            return "repositories/{0}/issues/{1}/timeline".FormatUri(repositoryId, number);
+            return "repositories/{0}/issues/{1}/timeline".FormatUri(repositoryId, issueNumber);
         }
 
         /// <summary>
@@ -665,11 +665,11 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <returns></returns>
-        public static Uri IssueComments(string owner, string name, int number)
+        public static Uri IssueComments(string owner, string name, int issueNumber)
         {
-            return "repos/{0}/{1}/issues/{2}/comments".FormatUri(owner, name, number);
+            return "repos/{0}/{1}/issues/{2}/comments".FormatUri(owner, name, issueNumber);
         }
 
         /// <summary>
@@ -844,11 +844,11 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <returns></returns>
-        public static Uri IssueAssignees(string owner, string name, int number)
+        public static Uri IssueAssignees(string owner, string name, int issueNumber)
         {
-            return "repos/{0}/{1}/issues/{2}/assignees".FormatUri(owner, name, number);
+            return "repos/{0}/{1}/issues/{2}/assignees".FormatUri(owner, name, issueNumber);
         }
 
         /// <summary>
@@ -1050,11 +1050,11 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <returns></returns>
-        public static Uri IssuesEvents(string owner, string name, int number)
+        public static Uri IssuesEvents(string owner, string name, int issueNumber)
         {
-            return "repos/{0}/{1}/issues/{2}/events".FormatUri(owner, name, number);
+            return "repos/{0}/{1}/issues/{2}/events".FormatUri(owner, name, issueNumber);
         }
 
         /// <summary>
@@ -1085,11 +1085,11 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The milestone number</param>
+        /// <param name="milestoneNumber">The milestone number</param>
         /// <returns></returns>
-        public static Uri Milestone(string owner, string name, int number)
+        public static Uri Milestone(string owner, string name, int milestoneNumber)
         {
-            return "repos/{0}/{1}/milestones/{2}".FormatUri(owner, name, number);
+            return "repos/{0}/{1}/milestones/{2}".FormatUri(owner, name, milestoneNumber);
         }
 
         /// <summary>
@@ -1131,12 +1131,12 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="labelName">The name of the label</param>
         /// <returns></returns>
-        public static Uri IssueLabel(string owner, string name, int number, string labelName)
+        public static Uri IssueLabel(string owner, string name, int issueNumber, string labelName)
         {
-            return "repos/{0}/{1}/issues/{2}/labels/{3}".FormatUri(owner, name, number, labelName);
+            return "repos/{0}/{1}/issues/{2}/labels/{3}".FormatUri(owner, name, issueNumber, labelName);
         }
 
         /// <summary>
@@ -1144,11 +1144,11 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <returns></returns>
-        public static Uri IssueLabels(string owner, string name, int number)
+        public static Uri IssueLabels(string owner, string name, int issueNumber)
         {
-            return "repos/{0}/{1}/issues/{2}/labels".FormatUri(owner, name, number);
+            return "repos/{0}/{1}/issues/{2}/labels".FormatUri(owner, name, issueNumber);
         }
 
         /// <summary>
@@ -1156,11 +1156,11 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The milestone number</param>
+        /// <param name="milestoneNumber">The milestone number</param>
         /// <returns></returns>
-        public static Uri MilestoneLabels(string owner, string name, int number)
+        public static Uri MilestoneLabels(string owner, string name, int milestoneNumber)
         {
-            return "repos/{0}/{1}/milestones/{2}/labels".FormatUri(owner, name, number);
+            return "repos/{0}/{1}/milestones/{2}/labels".FormatUri(owner, name, milestoneNumber);
         }
 
         /// <summary>
@@ -1491,11 +1491,11 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <returns></returns>
-        public static Uri PullRequest(string owner, string name, int number)
+        public static Uri PullRequest(string owner, string name, int pullRequestNumber)
         {
-            return "repos/{0}/{1}/pulls/{2}".FormatUri(owner, name, number);
+            return "repos/{0}/{1}/pulls/{2}".FormatUri(owner, name, pullRequestNumber);
         }
 
         /// <summary>
@@ -1514,11 +1514,11 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <returns>The <see cref="Uri"/> that returns the pull request merge state.</returns>
-        public static Uri MergePullRequest(string owner, string name, int number)
+        public static Uri MergePullRequest(string owner, string name, int pullRequestNumber)
         {
-            return "repos/{0}/{1}/pulls/{2}/merge".FormatUri(owner, name, number);
+            return "repos/{0}/{1}/pulls/{2}/merge".FormatUri(owner, name, pullRequestNumber);
         }
 
         /// <summary>
@@ -1526,11 +1526,11 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <returns>The <see cref="Uri"/> that returns the commits on a pull request.</returns>
-        public static Uri PullRequestCommits(string owner, string name, int number)
+        public static Uri PullRequestCommits(string owner, string name, int pullRequestNumber)
         {
-            return "repos/{0}/{1}/pulls/{2}/commits".FormatUri(owner, name, number);
+            return "repos/{0}/{1}/pulls/{2}/commits".FormatUri(owner, name, pullRequestNumber);
         }
 
         /// <summary>
@@ -1538,11 +1538,11 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <returns>The <see cref="Uri"/> that returns the files on a pull request.</returns>
-        public static Uri PullRequestFiles(string owner, string name, int number)
+        public static Uri PullRequestFiles(string owner, string name, int pullRequestNumber)
         {
-            return "repos/{0}/{1}/pulls/{2}/files".FormatUri(owner, name, number);
+            return "repos/{0}/{1}/pulls/{2}/files".FormatUri(owner, name, pullRequestNumber);
         }
 
         /// <summary>
@@ -1701,11 +1701,11 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <returns>The <see cref="Uri"/></returns>
-        public static Uri PullRequestReviewComments(string owner, string name, int number)
+        public static Uri PullRequestReviewComments(string owner, string name, int pullRequestNumber)
         {
-            return "repos/{0}/{1}/pulls/{2}/comments".FormatUri(owner, name, number);
+            return "repos/{0}/{1}/pulls/{2}/comments".FormatUri(owner, name, pullRequestNumber);
         }
 
         /// <summary>
@@ -1713,11 +1713,11 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <returns>The <see cref="Uri"/></returns>
-        public static Uri PullRequestReviews(string owner, string name, int number)
+        public static Uri PullRequestReviews(string owner, string name, int pullRequestNumber)
         {
-            return "repos/{0}/{1}/pulls/{2}/reviews".FormatUri(owner, name, number);
+            return "repos/{0}/{1}/pulls/{2}/reviews".FormatUri(owner, name, pullRequestNumber);
         }
 
         /// <summary>
@@ -1737,24 +1737,24 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <returns>The <see cref="Uri"/></returns>
-        public static Uri PullRequestReview(string owner, string name, int number, long reviewId)
+        public static Uri PullRequestReview(string owner, string name, int pullRequestNumber, long reviewId)
         {
-            return "repos/{0}/{1}/pulls/{2}/reviews/{3}".FormatUri(owner, name, number, reviewId);
+            return "repos/{0}/{1}/pulls/{2}/reviews/{3}".FormatUri(owner, name, pullRequestNumber, reviewId);
         }
 
         /// <summary>
         /// Returns the <see cref="Uri"/> for dismissing a specified pull request review
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <returns>The <see cref="Uri"/></returns>
-        public static Uri PullRequestReviewDismissal(long repositoryId, int number, long reviewId)
+        public static Uri PullRequestReviewDismissal(long repositoryId, int pullRequestNumber, long reviewId)
         {
-            return "repositories/{0}/pulls/{1}/reviews/{2}/dismissals".FormatUri(repositoryId, number, reviewId);
+            return "repositories/{0}/pulls/{1}/reviews/{2}/dismissals".FormatUri(repositoryId, pullRequestNumber, reviewId);
         }
 
         /// <summary>
@@ -1762,24 +1762,24 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <returns>The <see cref="Uri"/></returns>
-        public static Uri PullRequestReviewDismissal(string owner, string name, int number, long reviewId)
+        public static Uri PullRequestReviewDismissal(string owner, string name, int pullRequestNumber, long reviewId)
         {
-            return "repos/{0}/{1}/pulls/{2}/reviews/{3}/dismissals".FormatUri(owner, name, number, reviewId);
+            return "repos/{0}/{1}/pulls/{2}/reviews/{3}/dismissals".FormatUri(owner, name, pullRequestNumber, reviewId);
         }
 
         /// <summary>
         /// Returns the <see cref="Uri"/> for submitting a pull request review
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <returns>The <see cref="Uri"/> that </returns>
-        public static Uri PullRequestReviewSubmit(long repositoryId, int number, long reviewId)
+        public static Uri PullRequestReviewSubmit(long repositoryId, int pullRequestNumber, long reviewId)
         {
-            return "repositories/{0}/pulls/{1}/reviews/{2}/events".FormatUri(repositoryId, number, reviewId);
+            return "repositories/{0}/pulls/{1}/reviews/{2}/events".FormatUri(repositoryId, pullRequestNumber, reviewId);
         }
 
         /// <summary>
@@ -1787,24 +1787,24 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <returns>The <see cref="Uri"/></returns>
-        public static Uri PullRequestReviewSubmit(string owner, string name, int number, long reviewId)
+        public static Uri PullRequestReviewSubmit(string owner, string name, int pullRequestNumber, long reviewId)
         {
-            return "repos/{0}/{1}/pulls/{2}/reviews/{3}/events".FormatUri(owner, name, number, reviewId);
+            return "repos/{0}/{1}/pulls/{2}/reviews/{3}/events".FormatUri(owner, name, pullRequestNumber, reviewId);
         }
 
         /// <summary>
         /// Returns the <see cref="Uri"/> for submitting a pull request review
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <returns>The <see cref="Uri"/> that </returns>
-        public static Uri PullRequestReviewComments(long repositoryId, int number, long reviewId)
+        public static Uri PullRequestReviewComments(long repositoryId, int pullRequestNumber, long reviewId)
         {
-            return "repositories/{0}/pulls/{1}/reviews/{2}/comments".FormatUri(repositoryId, number, reviewId);
+            return "repositories/{0}/pulls/{1}/reviews/{2}/comments".FormatUri(repositoryId, pullRequestNumber, reviewId);
         }
 
         /// <summary>
@@ -1812,24 +1812,24 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <returns>The <see cref="Uri"/></returns>
-        public static Uri PullRequestReviewComments(string owner, string name, int number, long reviewId)
+        public static Uri PullRequestReviewComments(string owner, string name, int pullRequestNumber, long reviewId)
         {
-            return "repos/{0}/{1}/pulls/{2}/reviews/{3}/comments".FormatUri(owner, name, number, reviewId);
+            return "repos/{0}/{1}/pulls/{2}/reviews/{3}/comments".FormatUri(owner, name, pullRequestNumber, reviewId);
         }
 
         /// <summary>
         /// Returns the <see cref="Uri"/> for a specified pull request review.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <returns>The <see cref="Uri"/></returns>
-        public static Uri PullRequestReview(long repositoryId, int number, long reviewId)
+        public static Uri PullRequestReview(long repositoryId, int pullRequestNumber, long reviewId)
         {
-            return "repositories/{0}/pulls/{1}/reviews/{2}".FormatUri(repositoryId, number, reviewId);
+            return "repositories/{0}/pulls/{1}/reviews/{2}".FormatUri(repositoryId, pullRequestNumber, reviewId);
         }
 
         /// <summary>
@@ -2583,11 +2583,11 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The id of the deploy key of the repository</param>
+        /// <param name="deployKeyId">The id of the deploy key of the repository</param>
         /// <returns></returns>
-        public static Uri RepositoryDeployKey(string owner, string name, int number)
+        public static Uri RepositoryDeployKey(string owner, string name, int deployKeyId)
         {
-            return "repos/{0}/{1}/keys/{2}".FormatUri(owner, name, number);
+            return "repos/{0}/{1}/keys/{2}".FormatUri(owner, name, deployKeyId);
         }
 
         /// <summary>
@@ -3400,11 +3400,11 @@ namespace Octokit
         /// Returns the <see cref="Uri"/> for the specified issue.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <returns>The <see cref="Uri"/> for the specified issue.</returns>
-        public static Uri Issue(long repositoryId, int number)
+        public static Uri Issue(long repositoryId, int issueNumber)
         {
-            return "repositories/{0}/issues/{1}".FormatUri(repositoryId, number);
+            return "repositories/{0}/issues/{1}".FormatUri(repositoryId, issueNumber);
         }
 
         /// <summary>
@@ -3432,45 +3432,45 @@ namespace Octokit
         /// Returns the <see cref="Uri"/> for the comments of a specified issue.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <returns>The <see cref="Uri"/> for the comments of a specified issue.</returns>
-        public static Uri IssueComments(long repositoryId, int number)
+        public static Uri IssueComments(long repositoryId, int issueNumber)
         {
-            return "repositories/{0}/issues/{1}/comments".FormatUri(repositoryId, number);
+            return "repositories/{0}/issues/{1}/comments".FormatUri(repositoryId, issueNumber);
         }
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns the named label for the specified issue.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <param name="labelName">The name of the label</param>
         /// <returns>The <see cref="Uri"/> that returns the named label for the specified issue.</returns>
-        public static Uri IssueLabel(long repositoryId, int number, string labelName)
+        public static Uri IssueLabel(long repositoryId, int issueNumber, string labelName)
         {
-            return "repositories/{0}/issues/{1}/labels/{2}".FormatUri(repositoryId, number, labelName);
+            return "repositories/{0}/issues/{1}/labels/{2}".FormatUri(repositoryId, issueNumber, labelName);
         }
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns all of the labels for the specified issue.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <returns>The <see cref="Uri"/> that returns all of the labels for the specified issue.</returns>
-        public static Uri IssueLabels(long repositoryId, int number)
+        public static Uri IssueLabels(long repositoryId, int issueNumber)
         {
-            return "repositories/{0}/issues/{1}/labels".FormatUri(repositoryId, number);
+            return "repositories/{0}/issues/{1}/labels".FormatUri(repositoryId, issueNumber);
         }
 
         /// <summary>
         /// Returns the <see cref="Uri"/> for the specified issue to be locked/unlocked.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <returns>The <see cref="Uri"/> for the specified issue to be locked/unlocked.</returns>
-        public static Uri IssueLock(long repositoryId, int number)
+        public static Uri IssueLock(long repositoryId, int issueNumber)
         {
-            return "repositories/{0}/issues/{1}/lock".FormatUri(repositoryId, number);
+            return "repositories/{0}/issues/{1}/lock".FormatUri(repositoryId, issueNumber);
         }
 
         /// <summary>
@@ -3498,11 +3498,11 @@ namespace Octokit
         /// Returns the <see cref="Uri"/> that returns the issue/pull request event info for the specified issue.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="issueNumber">The issue number</param>
         /// <returns>The <see cref="Uri"/> that returns the issue/pull request event info for the specified issue.</returns>
-        public static Uri IssuesEvents(long repositoryId, int number)
+        public static Uri IssuesEvents(long repositoryId, int issueNumber)
         {
-            return "repositories/{0}/issues/{1}/events".FormatUri(repositoryId, number);
+            return "repositories/{0}/issues/{1}/events".FormatUri(repositoryId, issueNumber);
         }
 
         /// <summary>
@@ -3550,33 +3550,33 @@ namespace Octokit
         /// Returns the <see cref="Uri"/> that returns the pull request merge state.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <returns>The <see cref="Uri"/> that returns the pull request merge state.</returns>
-        public static Uri MergePullRequest(long repositoryId, int number)
+        public static Uri MergePullRequest(long repositoryId, int pullRequestNumber)
         {
-            return "repositories/{0}/pulls/{1}/merge".FormatUri(repositoryId, number);
+            return "repositories/{0}/pulls/{1}/merge".FormatUri(repositoryId, pullRequestNumber);
         }
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns the specified milestone.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The milestone number</param>
+        /// <param name="milestoneNumber">The milestone number</param>
         /// <returns>The <see cref="Uri"/> that returns the specified milestone.</returns>
-        public static Uri Milestone(long repositoryId, int number)
+        public static Uri Milestone(long repositoryId, int milestoneNumber)
         {
-            return "repositories/{0}/milestones/{1}".FormatUri(repositoryId, number);
+            return "repositories/{0}/milestones/{1}".FormatUri(repositoryId, milestoneNumber);
         }
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns all of the labels for all issues in the specified milestone.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The milestone number</param>
+        /// <param name="milestoneNumber">The milestone number</param>
         /// <returns>The <see cref="Uri"/> that returns all of the labels for all issues in the specified milestone.</returns>
-        public static Uri MilestoneLabels(long repositoryId, int number)
+        public static Uri MilestoneLabels(long repositoryId, int milestoneNumber)
         {
-            return "repositories/{0}/milestones/{1}/labels".FormatUri(repositoryId, number);
+            return "repositories/{0}/milestones/{1}/labels".FormatUri(repositoryId, milestoneNumber);
         }
 
         /// <summary>
@@ -3603,33 +3603,33 @@ namespace Octokit
         /// Returns the <see cref="Uri"/> that returns the specified pull request.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <returns>The <see cref="Uri"/> that returns the specified pull request.</returns>
-        public static Uri PullRequest(long repositoryId, int number)
+        public static Uri PullRequest(long repositoryId, int pullRequestNumber)
         {
-            return "repositories/{0}/pulls/{1}".FormatUri(repositoryId, number);
+            return "repositories/{0}/pulls/{1}".FormatUri(repositoryId, pullRequestNumber);
         }
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns the commits on a pull request.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <returns>The <see cref="Uri"/> that returns the commits on a pull request.</returns>
-        public static Uri PullRequestCommits(long repositoryId, int number)
+        public static Uri PullRequestCommits(long repositoryId, int pullRequestNumber)
         {
-            return "repositories/{0}/pulls/{1}/commits".FormatUri(repositoryId, number);
+            return "repositories/{0}/pulls/{1}/commits".FormatUri(repositoryId, pullRequestNumber);
         }
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns the files on a pull request.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <returns>The <see cref="Uri"/> that returns the files on a pull request.</returns>
-        public static Uri PullRequestFiles(long repositoryId, int number)
+        public static Uri PullRequestFiles(long repositoryId, int pullRequestNumber)
         {
-            return "repositories/{0}/pulls/{1}/files".FormatUri(repositoryId, number);
+            return "repositories/{0}/pulls/{1}/files".FormatUri(repositoryId, pullRequestNumber);
         }
 
         /// <summary>
@@ -3647,22 +3647,22 @@ namespace Octokit
         /// Returns the <see cref="Uri"/> for the comments of a specified pull request review.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <returns>The <see cref="Uri"/> that </returns>
-        public static Uri PullRequestReviewComments(long repositoryId, int number)
+        public static Uri PullRequestReviewComments(long repositoryId, int pullRequestNumber)
         {
-            return "repositories/{0}/pulls/{1}/comments".FormatUri(repositoryId, number);
+            return "repositories/{0}/pulls/{1}/comments".FormatUri(repositoryId, pullRequestNumber);
         }
 
         /// <summary>
         /// Returns the <see cref="Uri"/> for the reviews of a specified pull request
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <returns>The <see cref="Uri"/> that </returns>
-        public static Uri PullRequestReviews(long repositoryId, int number)
+        public static Uri PullRequestReviews(long repositoryId, int pullRequestNumber)
         {
-            return "repositories/{0}/pulls/{1}/reviews".FormatUri(repositoryId, number);
+            return "repositories/{0}/pulls/{1}/reviews".FormatUri(repositoryId, pullRequestNumber);
         }
 
         /// <summary>
@@ -3896,11 +3896,11 @@ namespace Octokit
         /// Returns the <see cref="Uri"/> for a deploy key for a repository
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The id of the deploy key of the repository</param>
+        /// <param name="deployKeyId">The id of the deploy key of the repository</param>
         /// <returns>The <see cref="Uri"/> for a deploy key for a repository</returns>
-        public static Uri RepositoryDeployKey(long repositoryId, int number)
+        public static Uri RepositoryDeployKey(long repositoryId, int deployKeyId)
         {
-            return "repositories/{0}/keys/{1}".FormatUri(repositoryId, number);
+            return "repositories/{0}/keys/{1}".FormatUri(repositoryId, deployKeyId);
         }
 
         /// <summary>
@@ -4162,11 +4162,11 @@ namespace Octokit
         /// <summary>
         /// Returns the <see cref="Uri"/> for deleting a reaction.
         /// </summary>
-        /// <param name="number">The reaction number</param>
+        /// <param name="reactionId">The reaction number</param>
         /// <returns>The <see cref="Uri"/> that lists the watched repositories for the authenticated user.</returns>
-        public static Uri Reactions(int number)
+        public static Uri Reactions(int reactionId)
         {
-            return "reactions/{0}".FormatUri(number);
+            return "reactions/{0}".FormatUri(reactionId);
         }
 
         /// <summary>
@@ -4298,22 +4298,22 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of repo</param>
         /// <param name="repo">The name of repo</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <returns>The <see cref="Uri"/> for pull request review requests.</returns>
-        public static Uri PullRequestReviewRequests(string owner, string repo, int number)
+        public static Uri PullRequestReviewRequests(string owner, string repo, int pullRequestNumber)
         {
-            return "repos/{0}/{1}/pulls/{2}/requested_reviewers".FormatUri(owner, repo, number);
+            return "repos/{0}/{1}/pulls/{2}/requested_reviewers".FormatUri(owner, repo, pullRequestNumber);
         }
 
         /// <summary>
         /// Returns the <see cref="Uri"/> for pull request review requests.
         /// </summary>
         /// <param name="repositoryId">The id of the repository</param>
-        /// <param name="number">The pull request number</param>
+        /// <param name="pullRequestNumber">The pull request number</param>
         /// <returns>The <see cref="Uri"/> for pull request review requests.</returns>
-        public static Uri PullRequestReviewRequests(long repositoryId, int number)
+        public static Uri PullRequestReviewRequests(long repositoryId, int pullRequestNumber)
         {
-            return "repositories/{0}/pulls/{1}/requested_reviewers".FormatUri(repositoryId, number);
+            return "repositories/{0}/pulls/{1}/requested_reviewers".FormatUri(repositoryId, pullRequestNumber);
         }
 
         /// <summary>

--- a/Octokit/Models/Response/ApplicationAuthorization.cs
+++ b/Octokit/Models/Response/ApplicationAuthorization.cs
@@ -14,7 +14,7 @@ namespace Octokit
         {
         }
 
-        public ApplicationAuthorization(int id, string url, Application application, string tokenLastEight, string hashedToken, string fingerprint, string note, string noteUrl, DateTimeOffset createdAt, DateTimeOffset updateAt, string[] scopes, string token)
+        public ApplicationAuthorization(long id, string url, Application application, string tokenLastEight, string hashedToken, string fingerprint, string note, string noteUrl, DateTimeOffset createdAt, DateTimeOffset updateAt, string[] scopes, string token)
             : base(id, url, application, tokenLastEight, hashedToken, fingerprint, note, noteUrl, createdAt, updateAt, scopes)
         {
             Token = token;

--- a/Octokit/Models/Response/Organization.cs
+++ b/Octokit/Models/Response/Organization.cs
@@ -10,7 +10,7 @@ namespace Octokit
     {
         public Organization() { }
 
-        public Organization(string avatarUrl, string bio, string blog, int collaborators, string company, DateTimeOffset createdAt, int diskUsage, string email, int followers, int following, bool? hireable, string htmlUrl, int totalPrivateRepos, int id, string nodeId, string location, string login, string name, int ownedPrivateRepos, Plan plan, int privateGists, int publicGists, int publicRepos, string url, string billingAddress, string reposUrl, string eventsUrl, string hooksUrl, string issuesUrl, string membersUrl, string publicMembersUrl, string description, bool isVerified, bool hasOrganizationProjects, bool hasRepositoryProjects, DateTimeOffset updatedAt)
+        public Organization(string avatarUrl, string bio, string blog, int collaborators, string company, DateTimeOffset createdAt, int diskUsage, string email, int followers, int following, bool? hireable, string htmlUrl, int totalPrivateRepos, long id, string nodeId, string location, string login, string name, int ownedPrivateRepos, Plan plan, int privateGists, int publicGists, int publicRepos, string url, string billingAddress, string reposUrl, string eventsUrl, string hooksUrl, string issuesUrl, string membersUrl, string publicMembersUrl, string description, bool isVerified, bool hasOrganizationProjects, bool hasRepositoryProjects, DateTimeOffset updatedAt)
             : base(avatarUrl, bio, blog, collaborators, company, createdAt, diskUsage, email, followers, following, hireable, htmlUrl, totalPrivateRepos, id, location, login, name, nodeId, ownedPrivateRepos, plan, privateGists, publicGists, publicRepos, AccountType.Organization, url)
         {
             BillingAddress = billingAddress;

--- a/Octokit/Models/Response/PullRequestReviewComment.cs
+++ b/Octokit/Models/Response/PullRequestReviewComment.cs
@@ -15,7 +15,7 @@ namespace Octokit
             Id = id;
         }
 
-        public PullRequestReviewComment(string url, long id, string nodeId, string diffHunk, string path, int? position, int? originalPosition, string commitId, string originalCommitId, User user, string body, DateTimeOffset createdAt, DateTimeOffset updatedAt, string htmlUrl, string pullRequestUrl, ReactionSummary reactions, int? inReplyToId, int? pullRequestReviewId, AuthorAssociation authorAssociation)
+        public PullRequestReviewComment(string url, long id, string nodeId, string diffHunk, string path, int? position, int? originalPosition, string commitId, string originalCommitId, User user, string body, DateTimeOffset createdAt, DateTimeOffset updatedAt, string htmlUrl, string pullRequestUrl, ReactionSummary reactions, long? inReplyToId, long? pullRequestReviewId, AuthorAssociation authorAssociation)
         {
             PullRequestReviewId = pullRequestReviewId;
             Url = url;
@@ -121,12 +121,12 @@ namespace Octokit
         /// <summary>
         /// The Id of the comment this comment replys to.
         /// </summary>
-        public int? InReplyToId { get; private set; }
+        public long? InReplyToId { get; private set; }
 
         /// <summary>
         /// The Id of the pull request this comment belongs to.
         /// </summary>
-        public int? PullRequestReviewId { get; private set; }
+        public long? PullRequestReviewId { get; private set; }
 
         /// <summary>
         /// The comment author association with repository.

--- a/Octokit/Models/Response/User.cs
+++ b/Octokit/Models/Response/User.cs
@@ -14,7 +14,7 @@ namespace Octokit
     {
         public User() { }
 
-        public User(string avatarUrl, string bio, string blog, int collaborators, string company, DateTimeOffset createdAt, DateTimeOffset updatedAt, int diskUsage, string email, int followers, int following, bool? hireable, string htmlUrl, int totalPrivateRepos, int id, string location, string login, string name, string nodeId, int ownedPrivateRepos, Plan plan, int privateGists, int publicGists, int publicRepos, string url, RepositoryPermissions permissions, bool siteAdmin, string ldapDistinguishedName, DateTimeOffset? suspendedAt)
+        public User(string avatarUrl, string bio, string blog, int collaborators, string company, DateTimeOffset createdAt, DateTimeOffset updatedAt, int diskUsage, string email, int followers, int following, bool? hireable, string htmlUrl, int totalPrivateRepos, long id, string location, string login, string name, string nodeId, int ownedPrivateRepos, Plan plan, int privateGists, int publicGists, int publicRepos, string url, RepositoryPermissions permissions, bool siteAdmin, string ldapDistinguishedName, DateTimeOffset? suspendedAt)
             : base(avatarUrl, bio, blog, collaborators, company, createdAt, diskUsage, email, followers, following, hireable, htmlUrl, totalPrivateRepos, id, location, login, name, nodeId, ownedPrivateRepos, plan, privateGists, publicGists, publicRepos, AccountType.User, url)
         {
             Permissions = permissions;


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2893

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The parameter names for numbers are not descriptive and do not represent what they actually are. 
* The types defined in the constructors of some resources were not the appropriate types based on OpenAPI and docs.
 * ApplicationAuthorization
 * Organization
 * User
* PullRequestReviewComment.InReplyToId and PullRequestReviewComment.PullRequestReviewId types were incorrectly defined. They should be long, not int32. 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* All number parameter names have been reworked to represent what they actually are. 
 * ApplicationAuthorization
 * Organization
 * User
* PullRequestReviewComment.InReplyToId and PullRequestReviewComment.PullRequestReviewId types have been corrected to long.

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
