### PR TITLE
[Fix] Fix route for TeamPermissionsForARepository()

### DIFF
--- a/Octokit.Tests/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests/Clients/TeamsClientTests.cs
@@ -494,7 +494,7 @@ namespace Octokit.Tests.Clients
 
                 await client.CheckTeamPermissionsForARepository("org", "teamSlug", "owner", "repo");
 
-                var expected = "/orgs/org/teams/teamSlug/repos/owner/repo";
+                var expected = "orgs/org/teams/teamSlug/repos/owner/repo";
 
                 connection.Received().Get<TeamRepository>(Arg.Is<Uri>(u => u.ToString() == expected));
             }
@@ -508,13 +508,13 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new TeamsClient(connection);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => 
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
                     client.CheckTeamPermissionsForARepositoryWithCustomAcceptHeader(null, "teamSlug", "owner", "repo"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => 
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
                     client.CheckTeamPermissionsForARepositoryWithCustomAcceptHeader("org", null, "owner", "repo"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => 
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
                     client.CheckTeamPermissionsForARepositoryWithCustomAcceptHeader("org", "teamSlug", null, "repo"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => 
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
                     client.CheckTeamPermissionsForARepositoryWithCustomAcceptHeader("org", "teamSlug", "owner", null));
             }
 
@@ -526,7 +526,7 @@ namespace Octokit.Tests.Clients
 
                 await client.CheckTeamPermissionsForARepositoryWithCustomAcceptHeader("org", "teamSlug", "owner", "repo");
 
-                var expected = "/orgs/org/teams/teamSlug/repos/owner/repo";
+                var expected = "orgs/org/teams/teamSlug/repos/owner/repo";
 
                 connection.Received().Get<TeamRepository>(
                     Arg.Is<Uri>(u => u.ToString() == expected),
@@ -569,7 +569,7 @@ namespace Octokit.Tests.Clients
 
                 await client.AddOrUpdateTeamRepositoryPermissions("org", "teamSlug", "owner", "repo", permission);
 
-                var expected = "/orgs/org/teams/teamSlug/repos/owner/repo";
+                var expected = "orgs/org/teams/teamSlug/repos/owner/repo";
 
                 connection.Received().Put(
                     Arg.Is<Uri>(u => u.ToString() == expected),
@@ -613,12 +613,12 @@ namespace Octokit.Tests.Clients
 
                 await client.RemoveRepositoryFromATeam("org", "teamSlug", "owner", "repo");
 
-                var expected = "/orgs/org/teams/teamSlug/repos/owner/repo";
+                var expected = "orgs/org/teams/teamSlug/repos/owner/repo";
 
                 connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == expected));
             }
         }
-        
+
         public class TheGetByNameMethod
         {
             [Fact]

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -2057,7 +2057,7 @@ namespace Octokit
         /// <param name="repo">The name of the repository. The name is not case sensitive.</param>
         public static Uri TeamPermissionsForARepository(string org, string teamId, string owner, string repo)
         {
-            return "/orgs/{0}/teams/{1}/repos/{2}/{3}".FormatUri(org, teamId, owner, repo);
+            return "orgs/{0}/teams/{1}/repos/{2}/{3}".FormatUri(org, teamId, owner, repo);
         }
 
         /// <summary>


### PR DESCRIPTION
The leading slash resulted in ApiValidationExceptions when attempting to add a team to a repository.

Resolves #3002 

In Octokit/Helpers/ApiUrls.cs, method TeamPermissionsForARepository() returns an erroneous leading slash in the URI it constructs; this leads methods that use it to fail as described below. This should instead be a relative URI like all other methods in the class (with the exception of EnterpriseManagementConsoleMaintenance() which is a documented special case).

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* All requests to orgs/{org}/teams/{team}/repos/{owner}/{repo} fail with an ApiValidationException.
* URL sent on the wire is of the form [https://example.com/orgs/{org}/teams/{team}/repos/{owner}/{repo}](https://example.com/orgs/%7Borg%7D/teams/%7Bteam%7D/repos/%7Bowner%7D/%7Brepo%7D)
* User is unable to add or remove teams from a repository.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* PUT requests to orgs/{org}/teams/{team}/repos/{owner}/{repo} succeed as expected.
* URL sent on the wire is of the form [https://example.com/api/v3/orgs/{org}/teams/{team}/repos/{owner}/{repo}](https://example.com/api/v3/orgs/%7Borg%7D/teams/%7Bteam%7D/repos/%7Bowner%7D/%7Brepo%7D)
* User is able to add or remove teams from a repository.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

Tests have been updated/fixed as well.
No documentation impacts that I can tell.

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
