### PR TITLE
handle int32 overflow with Artifact.SizeInBytes

### DIFF
--- a/Octokit.Tests/Models/ArtifactsTests.cs
+++ b/Octokit.Tests/Models/ArtifactsTests.cs
@@ -10,7 +10,7 @@ namespace Octokit.Tests.Models
         public void CanBeDeserialized()
         {
           var json = @"{
-  ""total_count"": 2,
+  ""total_count"": 3,
   ""artifacts"": [
     {
       ""id"": 11,
@@ -49,6 +49,25 @@ namespace Octokit.Tests.Models
         ""head_branch"": ""main"",
         ""head_sha"": ""178f4f6090b3fccad4a65b3e83d076a622d59652""
       }
+    },
+    {
+      ""id"": 13,
+      ""node_id"": ""MDg6QXJ0aWZhY3QxMw=="",
+      ""name"": ""Large artifact with size more than MAX_INT32"",
+      ""size_in_bytes"": 2712782237,
+      ""url"": ""https://api.github.com/repos/octo-org/octo-docs/actions/artifacts/13"",
+      ""archive_download_url"": ""https://api.github.com/repos/octo-org/octo-docs/actions/artifacts/13/zip"",
+      ""expired"": false,
+      ""created_at"": ""2020-01-10T14:59:22Z"",
+      ""expires_at"": ""2020-03-21T14:59:22Z"",
+      ""updated_at"": ""2020-02-21T14:59:22Z"",
+      ""workflow_run"": {
+        ""id"": 2332942,
+        ""repository_id"": 1296269,
+        ""head_repository_id"": 1296269,
+        ""head_branch"": ""main"",
+        ""head_sha"": ""178f4f6090b3fccad4a65b3e83d076a622d59652""
+      }
     }
   ]
 }";
@@ -59,8 +78,8 @@ namespace Octokit.Tests.Models
 
           Assert.NotNull(payload);
           
-          Assert.Equal(2, payload.TotalCount);
-          Assert.Equal(2, payload.Artifacts.Count);
+          Assert.Equal(3, payload.TotalCount);
+          Assert.Equal(3, payload.Artifacts.Count);
           
           Assert.Equal(11, payload.Artifacts[0].Id);
           Assert.Equal("MDg6QXJ0aWZhY3QxMQ==", payload.Artifacts[0].NodeId);
@@ -93,6 +112,22 @@ namespace Octokit.Tests.Models
           Assert.Equal(1296269, payload.Artifacts[1].WorkflowRun.HeadRepositoryId);
           Assert.Equal("main", payload.Artifacts[1].WorkflowRun.HeadBranch);
           Assert.Equal("178f4f6090b3fccad4a65b3e83d076a622d59652", payload.Artifacts[1].WorkflowRun.HeadSha);
+
+          Assert.Equal(13, payload.Artifacts[2].Id);
+          Assert.Equal("MDg6QXJ0aWZhY3QxMw==", payload.Artifacts[2].NodeId);
+          Assert.Equal("Large artifact with size more than MAX_INT32", payload.Artifacts[2].Name);
+          Assert.Equal(2712782237, payload.Artifacts[2].SizeInBytes);
+          Assert.Equal("https://api.github.com/repos/octo-org/octo-docs/actions/artifacts/13", payload.Artifacts[2].Url);
+          Assert.Equal("https://api.github.com/repos/octo-org/octo-docs/actions/artifacts/13/zip", payload.Artifacts[2].ArchiveDownloadUrl);
+          Assert.False(payload.Artifacts[2].Expired);
+          Assert.Equal(new DateTime(2020, 1, 10, 14, 59, 22, DateTimeKind.Utc), payload.Artifacts[2].CreatedAt);
+          Assert.Equal(new DateTime(2020, 3, 21, 14, 59, 22, DateTimeKind.Utc), payload.Artifacts[2].ExpiresAt);
+          Assert.Equal(new DateTime(2020, 2, 21, 14, 59, 22, DateTimeKind.Utc), payload.Artifacts[2].UpdatedAt);
+          Assert.Equal(2332942, payload.Artifacts[2].WorkflowRun.Id);
+          Assert.Equal(1296269, payload.Artifacts[2].WorkflowRun.RepositoryId);
+          Assert.Equal(1296269, payload.Artifacts[2].WorkflowRun.HeadRepositoryId);
+          Assert.Equal("main", payload.Artifacts[2].WorkflowRun.HeadBranch);
+          Assert.Equal("178f4f6090b3fccad4a65b3e83d076a622d59652", payload.Artifacts[2].WorkflowRun.HeadSha);
         }
     }
 }

--- a/Octokit/Models/Response/Artifact.cs
+++ b/Octokit/Models/Response/Artifact.cs
@@ -11,7 +11,7 @@ namespace Octokit
         {
         }
 
-        public Artifact(long id, string nodeId, string name, int sizeInBytes, string url, string archiveDownloadUrl, bool expired, DateTime createdAt, DateTime expiresAt, DateTime updatedAt, ArtifactWorkflowRun workflowRun)
+        public Artifact(long id, string nodeId, string name, long sizeInBytes, string url, string archiveDownloadUrl, bool expired, DateTime createdAt, DateTime expiresAt, DateTime updatedAt, ArtifactWorkflowRun workflowRun)
         {
             Id = id;
             NodeId = nodeId;
@@ -44,7 +44,7 @@ namespace Octokit
         /// <summary>
         /// The size of the artifact in bytes
         /// </summary>
-        public int SizeInBytes { get; private set; }
+        public long SizeInBytes { get; private set; }
 
         /// <summary>
         /// The url for retrieving the artifact information


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves https://github.com/octokit/octokit.net/issues/3027

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* OverflowException for artifacts with size larger than MAX_INT32

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Correctly creates the `Artifact` object for such artifacts

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----
