### PR TITLE
[WIP] Return RepositoryContentChangeSet from RepositoryContentsClient.DeleteFile

### DIFF
--- a/Octokit.Reactive/Clients/IObservableRepositoryContentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryContentsClient.cs
@@ -247,7 +247,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to delete</param>
-        IObservable<Unit> DeleteFile(string owner, string name, string path, DeleteFileRequest request);
+        IObservable<RepositoryContentChangeSet> DeleteFile(string owner, string name, string path, DeleteFileRequest request);
 
         /// <summary>
         /// Creates a commit that deletes a file in a repository.
@@ -255,6 +255,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to delete</param>
-        IObservable<Unit> DeleteFile(long repositoryId, string path, DeleteFileRequest request);
+        IObservable<RepositoryContentChangeSet> DeleteFile(long repositoryId, string path, DeleteFileRequest request);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableRepositoryContentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryContentsClient.cs
@@ -431,7 +431,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to delete</param>
-        public IObservable<Unit> DeleteFile(string owner, string name, string path, DeleteFileRequest request)
+        public IObservable<RepositoryContentChangeSet> DeleteFile(string owner, string name, string path, DeleteFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -447,7 +447,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to delete</param>
-        public IObservable<Unit> DeleteFile(long repositoryId, string path, DeleteFileRequest request)
+        public IObservable<RepositoryContentChangeSet> DeleteFile(long repositoryId, string path, DeleteFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(path, nameof(path));
             Ensure.ArgumentNotNull(request, nameof(request));

--- a/Octokit.Tests.Integration/Clients/RepositoryContentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryContentsClientTests.cs
@@ -352,11 +352,12 @@ namespace Octokit.Tests.Integration.Clients
                 Assert.Equal("New Content", contents.First().Content);
                 fileSha = contents.First().Sha;
 
-                await fixture.DeleteFile(
+                var delete = await fixture.DeleteFile(
                     repository.Owner.Login,
                     repository.Name,
                     "somefile.txt",
                     new DeleteFileRequest("Deleted file", fileSha));
+                Assert.Equal("Deleted file", delete.Commit.Message);
 
                 await Assert.ThrowsAsync<NotFoundException>(
                      () => fixture.GetAllContents(repository.Owner.Login, repository.Name, "somefile.txt"));
@@ -394,10 +395,11 @@ namespace Octokit.Tests.Integration.Clients
                 Assert.Equal("New Content", contents.First().Content);
                 fileSha = contents.First().Sha;
 
-                await fixture.DeleteFile(
+                var delete = await fixture.DeleteFile(
                     repository.Id,
                     "somefile.txt",
                     new DeleteFileRequest("Deleted file", fileSha));
+                Assert.Equal("Deleted file", delete.Commit.Message);
 
                 await Assert.ThrowsAsync<NotFoundException>(
                      () => fixture.GetAllContents(repository.Owner.Login, repository.Name, "somefile.txt"));
@@ -440,11 +442,12 @@ namespace Octokit.Tests.Integration.Clients
                 Assert.Equal("New Content", contents.First().Content);
                 fileSha = contents.First().Sha;
 
-                await fixture.DeleteFile(
+                var delete = await fixture.DeleteFile(
                     repository.Owner.Login,
                     repository.Name,
                     "somefile.txt",
                     new DeleteFileRequest("Deleted file", fileSha, branchName));
+                Assert.Equal("Deleted file", delete.Commit.Message);
 
                 await Assert.ThrowsAsync<NotFoundException>(
                     () => fixture.GetAllContents(repository.Owner.Login, repository.Name, "somefile.txt"));
@@ -485,10 +488,11 @@ namespace Octokit.Tests.Integration.Clients
                 Assert.Equal("New Content", contents.First().Content);
                 fileSha = contents.First().Sha;
 
-                await fixture.DeleteFile(
+                var delete = await fixture.DeleteFile(
                     repository.Id,
                     "somefile.txt",
                     new DeleteFileRequest("Deleted file", fileSha, branchName));
+                Assert.Equal("Deleted file", delete.Commit.Message);
 
                 await Assert.ThrowsAsync<NotFoundException>(
                     () => fixture.GetAllContents(repository.Owner.Login, repository.Name, "somefile.txt"));
@@ -528,11 +532,12 @@ namespace Octokit.Tests.Integration.Clients
                 Assert.Equal("New Content", contents.First().Content);
                 fileSha = contents.First().Sha;
 
-                await fixture.DeleteFile(
+                var delete = await fixture.DeleteFile(
                     repository.Owner.Login,
                     repository.Name,
                     "somefile.txt",
                     new DeleteFileRequest("Deleted file", fileSha));
+                Assert.Equal("Deleted file", delete.Commit.Message);
 
                 await Assert.ThrowsAsync<NotFoundException>(
                      () => fixture.GetAllContents(repository.Owner.Login, repository.Name, "somefile.txt"));
@@ -570,10 +575,11 @@ namespace Octokit.Tests.Integration.Clients
                 Assert.Equal("New Content", contents.First().Content);
                 fileSha = contents.First().Sha;
 
-                await fixture.DeleteFile(
+                var delete = await fixture.DeleteFile(
                     repository.Id,
                     "somefile.txt",
                     new DeleteFileRequest("Deleted file", fileSha));
+                Assert.Equal("Deleted file", delete.Commit.Message);
 
                 await Assert.ThrowsAsync<NotFoundException>(
                      () => fixture.GetAllContents(repository.Owner.Login, repository.Name, "somefile.txt"));
@@ -616,11 +622,12 @@ namespace Octokit.Tests.Integration.Clients
                 Assert.Equal("New Content", contents.First().Content);
                 fileSha = contents.First().Sha;
 
-                await fixture.DeleteFile(
+                var delete = await fixture.DeleteFile(
                     repository.Owner.Login,
                     repository.Name,
                     "somefile.txt",
                     new DeleteFileRequest("Deleted file", fileSha, branchName));
+                Assert.Equal("Deleted file", delete.Commit.Message);
 
                 await Assert.ThrowsAsync<NotFoundException>(
                     () => fixture.GetAllContents(repository.Owner.Login, repository.Name, "somefile.txt"));
@@ -661,10 +668,11 @@ namespace Octokit.Tests.Integration.Clients
                 Assert.Equal("New Content", contents.First().Content);
                 fileSha = contents.First().Sha;
 
-                await fixture.DeleteFile(
+                var delete = await fixture.DeleteFile(
                     repository.Id,
                     "somefile.txt",
                     new DeleteFileRequest("Deleted file", fileSha, branchName));
+                Assert.Equal("Deleted file", delete.Commit.Message);
 
                 await Assert.ThrowsAsync<NotFoundException>(
                     () => fixture.GetAllContents(repository.Owner.Login, repository.Name, "somefile.txt"));

--- a/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
@@ -528,7 +528,7 @@ namespace Octokit.Tests.Clients
                 string expectedUri = "repos/org/repo/contents/path/to/file";
                 await client.DeleteFile("org", "repo", "path/to/file", new DeleteFileRequest("message", "1234abc", "mybranch"));
 
-                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+                connection.Received().Delete<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
             }
 
             [Fact]
@@ -540,7 +540,7 @@ namespace Octokit.Tests.Clients
                 string expectedUri = "repositories/1/contents/path/to/file";
                 await client.DeleteFile(1, "path/to/file", new DeleteFileRequest("message", "1234abc", "mybranch"));
 
-                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+                connection.Received().Delete<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
             }
 
             [Fact]
@@ -551,7 +551,7 @@ namespace Octokit.Tests.Clients
 
                 await client.DeleteFile("org", "repo", "path/to/file", new DeleteFileRequest("message", "1234abc", "mybranch"));
 
-                connection.Received().Delete(
+                connection.Received().Delete<RepositoryContentChangeSet>(
                     Arg.Any<Uri>(),
                     Arg.Is<DeleteFileRequest>(a =>
                         a.Message == "message"
@@ -567,7 +567,7 @@ namespace Octokit.Tests.Clients
 
                 await client.DeleteFile(1, "path/to/file", new DeleteFileRequest("message", "1234abc", "mybranch"));
 
-                connection.Received().Delete(
+                connection.Received().Delete<RepositoryContentChangeSet>(
                     Arg.Any<Uri>(),
                     Arg.Is<DeleteFileRequest>(a =>
                         a.Message == "message"

--- a/Octokit.Tests/Reactive/ObservableRepositoryContentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryContentsClientTests.cs
@@ -596,7 +596,7 @@ namespace Octokit.Tests.Reactive
                 string expectedUri = "repos/org/repo/contents/path/to/file";
                 client.DeleteFile("org", "repo", "path/to/file", new DeleteFileRequest("message", "1234abc", "mybranch"));
 
-                gitHubClient.Connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+                gitHubClient.Connection.Received().Delete<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
             }
 
             [Fact]
@@ -609,7 +609,7 @@ namespace Octokit.Tests.Reactive
                 string expectedUri = "repositories/1/contents/path/to/file";
                 client.DeleteFile(1, "path/to/file", new DeleteFileRequest("message", "1234abc", "mybranch"));
 
-                gitHubClient.Connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+                gitHubClient.Connection.Received().Delete<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
             }
 
             [Fact]
@@ -621,7 +621,7 @@ namespace Octokit.Tests.Reactive
 
                 client.DeleteFile("org", "repo", "path/to/file", new DeleteFileRequest("message", "1234abc", "mybranch"));
 
-                gitHubClient.Connection.Received().Delete(
+                gitHubClient.Connection.Received().Delete<RepositoryContentChangeSet>(
                     Arg.Any<Uri>(),
                     Arg.Is<DeleteFileRequest>(a =>
                         a.Message == "message"
@@ -638,7 +638,7 @@ namespace Octokit.Tests.Reactive
 
                 client.DeleteFile(1, "path/to/file", new DeleteFileRequest("message", "1234abc", "mybranch"));
 
-                gitHubClient.Connection.Received().Delete(
+                gitHubClient.Connection.Received().Delete<RepositoryContentChangeSet>(
                     Arg.Any<Uri>(),
                     Arg.Is<DeleteFileRequest>(a =>
                         a.Message == "message"

--- a/Octokit/Clients/IRepositoryContentsClient.cs
+++ b/Octokit/Clients/IRepositoryContentsClient.cs
@@ -285,7 +285,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to delete</param>
-        Task DeleteFile(string owner, string name, string path, DeleteFileRequest request);
+        Task<RepositoryContentChangeSet> DeleteFile(string owner, string name, string path, DeleteFileRequest request);
 
         /// <summary>
         /// Creates a commit that deletes a file in a repository.
@@ -293,7 +293,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to delete</param>
-        Task DeleteFile(long repositoryId, string path, DeleteFileRequest request);
+        Task<RepositoryContentChangeSet> DeleteFile(long repositoryId, string path, DeleteFileRequest request);
     }
 
     /// <summary>

--- a/Octokit/Clients/RepositoryContentsClient.cs
+++ b/Octokit/Clients/RepositoryContentsClient.cs
@@ -499,7 +499,7 @@ namespace Octokit
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to delete</param>
         [ManualRoute("DELETE", "/repos/{owner}/{repo}/contents/{path}")]
-        public Task DeleteFile(string owner, string name, string path, DeleteFileRequest request)
+        public Task<RepositoryContentChangeSet> DeleteFile(string owner, string name, string path, DeleteFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -507,7 +507,7 @@ namespace Octokit
             Ensure.ArgumentNotNull(request, nameof(request));
 
             var deleteUrl = ApiUrls.RepositoryContent(owner, name, path);
-            return ApiConnection.Delete(deleteUrl, request);
+            return ApiConnection.Delete<RepositoryContentChangeSet>(deleteUrl, request);
         }
 
         /// <summary>
@@ -517,13 +517,13 @@ namespace Octokit
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to delete</param>
         [ManualRoute("DELETE", "/repositorioes/{id}/contents/{path}")]
-        public Task DeleteFile(long repositoryId, string path, DeleteFileRequest request)
+        public Task<RepositoryContentChangeSet> DeleteFile(long repositoryId, string path, DeleteFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(path, nameof(path));
             Ensure.ArgumentNotNull(request, nameof(request));
 
             var deleteUrl = ApiUrls.RepositoryContent(repositoryId, path);
-            return ApiConnection.Delete(deleteUrl, request);
+            return ApiConnection.Delete<RepositoryContentChangeSet>(deleteUrl, request);
         }
     }
 }


### PR DESCRIPTION
Fixes #3016

----

### Before the change?
The `RepositoryContentsClient.DeleteFile` currently only returns a `Task`. The API returns details of the commit where the file was deleted, but this is not currently returned by Octokit.

### After the change?
`DeleteFile` in both the `RepositoryContentsClient` and `ObservableRepositoryContentsClient` now return a `RepositoryContentChangeSet` like the `CreateFile` and `UpdateFile` methods.

The `Commit` property will contain details of the commit that was created to delete the file, and the `Content` property will always be null as documented in the [Repository Contents API documentation](https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#delete-a-file).

#### Testing
I've updated the unit tests to assert that we're calling the Delete method on the connection with the correct type, but I have not added any additional tests beyond that. This only changes the return type, and we don't test the mapping to this return type in the `CreateFile` or `UpdateFile` tests, so it didn't feel necessary here.

I've updated the integration tests to check that the commit message in the response matches what was passed in the request. The commit message feels like the most reliable, meaningful property to assert on (contents is `null` because we've just deleted the file). I've limited it to just one assertion as that aligns with the approach of the other requests in these integration tests, and gives enough confidence that the response is being mapped back correctly.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
I've opted to update the return type in the existing `DeleteFile` methods. This keeps the client tidy, but makes this a breaking change. If we wanted to avoid a breaking change we could do something like `DeleteFileAndReturnResult` (naming TBD), but this would be inconsistent with anything else in this client.

This is my first contribution, so I'm happy to follow the lead of someone with stronger opinions.

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [x] Yes
- [ ] No

----
