### PR TITLE
Fix runner group access return type

### DIFF
--- a/Octokit.AsyncPaginationExtension/Extensions.cs
+++ b/Octokit.AsyncPaginationExtension/Extensions.cs
@@ -235,14 +235,6 @@ namespace Octokit.AsyncPaginationExtension
     public static IPaginatedList<Collaborator> GetAllAsync(this IRepoCollaboratorsClient t, long repositoryId, RepositoryCollaboratorListRequest request, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<Collaborator>(options => t.GetAll(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IActionsSelfHostedRunnerGroupsClient.ListAllRunnerGroupOrganizationsForEnterprise(string, long, ApiOptions)"/>
-    public static IPaginatedList<Organization> ListAllRunnerGroupOrganizationsForEnterpriseAsync(this IActionsSelfHostedRunnerGroupsClient t, string enterprise, long runnerGroupId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Organization>(options => t.ListAllRunnerGroupOrganizationsForEnterprise(enterprise, runnerGroupId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
-    /// <inheritdoc cref="IActionsSelfHostedRunnerGroupsClient.ListAllRunnerGroupRepositoriesForOrganization(string, long, ApiOptions)"/>
-    public static IPaginatedList<Repository> ListAllRunnerGroupRepositoriesForOrganizationAsync(this IActionsSelfHostedRunnerGroupsClient t, string org, long runnerGroupId, int pageSize = DEFAULT_PAGE_SIZE)
-        => pageSize > 0 ? new PaginatedList<Repository>(options => t.ListAllRunnerGroupRepositoriesForOrganization(org, runnerGroupId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
-
     /// <inheritdoc cref="IProjectColumnsClient.GetAll(int, ApiOptions)"/>
     public static IPaginatedList<ProjectColumn> GetAllAsync(this IProjectColumnsClient t, int projectId, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<ProjectColumn>(options => t.GetAll(projectId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");

--- a/Octokit.Reactive/Clients/IObservableActionsSelfHostedRunnerGroupsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableActionsSelfHostedRunnerGroupsClient.cs
@@ -117,7 +117,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="enterprise">The enterprise name</param>
         /// <param name="runnerGroupId">The runner group id</param>
-        IObservable<Organization> ListAllRunnerGroupOrganizationsForEnterprise(string enterprise, long runnerGroupId);
+        IObservable<OrganizationsResponse> ListAllRunnerGroupOrganizationsForEnterprise(string enterprise, long runnerGroupId);
 
         /// <summary>
         /// List organization access to a self-hosted runner group in an enterprise
@@ -128,7 +128,7 @@ namespace Octokit.Reactive
         /// <param name="enterprise">The enterprise name</param>
         /// <param name="runnerGroupId">The runner group id</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<Organization> ListAllRunnerGroupOrganizationsForEnterprise(string enterprise, long runnerGroupId, ApiOptions options);
+        IObservable<OrganizationsResponse> ListAllRunnerGroupOrganizationsForEnterprise(string enterprise, long runnerGroupId, ApiOptions options);
 
         /// <summary>
         /// List repository access to a self-hosted runner group in an organization
@@ -138,7 +138,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="org">The organization name</param>
         /// <param name="runnerGroupId">The runner group id</param>
-        IObservable<Repository> ListAllRunnerGroupRepositoriesForOrganization(string org, long runnerGroupId);
+        IObservable<RepositoriesResponse> ListAllRunnerGroupRepositoriesForOrganization(string org, long runnerGroupId);
 
         /// <summary>
         /// List repository access to a self-hosted runner group in an organization
@@ -149,7 +149,7 @@ namespace Octokit.Reactive
         /// <param name="org">The organization name</param>
         /// <param name="runnerGroupId">The runner group id</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<Repository> ListAllRunnerGroupRepositoriesForOrganization(string org, long runnerGroupId, ApiOptions options);
+        IObservable<RepositoriesResponse> ListAllRunnerGroupRepositoriesForOrganization(string org, long runnerGroupId, ApiOptions options);
 
     }
 }

--- a/Octokit.Reactive/Clients/ObservableActionsSelfHostedRunnerGroupsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableActionsSelfHostedRunnerGroupsClient.cs
@@ -175,7 +175,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="enterprise">The enterprise name</param>
         /// <param name="runnerGroupId">The runner group ID</param>
-        public IObservable<Organization> ListAllRunnerGroupOrganizationsForEnterprise(string enterprise, long runnerGroupId)
+        public IObservable<OrganizationsResponse> ListAllRunnerGroupOrganizationsForEnterprise(string enterprise, long runnerGroupId)
         {
             return ListAllRunnerGroupOrganizationsForEnterprise(enterprise, runnerGroupId, ApiOptions.None);
         }
@@ -189,12 +189,12 @@ namespace Octokit.Reactive
         /// <param name="enterprise">The enterprise name</param>
         /// <param name="runnerGroupId">The runner group ID</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<Organization> ListAllRunnerGroupOrganizationsForEnterprise(string enterprise, long runnerGroupId, ApiOptions options)
+        public IObservable<OrganizationsResponse> ListAllRunnerGroupOrganizationsForEnterprise(string enterprise, long runnerGroupId, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(enterprise, nameof(enterprise));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return _connection.GetAndFlattenAllPages<Organization>(ApiUrls.ActionsListEnterpriseRunnerGroupOrganizations(enterprise, runnerGroupId), options);
+            return _client.ListAllRunnerGroupOrganizationsForEnterprise(enterprise, runnerGroupId, options).ToObservable();
         }
 
         /// <summary>
@@ -205,7 +205,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="org">The organization name</param>
         /// <param name="runnerGroupId">The runner group ID</param>
-        public IObservable<Repository> ListAllRunnerGroupRepositoriesForOrganization(string org, long runnerGroupId)
+        public IObservable<RepositoriesResponse> ListAllRunnerGroupRepositoriesForOrganization(string org, long runnerGroupId)
         {
             return ListAllRunnerGroupRepositoriesForOrganization(org, runnerGroupId, ApiOptions.None);
         }
@@ -219,12 +219,12 @@ namespace Octokit.Reactive
         /// <param name="org">The organization name</param>
         /// <param name="runnerGroupId">The runner group ID</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<Repository> ListAllRunnerGroupRepositoriesForOrganization(string org, long runnerGroupId, ApiOptions options)
+        public IObservable<RepositoriesResponse> ListAllRunnerGroupRepositoriesForOrganization(string org, long runnerGroupId, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return _connection.GetAndFlattenAllPages<Repository>(ApiUrls.ActionsListOrganizationRunnerGroupRepositories(org, runnerGroupId), options);
+            return _client.ListAllRunnerGroupRepositoriesForOrganization(org, runnerGroupId, options).ToObservable();
         }
 
     }

--- a/Octokit.Tests/Clients/ActionsSelfHostedRunnerGroupsClientTests.cs
+++ b/Octokit.Tests/Clients/ActionsSelfHostedRunnerGroupsClientTests.cs
@@ -217,7 +217,7 @@ namespace Octokit.Tests.Clients
 
                 await client.ListAllRunnerGroupOrganizationsForEnterprise("fake", 1);
 
-                connection.Received().GetAll<Organization>(
+                connection.Received().GetAll<OrganizationsResponse>(
                   Arg.Is<Uri>(u => u.ToString() == "enterprises/fake/actions/runner-groups/1/organizations"), Args.ApiOptions);
             }
 
@@ -248,7 +248,7 @@ namespace Octokit.Tests.Clients
 
                 await client.ListAllRunnerGroupRepositoriesForOrganization("fake", 1, ApiOptions.None);
 
-                connection.Received().GetAll<Repository>(
+                connection.Received().GetAll<RepositoriesResponse>(
                   Arg.Is<Uri>(u => u.ToString() == "orgs/fake/actions/runner-groups/1/repositories"), Args.ApiOptions);
             }
 

--- a/Octokit/Clients/ActionsSelfHostedRunnerGroupsClient.cs
+++ b/Octokit/Clients/ActionsSelfHostedRunnerGroupsClient.cs
@@ -203,7 +203,7 @@ namespace Octokit
         /// <param name="enterprise">The enterprise name</param>
         /// <param name="runnerGroupId">The runner group id</param>
         [ManualRoute("GET", "/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations")]
-        public Task<IReadOnlyList<Organization>> ListAllRunnerGroupOrganizationsForEnterprise(string enterprise, long runnerGroupId)
+        public Task<OrganizationsResponse> ListAllRunnerGroupOrganizationsForEnterprise(string enterprise, long runnerGroupId)
         {
             return ListAllRunnerGroupOrganizationsForEnterprise(enterprise, runnerGroupId, ApiOptions.None);
         }
@@ -218,11 +218,16 @@ namespace Octokit
         /// <param name="runnerGroupId">The runner group id</param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations")]
-        public Task<IReadOnlyList<Organization>> ListAllRunnerGroupOrganizationsForEnterprise(string enterprise, long runnerGroupId, ApiOptions options)
+        public async Task<OrganizationsResponse> ListAllRunnerGroupOrganizationsForEnterprise(string enterprise, long runnerGroupId, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(enterprise, nameof(enterprise));
 
-            return ApiConnection.GetAll<Organization>(ApiUrls.ActionsListEnterpriseRunnerGroupOrganizations(enterprise, runnerGroupId), options);
+            var results = await ApiConnection.GetAll<OrganizationsResponse>(ApiUrls.ActionsListEnterpriseRunnerGroupOrganizations(enterprise, runnerGroupId), options).ConfigureAwait(false);
+
+            return new OrganizationsResponse(
+              results.Count > 0 ? results.Max(x => x.TotalCount) : 0,
+              results.SelectMany(x => x.Organizations).ToList()
+            );
         }
 
         /// <summary>
@@ -234,7 +239,7 @@ namespace Octokit
         /// <param name="org">The organization name</param>
         /// <param name="runnerGroupId">The runner group id</param>
         [ManualRoute("GET", "/orgs/{org}/actions/runner-groups/{runner_group_id}/repositories")]
-        public Task<IReadOnlyList<Repository>> ListAllRunnerGroupRepositoriesForOrganization(string org, long runnerGroupId)
+        public Task<RepositoriesResponse> ListAllRunnerGroupRepositoriesForOrganization(string org, long runnerGroupId)
         {
             return ListAllRunnerGroupRepositoriesForOrganization(org, runnerGroupId, ApiOptions.None);
         }
@@ -249,11 +254,16 @@ namespace Octokit
         /// <param name="runnerGroupId">The runner group id</param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/orgs/{org}/actions/runner-groups/{runner_group_id}/repositories")]
-        public Task<IReadOnlyList<Repository>> ListAllRunnerGroupRepositoriesForOrganization(string org, long runnerGroupId, ApiOptions options)
+        public async Task<RepositoriesResponse> ListAllRunnerGroupRepositoriesForOrganization(string org, long runnerGroupId, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
 
-            return ApiConnection.GetAll<Repository>(ApiUrls.ActionsListOrganizationRunnerGroupRepositories(org, runnerGroupId), options);
+            var results = await ApiConnection.GetAll<RepositoriesResponse>(ApiUrls.ActionsListOrganizationRunnerGroupRepositories(org, runnerGroupId), options).ConfigureAwait(false);
+
+            return new RepositoriesResponse(
+              results.Count > 0 ? results.Max(x => x.TotalCount) : 0,
+              results.SelectMany(x => x.Repositories).ToList()
+            );
         }
   }
 }

--- a/Octokit/Clients/IActionsSelfHostedRunnerGroupsClient.cs
+++ b/Octokit/Clients/IActionsSelfHostedRunnerGroupsClient.cs
@@ -119,7 +119,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="enterprise">The enterprise name</param>
         /// <param name="runnerGroupId">The runner group id</param>
-        Task<IReadOnlyList<Organization>> ListAllRunnerGroupOrganizationsForEnterprise(string enterprise, long runnerGroupId);
+        Task<OrganizationsResponse> ListAllRunnerGroupOrganizationsForEnterprise(string enterprise, long runnerGroupId);
 
         /// <summary>
         /// List organization access to a self-hosted runner group in an enterprise
@@ -130,7 +130,7 @@ namespace Octokit
         /// <param name="enterprise">The enterprise name</param>
         /// <param name="runnerGroupId">The runner group id</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<Organization>> ListAllRunnerGroupOrganizationsForEnterprise(string enterprise, long runnerGroupId, ApiOptions options);
+        Task<OrganizationsResponse> ListAllRunnerGroupOrganizationsForEnterprise(string enterprise, long runnerGroupId, ApiOptions options);
 
         /// <summary>
         /// List repository access to a self-hosted runner group in an organization
@@ -140,7 +140,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="org">The organization name</param>
         /// <param name="runnerGroupId">The runner group id</param>
-        Task<IReadOnlyList<Repository>> ListAllRunnerGroupRepositoriesForOrganization(string org, long runnerGroupId);
+        Task<RepositoriesResponse> ListAllRunnerGroupRepositoriesForOrganization(string org, long runnerGroupId);
 
         /// <summary>
         /// List repository access to a self-hosted runner group in an organization
@@ -151,6 +151,6 @@ namespace Octokit
         /// <param name="org">The organization name</param>
         /// <param name="runnerGroupId">The runner group id</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<Repository>> ListAllRunnerGroupRepositoriesForOrganization(string org, long runnerGroupId, ApiOptions options);
+        Task<RepositoriesResponse> ListAllRunnerGroupRepositoriesForOrganization(string org, long runnerGroupId, ApiOptions options);
     }
 }

--- a/Octokit/Models/Response/OrganizationsResponse.cs
+++ b/Octokit/Models/Response/OrganizationsResponse.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace Octokit
+{
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class OrganizationsResponse
+    {
+        public OrganizationsResponse()
+        {
+        }
+
+        public OrganizationsResponse(int totalCount, IReadOnlyList<Repository> organizations)
+        {
+            TotalCount = totalCount;
+            Organizations = organizations;
+        }
+
+        /// <summary>
+        /// The total number of organizations
+        /// </summary>
+        public int TotalCount { get; private set; }
+
+        /// <summary>
+        /// The retrieved organizations
+        /// </summary>
+        public IReadOnlyList<Repository> Organizations { get; private set; }
+
+        internal string DebuggerDisplay => string.Format(CultureInfo.CurrentCulture, "TotalCount: {0}, Organizations: {1}", TotalCount, Organizations.Count);
+    }
+}

--- a/Octokit/Models/Response/RepositoriesResponse.cs
+++ b/Octokit/Models/Response/RepositoriesResponse.cs
@@ -18,12 +18,12 @@ namespace Octokit
         }
 
         /// <summary>
-        /// The total number of check suites that match the request filter
+        /// The total number of repositories
         /// </summary>
         public int TotalCount { get; private set; }
 
         /// <summary>
-        /// The retrieved check suites
+        /// The retrieved repositories
         /// </summary>
         public IReadOnlyList<Repository> Repositories { get; private set; }
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2964

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Runner group access APIs would return empty objects because they weren't wrapped in a response object

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Runner group access APIs return properly deserialized responses

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

I didn't see existing tests for deserialization, but I'm happy to add tests if there is an established pattern to follow.

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [x] Yes
- [ ] No

The return type of several functions changed (although these functions would have returned empty objects before)

----
