### PR TITLE
Add optional cancellation token for oauth client

### DIFF
--- a/Octokit.Reactive/Clients/IObservableOauthClient.cs
+++ b/Octokit.Reactive/Clients/IObservableOauthClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 
 namespace Octokit.Reactive
 {
@@ -22,8 +23,9 @@ namespace Octokit.Reactive
         /// an access token using this method.
         /// </remarks>
         /// <param name="request"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        IObservable<OauthToken> CreateAccessToken(OauthTokenRequest request);
+        IObservable<OauthToken> CreateAccessToken(OauthTokenRequest request, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Makes a request to initiate the device flow authentication.
@@ -33,25 +35,28 @@ namespace Octokit.Reactive
         /// This request also returns a device verification code that you must use to receive an access token to check the status of user authentication.
         /// </remarks>
         /// <param name="request"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        IObservable<OauthDeviceFlowResponse> InitiateDeviceFlow(OauthDeviceFlowRequest request);
+        IObservable<OauthDeviceFlowResponse> InitiateDeviceFlow(OauthDeviceFlowRequest request, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Makes a request to get an access token using the response from <see cref="InitiateDeviceFlow(OauthDeviceFlowRequest)"/>.
+        /// Makes a request to get an access token using the response from <see cref="InitiateDeviceFlow(OauthDeviceFlowRequest, CancellationToken)"/>.
         /// </summary>
         /// <remarks>
         /// Will poll the access token endpoint, until the device and user codes expire or the user has successfully authorized the app with a valid user code.
         /// </remarks>
         /// <param name="clientId">The client Id you received from GitHub when you registered the application.</param>
-        /// <param name="deviceFlowResponse">The response you received from <see cref="InitiateDeviceFlow(OauthDeviceFlowRequest)"/></param>
+        /// <param name="deviceFlowResponse">The response you received from <see cref="InitiateDeviceFlow(OauthDeviceFlowRequest, CancellationToken)"/></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        IObservable<OauthToken> CreateAccessTokenForDeviceFlow(string clientId, OauthDeviceFlowResponse deviceFlowResponse);
+        IObservable<OauthToken> CreateAccessTokenForDeviceFlow(string clientId, OauthDeviceFlowResponse deviceFlowResponse, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Makes a request to get an access token using the refresh token returned in <see cref="CreateAccessToken(OauthTokenRequest)"/>.
+        /// Makes a request to get an access token using the refresh token returned in <see cref="CreateAccessToken(OauthTokenRequest, CancellationToken)"/>.
         /// </summary>
         /// <param name="request">Token renewal request.</param>
+        /// <param name="cancellationToken"></param>
         /// <returns><see cref="OauthToken"/> with the new token set.</returns>
-        IObservable<OauthToken> CreateAccessTokenFromRenewalToken(OauthTokenRenewalRequest request);
+        IObservable<OauthToken> CreateAccessTokenFromRenewalToken(OauthTokenRenewalRequest request, CancellationToken cancellationToken = default);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableOauthClient.cs
+++ b/Octokit.Reactive/Clients/ObservableOauthClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reactive.Threading.Tasks;
+using System.Threading;
 
 namespace Octokit.Reactive
 {
@@ -23,24 +24,24 @@ namespace Octokit.Reactive
             return _client.Oauth.GetGitHubLoginUrl(request);
         }
 
-        public IObservable<OauthToken> CreateAccessToken(OauthTokenRequest request)
+        public IObservable<OauthToken> CreateAccessToken(OauthTokenRequest request, CancellationToken cancellationToken = default)
         {
-            return _client.Oauth.CreateAccessToken(request).ToObservable();
+            return _client.Oauth.CreateAccessToken(request, cancellationToken).ToObservable();
         }
 
-        public IObservable<OauthDeviceFlowResponse> InitiateDeviceFlow(OauthDeviceFlowRequest request)
+        public IObservable<OauthDeviceFlowResponse> InitiateDeviceFlow(OauthDeviceFlowRequest request, CancellationToken cancellationToken = default)
         {
-            return _client.Oauth.InitiateDeviceFlow(request).ToObservable();
+            return _client.Oauth.InitiateDeviceFlow(request, cancellationToken).ToObservable();
         }
 
-        public IObservable<OauthToken> CreateAccessTokenForDeviceFlow(string clientId, OauthDeviceFlowResponse deviceFlowResponse)
+        public IObservable<OauthToken> CreateAccessTokenForDeviceFlow(string clientId, OauthDeviceFlowResponse deviceFlowResponse, CancellationToken cancellationToken = default)
         {
-            return _client.Oauth.CreateAccessTokenForDeviceFlow(clientId, deviceFlowResponse).ToObservable();
+            return _client.Oauth.CreateAccessTokenForDeviceFlow(clientId, deviceFlowResponse, cancellationToken).ToObservable();
         }
 
-        public IObservable<OauthToken> CreateAccessTokenFromRenewalToken(OauthTokenRenewalRequest request)
+        public IObservable<OauthToken> CreateAccessTokenFromRenewalToken(OauthTokenRenewalRequest request, CancellationToken cancellationToken = default)
         {
-            return _client.Oauth.CreateAccessTokenFromRenewalToken(request)
+            return _client.Oauth.CreateAccessTokenFromRenewalToken(request, cancellationToken)
                 .ToObservable();
         }
     }

--- a/Octokit/Clients/IOAuthClient.cs
+++ b/Octokit/Clients/IOAuthClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Octokit
@@ -26,8 +27,9 @@ namespace Octokit
         /// an access token using this method.
         /// </remarks>
         /// <param name="request"></param>
+        /// <param name="concellationToken"></param>
         /// <returns></returns>
-        Task<OauthToken> CreateAccessToken(OauthTokenRequest request);
+        Task<OauthToken> CreateAccessToken(OauthTokenRequest request, CancellationToken concellationToken = default);
 
         /// <summary>
         /// Makes a request to initiate the device flow authentication.
@@ -37,25 +39,28 @@ namespace Octokit
         /// This request also returns a device verification code that you must use to receive an access token to check the status of user authentication.
         /// </remarks>
         /// <param name="request"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<OauthDeviceFlowResponse> InitiateDeviceFlow(OauthDeviceFlowRequest request);
+        Task<OauthDeviceFlowResponse> InitiateDeviceFlow(OauthDeviceFlowRequest request, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Makes a request to get an access token using the response from <see cref="InitiateDeviceFlow(OauthDeviceFlowRequest)"/>.
+        /// Makes a request to get an access token using the response from <see cref="InitiateDeviceFlow(OauthDeviceFlowRequest, CancellationToken)"/>.
         /// </summary>
         /// <remarks>
         /// Will poll the access token endpoint, until the device and user codes expire or the user has successfully authorized the app with a valid user code.
         /// </remarks>
         /// <param name="clientId">The client Id you received from GitHub when you registered the application.</param>
-        /// <param name="deviceFlowResponse">The response you received from <see cref="InitiateDeviceFlow(OauthDeviceFlowRequest)"/></param>
+        /// <param name="deviceFlowResponse">The response you received from <see cref="InitiateDeviceFlow(OauthDeviceFlowRequest, CancellationToken)"/></param>
+        /// <param name="concellationToken"></param>
         /// <returns></returns>
-        Task<OauthToken> CreateAccessTokenForDeviceFlow(string clientId, OauthDeviceFlowResponse deviceFlowResponse);
+        Task<OauthToken> CreateAccessTokenForDeviceFlow(string clientId, OauthDeviceFlowResponse deviceFlowResponse, CancellationToken concellationToken = default);
 
         /// <summary>
-        /// Makes a request to get an access token using the refresh token returned in <see cref="CreateAccessToken(OauthTokenRequest)"/>.
+        /// Makes a request to get an access token using the refresh token returned in <see cref="CreateAccessToken(OauthTokenRequest, CancellationToken)"/>.
         /// </summary>
         /// <param name="request">Token renewal request.</param>
+        /// <param name="concellationToken"></param>
         /// <returns><see cref="OauthToken"/> with the new token set.</returns>
-        Task<OauthToken> CreateAccessTokenFromRenewalToken(OauthTokenRenewalRequest request);
+        Task<OauthToken> CreateAccessTokenFromRenewalToken(OauthTokenRenewalRequest request, CancellationToken concellationToken = default);
     }
 }


### PR DESCRIPTION
I did not make an issue, but there is already multiples PR for other parts of the codebase so I guess this is fine?

----

### Before the change?
We could never cancel login requests (especially device flow requests, which waits for the user to do something in a browser window).

### After the change?
We can now cancel such requests.

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
- [ ] Yes
- [x] No

----
