### PR TITLE
Reduce string allocations during SimpleJson.ParseString

### DIFF
--- a/Octokit.Tests/SimpleJsonTests.cs
+++ b/Octokit.Tests/SimpleJsonTests.cs
@@ -1,0 +1,36 @@
+﻿using Octokit;
+using System.Threading.Tasks;
+using Xunit;
+
+public class SimpleJsonTests
+{
+    [Theory]
+    [InlineData("\"abc\"", "abc")]
+    [InlineData(" \"abc\" ", "abc")]
+    [InlineData("\" abc \" ", " abc ")]
+    [InlineData("\"abc\\\"def\"", "abc\"def")]
+    [InlineData("\"abc\\r\\ndef\"", "abc\r\ndef")]
+    public async Task ParseStringSuccess(string input, string expected)
+    {
+        int index = 0;
+        bool success = true;
+
+        string actual = SimpleJson.ParseString(input.ToCharArray(), ref index, ref success);
+
+        Assert.True(success);
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData("\"abc")]
+    public async Task ParseStringIncomplete(string input)
+    {
+        int index = 0;
+        bool success = true;
+
+        string actual = SimpleJson.ParseString(input.ToCharArray(), ref index, ref success);
+
+        Assert.False(success);
+        Assert.Null(actual);
+    }
+}


### PR DESCRIPTION
Noticed this allocation while looking at a profile of solution load in visual studio. These StringBuilder allocations were showing up as 0.5% of total allocations. I took a peek at the code, and reaslized the StringBuilder need not be created unless there is a '\' in the string value being parsed. In that case, just copy already seen characters into a StringBuilder and continue as previously.

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves [2976](https://github.com/octokit/octokit.net/issues/2976)

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* String parsing was always allocating a StringBuilder.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Changed to only allocate if there are escaped characters in the json.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
