### PR TITLE
getting-started.md: Replace user.Url with user.HtmlUrl

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -58,7 +58,7 @@ var user = await client.User.Get("shiftkey");
 Console.WriteLine("{0} has {1} public repositories - go check out their profile at {2}",
 	user.Name,
 	user.PublicRepos,
-	user.Url);
+	user.HtmlUrl);
 ```
 
 If you've authenticated as a given user, you can query their details directly:


### PR DESCRIPTION
The `HtmlUrl` user property should be used rather than `Url` to view a user's profile link. The documentation explains that the code sample will provide a link to the user's profile page. 

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
No issues resolved that I am aware of but it provides the appropriate link to view a user's profile page.

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Output of `user.Url` returns a link that displays available API property values for the specified user.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Output of `user.HtmlUrl` returns a link to the specified user's profile page.

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
