### PR TITLE
Added `DownloadAsset` methods to `ReleaseClient`

### DIFF
--- a/Octokit/Clients/ReleasesClient.cs
+++ b/Octokit/Clients/ReleasesClient.cs
@@ -1,6 +1,8 @@
 ﻿using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Threading;
+using System.IO;
+using System;
 
 namespace Octokit
 {
@@ -499,6 +501,37 @@ namespace Octokit
         {
             var endpoint = ApiUrls.Asset(repositoryId, assetId);
             return ApiConnection.Get<ReleaseAsset>(endpoint);
+        }
+
+        /// <summary>
+        /// Gets a raw read-only stream containing the file data for the specified asset
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/releases/#get-a-single-release-asset">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="assetId">The id of the <see cref="ReleaseAsset"/></param>
+        [ManualRoute("GET", "/repositories/{id}/releases/assets/{asset_id}")]
+        public Task<Stream> DownloadAsset(long repositoryId, int assetId)
+        {
+            var endpoint = ApiUrls.Asset(repositoryId, assetId);
+            return ApiConnection.GetRawStream(endpoint, null, "application/octet-stream");
+        }
+
+        /// <summary>
+        /// Gets a raw read-only stream containing the file data for the specified asset
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/releases/#get-a-single-release-asset">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="assetId">The id of the <see cref="ReleaseAsset"/></param>
+        [ManualRoute("GET", "/repositories/{id}/releases/assets/{asset_id}")]
+        public Task<Stream> DownloadAsset(string owner, string name, int assetId)
+        {
+            var endpoint = ApiUrls.Asset(owner, name, assetId);
+            return ApiConnection.GetRawStream(endpoint, null, "application/octet-stream");
         }
 
         /// <summary>

--- a/Octokit/Http/ApiConnection.cs
+++ b/Octokit/Http/ApiConnection.cs
@@ -129,6 +129,31 @@ namespace Octokit
         /// Gets the raw content of the API resource at the specified URI.
         /// </summary>
         /// <param name="uri">URI of the API resource to get</param>
+        /// <param name="accepts">Accept header to use for the API request</param>
+        /// <param name="parameters">Parameters to add to the API request</param>
+        /// <returns>The API resource's raw content or <c>null</c> if the <paramref name="uri"/> points to a directory.</returns>
+        /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
+        public async Task<byte[]> GetRaw(Uri uri, IDictionary<string, string> parameters, string accepts)
+        {
+            Ensure.ArgumentNotNull(uri, nameof(uri));
+
+            var response = await Connection.GetRaw(uri, parameters, accepts).ConfigureAwait(false);
+            return response.Body;
+        }
+
+        /// <inheritdoc/>
+        public async Task<Stream> GetRawStream(Uri uri, IDictionary<string, string> parameters, string accepts)
+        {
+            Ensure.ArgumentNotNull(uri, nameof(uri));
+
+            var response = await Connection.GetRawStream(uri, parameters, accepts).ConfigureAwait(false);
+            return response.Body;
+        }
+
+        /// <summary>
+        /// Gets the raw content of the API resource at the specified URI.
+        /// </summary>
+        /// <param name="uri">URI of the API resource to get</param>
         /// <param name="parameters">Parameters to add to the API request</param>
         /// <returns>The API resource's raw content or <c>null</c> if the <paramref name="uri"/> points to a directory.</returns>
         /// <exception cref="ApiException">Thrown when an API error occurs.</exception>

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -229,6 +229,62 @@ namespace Octokit
         /// </summary>
         /// <param name="uri">URI endpoint to send request to</param>
         /// <param name="parameters">Querystring parameters for the request</param>
+        /// <param name="accepts">Accept header to use for the API request</param>
+        /// <returns><seealso cref="IResponse"/> representing the received HTTP response</returns>
+        /// <remarks>The <see cref="IResponse.Body"/> property will be <c>null</c> if the <paramref name="uri"/> points to a directory instead of a file</remarks>
+        public Task<IApiResponse<byte[]>> GetRaw(Uri uri, IDictionary<string, string> parameters, string accepts)
+        {
+            Ensure.ArgumentNotNull(uri, nameof(uri));
+
+            var req = new Request
+            {
+                Method = HttpMethod.Get,
+                BaseAddress = BaseAddress,
+                Endpoint = uri.ApplyParameters(parameters),
+            };
+            req.Headers.Add("Accept", accepts);
+
+            return GetRaw(req);
+        }
+
+        /// <inheritdoc/>
+        public Task<IApiResponse<byte[]>> GetRaw(Uri uri, IDictionary<string, string> parameters, TimeSpan timeout, string accepts)
+        {
+            Ensure.ArgumentNotNull(uri, nameof(uri));
+
+            var req = new Request
+            {
+                Method = HttpMethod.Get,
+                BaseAddress = BaseAddress,
+                Endpoint = uri.ApplyParameters(parameters),
+                Timeout = timeout
+            };
+            req.Headers.Add("Accept", accepts);
+
+            return GetRaw(req);
+        }
+
+        /// <inheritdoc/>
+        public Task<IApiResponse<Stream>> GetRawStream(Uri uri, IDictionary<string, string> parameters, string accepts)
+        {
+            Ensure.ArgumentNotNull(uri, nameof(uri));
+
+            var req = new Request
+            {
+                Method = HttpMethod.Get,
+                BaseAddress = BaseAddress,
+                Endpoint = uri.ApplyParameters(parameters)
+            };
+            req.Headers.Add("Accept", accepts);
+
+            return GetRawStream(req);
+        }
+
+        /// <summary>
+        /// Performs an asynchronous HTTP GET request that expects a <seealso cref="IResponse"/> containing raw data.
+        /// </summary>
+        /// <param name="uri">URI endpoint to send request to</param>
+        /// <param name="parameters">Querystring parameters for the request</param>
         /// <returns><seealso cref="IResponse"/> representing the received HTTP response</returns>
         /// <remarks>The <see cref="IResponse.Body"/> property will be <c>null</c> if the <paramref name="uri"/> points to a directory instead of a file</remarks>
         public Task<IApiResponse<byte[]>> GetRaw(Uri uri, IDictionary<string, string> parameters)
@@ -737,14 +793,16 @@ namespace Octokit
 
         async Task<IApiResponse<string>> GetHtml(IRequest request)
         {
-            request.Headers.Add("Accept", AcceptHeaders.StableVersionHtml);
+            if (request.Headers.ContainsKey("Accept") is false)
+                request.Headers.Add("Accept", AcceptHeaders.StableVersionHtml);
             var response = await RunRequest(request, CancellationToken.None).ConfigureAwait(false);
             return new ApiResponse<string>(response, response.Body as string);
         }
 
         async Task<IApiResponse<byte[]>> GetRaw(IRequest request)
         {
-            request.Headers.Add("Accept", AcceptHeaders.RawContentMediaType);
+            if (request.Headers.ContainsKey("Accept") is false)
+                request.Headers.Add("Accept", AcceptHeaders.RawContentMediaType);
             var response = await RunRequest(request, CancellationToken.None).ConfigureAwait(false);
 
             if (response.Body is Stream stream)
@@ -757,7 +815,8 @@ namespace Octokit
         
         async Task<IApiResponse<Stream>> GetRawStream(IRequest request)
         {
-            request.Headers.Add("Accept", AcceptHeaders.RawContentMediaType);
+            if (request.Headers.ContainsKey("Accept") is false)
+                request.Headers.Add("Accept", AcceptHeaders.RawContentMediaType);
             var response = await RunRequest(request, CancellationToken.None).ConfigureAwait(false);
             
             return new ApiResponse<Stream>(response, response.Body as Stream);

--- a/Octokit/Http/IApiConnection.cs
+++ b/Octokit/Http/IApiConnection.cs
@@ -67,6 +67,26 @@ namespace Octokit
         /// Gets the raw content of the API resource at the specified URI.
         /// </summary>
         /// <param name="uri">URI of the API resource to get</param>
+        /// <param name="accepts">Accept header to use for the API request</param>
+        /// <param name="parameters">Parameters to add to the API request</param>
+        /// <returns>The API resource's raw content or <c>null</c> if the <paramref name="uri"/> points to a directory.</returns>
+        /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
+        Task<byte[]> GetRaw(Uri uri, IDictionary<string, string> parameters, string accepts);
+
+        /// <summary>
+        /// Gets the raw stream of the API resource at the specified URI.
+        /// </summary>
+        /// <param name="uri">URI of the API resource to get</param>
+        /// <param name="parameters">Parameters to add to the API request</param>
+        /// <param name="accepts">Accept header to use for the API request</param>
+        /// <returns>The API resource's raw stream or <c>null</c> if the <paramref name="uri"/> points to a directory.</returns>
+        /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
+        Task<Stream> GetRawStream(Uri uri, IDictionary<string, string> parameters, string accepts);
+
+        /// <summary>
+        /// Gets the raw content of the API resource at the specified URI.
+        /// </summary>
+        /// <param name="uri">URI of the API resource to get</param>
         /// <param name="parameters">Parameters to add to the API request</param>
         /// <returns>The API resource's raw content or <c>null</c> if the <paramref name="uri"/> points to a directory.</returns>
         /// <exception cref="ApiException">Thrown when an API error occurs.</exception>

--- a/Octokit/Http/IConnection.cs
+++ b/Octokit/Http/IConnection.cs
@@ -27,6 +27,37 @@ namespace Octokit
         /// </summary>
         /// <param name="uri">URI endpoint to send request to</param>
         /// <param name="parameters">Querystring parameters for the request</param>
+        /// <param name="accepts">Accept header to use for the API request</param>
+        /// <returns><seealso cref="IResponse"/> representing the received HTTP response</returns>
+        /// <remarks>The <see cref="IResponse.Body"/> property will be <c>null</c> if the <paramref name="uri"/> points to a directory instead of a file</remarks>
+        Task<IApiResponse<byte[]>> GetRaw(Uri uri, IDictionary<string, string> parameters, string accepts);
+
+        /// <summary>
+        /// Performs an asynchronous HTTP GET request that expects a <seealso cref="IResponse"/> containing raw data.
+        /// </summary>
+        /// <param name="uri">URI endpoint to send request to</param>
+        /// <param name="parameters">Querystring parameters for the request</param>
+        /// <param name="accepts">Accept header to use for the API request</param>
+        /// <param name="timeout">The Timeout value</param>
+        /// <returns><seealso cref="IResponse"/> representing the received HTTP response</returns>
+        /// <remarks>The <see cref="IResponse.Body"/> property will be <c>null</c> if the <paramref name="uri"/> points to a directory instead of a file</remarks>
+        Task<IApiResponse<byte[]>> GetRaw(Uri uri, IDictionary<string, string> parameters, TimeSpan timeout, string accepts);
+
+        /// <summary>
+        /// Performs an asynchronous HTTP GET request that expects a <seealso cref="IResponse"/> containing raw data.
+        /// </summary>
+        /// <param name="uri">URI endpoint to send request to</param>
+        /// <param name="parameters">Querystring parameters for the request</param>
+        /// <param name="accepts">Accept header to use for the API request</param>
+        /// <returns><seealso cref="IResponse"/> representing the received HTTP response</returns>
+        /// <remarks>The <see cref="IResponse.Body"/> property will be <c>null</c> if the <paramref name="uri"/> points to a directory instead of a file</remarks>
+        Task<IApiResponse<Stream>> GetRawStream(Uri uri, IDictionary<string, string> parameters, string accepts);
+
+        /// <summary>
+        /// Performs an asynchronous HTTP GET request that expects a <seealso cref="IResponse"/> containing raw data.
+        /// </summary>
+        /// <param name="uri">URI endpoint to send request to</param>
+        /// <param name="parameters">Querystring parameters for the request</param>
         /// <returns><seealso cref="IResponse"/> representing the received HTTP response</returns>
         /// <remarks>The <see cref="IResponse.Body"/> property will be <c>null</c> if the <paramref name="uri"/> points to a directory instead of a file</remarks>
         Task<IApiResponse<byte[]>> GetRaw(Uri uri, IDictionary<string, string> parameters);


### PR DESCRIPTION
Resolves #3038

----

### Before the change?
Currently, to download a Release Asset, one would need to delve into ApiConnection and Connection objects, get a byte[] array and manually set the Accept header

It's bulky, and not much documentation is available for this

*

### After the change?
Two new easily discoverable methods are present in ReleaseClient: `Task<Stream> DownloadAsset(long, long)` and `Task<Stream> DownloadAsset(string, string, long)`
Even if no documentation is available, any good enough IDE can allow a programmer to discover the two methods and use them

I reviewed the tests but was unable to find a relevant test to modify -- The download uses the same string building techniques the rest of the API uses and that the tests try for
I did test it on my own machine, but didn't want to pollute the Tests set with file download tests when none are present (that I could find) even for obtaining response results

*

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
No breaking changes, lengths were taken to exclusively add and not modify nor remove

- [x] Yes
- [x] No

----

I'd like to additionally include that I didn't deem it necessary to update the documentation, but if there's anything that I missed, misunderstood, or that is pending for me to include, I would greatly appreciate being told, and I'll gladly do it!