### PR TITLE
BREAKING CHANGE: Use long type for reading PunchCard statistics, just in case

### DIFF
--- a/Octokit.Tests/Clients/StatisticsClientTests.cs
+++ b/Octokit.Tests/Clients/StatisticsClientTests.cs
@@ -417,8 +417,8 @@ namespace Octokit.Tests.Clients
                 var expectedEndPoint = new Uri("repos/owner/name/stats/punch_card", UriKind.Relative);
 
                 var client = Substitute.For<IApiConnection>();
-                IReadOnlyList<int[]> data = new ReadOnlyCollection<int[]>(new[] { new[] { 2, 8, 42 } });
-                client.GetQueuedOperation<int[]>(expectedEndPoint, Args.CancellationToken)
+                IReadOnlyList<long[]> data = new ReadOnlyCollection<long[]>(new[] { new[] { 2L, 8, 42 } });
+                client.GetQueuedOperation<long[]>(expectedEndPoint, Args.CancellationToken)
                     .Returns(Task.FromResult(data));
                 var statisticsClient = new StatisticsClient(client);
 
@@ -436,8 +436,8 @@ namespace Octokit.Tests.Clients
                 var expectedEndPoint = new Uri("repositories/1/stats/punch_card", UriKind.Relative);
 
                 var client = Substitute.For<IApiConnection>();
-                IReadOnlyList<int[]> data = new ReadOnlyCollection<int[]>(new[] { new[] { 2, 8, 42 } });
-                client.GetQueuedOperation<int[]>(expectedEndPoint, Args.CancellationToken)
+                IReadOnlyList<long[]> data = new ReadOnlyCollection<long[]>(new[] { new[] { 2L, 8, 42 } });
+                client.GetQueuedOperation<long[]>(expectedEndPoint, Args.CancellationToken)
                     .Returns(Task.FromResult(data));
                 var statisticsClient = new StatisticsClient(client);
 
@@ -456,9 +456,9 @@ namespace Octokit.Tests.Clients
                 var cancellationToken = new CancellationToken();
 
                 var connection = Substitute.For<IApiConnection>();
-                IReadOnlyList<int[]> data = new ReadOnlyCollection<int[]>(new[] { new[] { 2, 8, 42 } });
+                IReadOnlyList<long[]> data = new ReadOnlyCollection<long[]>(new[] { new[] { 2L, 8, 42 } });
 
-                connection.GetQueuedOperation<int[]>(expectedEndPoint, cancellationToken)
+                connection.GetQueuedOperation<long[]>(expectedEndPoint, cancellationToken)
                     .Returns(Task.FromResult(data));
                 var client = new StatisticsClient(connection);
 
@@ -477,9 +477,9 @@ namespace Octokit.Tests.Clients
                 var cancellationToken = new CancellationToken();
 
                 var connection = Substitute.For<IApiConnection>();
-                IReadOnlyList<int[]> data = new ReadOnlyCollection<int[]>(new[] { new[] { 2, 8, 42 } });
+                IReadOnlyList<long[]> data = new ReadOnlyCollection<long[]>(new[] { new[] { 2L, 8, 42 } });
 
-                connection.GetQueuedOperation<int[]>(expectedEndPoint, cancellationToken)
+                connection.GetQueuedOperation<long[]>(expectedEndPoint, cancellationToken)
                     .Returns(Task.FromResult(data));
                 var client = new StatisticsClient(connection);
 
@@ -502,6 +502,25 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetPunchCard("", "name"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetPunchCard("owner", ""));
             }
+        }
+
+        [Fact]
+        public async Task HandlesGreatBigCountsIfGetQueuedOperationTemplateParameterIsLong()
+        {
+            var expectedEndPoint = new Uri("repos/owner/name/stats/punch_card", UriKind.Relative);
+
+            var client = Substitute.For<IApiConnection>();
+            IReadOnlyList<long[]> data = new ReadOnlyCollection<long[]>(new [] { new [] { 2L, 8L, 42424242424242L } });
+            client.GetQueuedOperation<long[]>(expectedEndPoint, Args.CancellationToken)
+                .Returns(Task.FromResult(data));
+            var statisticsClient = new StatisticsClient(client);
+
+            var result = await statisticsClient.GetPunchCard("owner", "name");
+
+            Assert.Single(result.PunchPoints);
+            Assert.Equal(DayOfWeek.Tuesday, result.PunchPoints[0].DayOfWeek);
+            Assert.Equal(8, result.PunchPoints[0].HourOfTheDay);
+            Assert.Equal(42424242424242L, result.PunchPoints[0].CommitCount);
         }
     }
 }

--- a/Octokit.Tests/Models/PunchCardTests.cs
+++ b/Octokit.Tests/Models/PunchCardTests.cs
@@ -54,10 +54,10 @@ public class PunchCardTests
         [Fact]
         public void SetsPunchPointsAsReadOnlyDictionary()
         {
-            IList<int> point1 = new[] { 1, 0, 3 };
-            IList<int> point2 = new[] { 1, 1, 4 };
-            IList<int> point3 = new[] { 1, 2, 0 };
-            IEnumerable<IList<int>> points = new List<IList<int>> { point1, point2, point3 };
+            IList<long> point1 = new long[] { 1, 0, 3 };
+            IList<long> point2 = new long[] { 1, 1, 4 };
+            IList<long> point3 = new long[] { 1, 2, 0 };
+            IEnumerable<IList<long>> points = new List<IList<long>> { point1, point2, point3 };
 
             var punchCard = new PunchCard(points);
 

--- a/Octokit.Tests/Models/PunchCardTests.cs
+++ b/Octokit.Tests/Models/PunchCardTests.cs
@@ -33,10 +33,10 @@ public class PunchCardTests
         [Fact]
         public void CanQueryCommitsForDayAndHour()
         {
-            IList<int> point1 = new[] { 1, 0, 3 };
-            IList<int> point2 = new[] { 1, 1, 4 };
-            IList<int> point3 = new[] { 1, 2, 0 };
-            IEnumerable<IList<int>> points = new List<IList<int>> { point1, point2, point3 };
+            IList<long> point1 = new long[] { 1, 0, 3 };
+            IList<long> point2 = new long[] { 1, 1, 4 };
+            IList<long> point3 = new long[] { 1, 2, 0 };
+            IEnumerable<IList<long>> points = new List<IList<long>> { point1, point2, point3 };
 
             var punchCard = new PunchCard(points);
 

--- a/Octokit/Clients/StatisticsClient.cs
+++ b/Octokit/Clients/StatisticsClient.cs
@@ -265,7 +265,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            var punchCardData = await ApiConnection.GetQueuedOperation<int[]>(ApiUrls.StatsPunchCard(owner, name), cancellationToken).ConfigureAwait(false);
+            var punchCardData = await ApiConnection.GetQueuedOperation<long[]>(ApiUrls.StatsPunchCard(owner, name), cancellationToken).ConfigureAwait(false);
             return new PunchCard(punchCardData);
         }
 
@@ -277,7 +277,7 @@ namespace Octokit
         [ManualRoute("GET", "/repositories/{id}/stats/punch_card")]
         public async Task<PunchCard> GetPunchCard(long repositoryId, CancellationToken cancellationToken)
         {
-            var punchCardData = await ApiConnection.GetQueuedOperation<int[]>(ApiUrls.StatsPunchCard(repositoryId), cancellationToken).ConfigureAwait(false);
+            var punchCardData = await ApiConnection.GetQueuedOperation<long[]>(ApiUrls.StatsPunchCard(repositoryId), cancellationToken).ConfigureAwait(false);
             return new PunchCard(punchCardData);
         }
     }

--- a/Octokit/Models/Response/PunchCard.cs
+++ b/Octokit/Models/Response/PunchCard.cs
@@ -12,6 +12,13 @@ namespace Octokit
     {
         public PunchCard() { }
 
+        public PunchCard(IEnumerable<IList<int>> punchCardData)
+        {
+            Ensure.ArgumentNotNull(punchCardData, nameof(punchCardData));
+            PunchPoints = new ReadOnlyCollection<PunchCardPoint>(
+            punchCardData.Select(point => new PunchCardPoint(point)).ToList());
+        }
+
         public PunchCard(IEnumerable<IList<long>> punchCardData)
         {
             Ensure.ArgumentNotNull(punchCardData, nameof(punchCardData));

--- a/Octokit/Models/Response/PunchCard.cs
+++ b/Octokit/Models/Response/PunchCard.cs
@@ -12,7 +12,7 @@ namespace Octokit
     {
         public PunchCard() { }
 
-        public PunchCard(IEnumerable<IList<int>> punchCardData)
+        public PunchCard(IEnumerable<IList<long>> punchCardData)
         {
             Ensure.ArgumentNotNull(punchCardData, nameof(punchCardData));
             PunchPoints = new ReadOnlyCollection<PunchCardPoint>(
@@ -36,7 +36,7 @@ namespace Octokit
         /// <param name="dayOfWeek">The day of the week to query</param>
         /// <param name="hourOfDay">The hour in 24 hour time. 0-23.</param>
         /// <returns>The total number of commits made.</returns>
-        public int GetCommitCountFor(DayOfWeek dayOfWeek, int hourOfDay)
+        public long GetCommitCountFor(DayOfWeek dayOfWeek, int hourOfDay)
         {
             var punchPoint = PunchPoints.SingleOrDefault(point => point.DayOfWeek == dayOfWeek && point.HourOfTheDay == hourOfDay);
             return punchPoint == null ? 0 : punchPoint.CommitCount;

--- a/Octokit/Models/Response/PunchCardPoint.cs
+++ b/Octokit/Models/Response/PunchCardPoint.cs
@@ -10,6 +10,18 @@ namespace Octokit
     {
         public PunchCardPoint() { }
 
+        public PunchCardPoint(IList<int> punchPoint)
+        {
+            Ensure.ArgumentNotNull(punchPoint, nameof(punchPoint));
+            if (punchPoint.Count != 3)
+            {
+                throw new ArgumentException("Daily punch card must only contain three data points.");
+            }
+            DayOfWeek = (DayOfWeek)punchPoint[0];
+            HourOfTheDay = punchPoint[1];
+            CommitCount = punchPoint[2];
+        }
+
         public PunchCardPoint(IList<long> punchPoint)
         {
             Ensure.ArgumentNotNull(punchPoint, nameof(punchPoint));

--- a/Octokit/Models/Response/PunchCardPoint.cs
+++ b/Octokit/Models/Response/PunchCardPoint.cs
@@ -10,7 +10,7 @@ namespace Octokit
     {
         public PunchCardPoint() { }
 
-        public PunchCardPoint(IList<int> punchPoint)
+        public PunchCardPoint(IList<long> punchPoint)
         {
             Ensure.ArgumentNotNull(punchPoint, nameof(punchPoint));
             if (punchPoint.Count != 3)
@@ -18,7 +18,7 @@ namespace Octokit
                 throw new ArgumentException("Daily punch card must only contain three data points.");
             }
             DayOfWeek = (DayOfWeek)punchPoint[0];
-            HourOfTheDay = punchPoint[1];
+            HourOfTheDay = (int)punchPoint[1];
             CommitCount = punchPoint[2];
         }
 
@@ -31,7 +31,7 @@ namespace Octokit
 
         public StringEnum<DayOfWeek> DayOfWeek { get; private set; }
         public int HourOfTheDay { get; private set; }
-        public int CommitCount { get; private set; }
+        public long CommitCount { get; private set; }
 
         internal string DebuggerDisplay
         {


### PR DESCRIPTION
Future-proofing. Just because, any time you have an arbitrary statistical counter, there could be some really big counts.

----

### Before the change?
Numeric values deserialize as int32, using StatisticsClient.

### After the change?
Numeric values deserialize as int64, using StatisticsClient.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

I don't see any docs for the PunchCard classes, which are where the API changes are.

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [x] Yes
- [ ] No

PunchCard and PunchCardPoint public constructors accepting the old int array parameter types are added, just for backward compatibility. But the return type of CommitCount and GetCommitCountFor _do_ have to change to long, which I guess is unfortunately, technically breaking.

----
