### PR TITLE
Fix new tree deletion

### DIFF
--- a/Octokit.Tests.Integration/Clients/TreeClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/TreeClientTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Octokit;
 using Octokit.Tests.Integration;
@@ -142,6 +142,26 @@ public class TreeClientTests : IDisposable
 
         Assert.NotNull(result);
         Assert.Single(result.Tree);
+    }
+
+    [IntegrationTest]
+    public async Task CanDeleteACreatedTreeWithRepositoryId()
+    {
+        var newTree = new NewTree();
+        newTree.Tree.Add(new NewTreeItem
+        {
+            Type = TreeType.Blob,
+            Path = "README.md",
+            Sha = null,
+            Mode = FileMode.File
+        });
+
+        var tree = await _fixture.Create(_context.Repository.Id, newTree);
+
+        var result = await _fixture.Get(_context.Repository.Id, tree.Sha);
+
+        Assert.NotNull(result);
+        Assert.Empty(result.Tree);
     }
 
     public void Dispose()

--- a/Octokit/Models/Request/NewTreeItem.cs
+++ b/Octokit/Models/Request/NewTreeItem.cs
@@ -1,6 +1,7 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using Octokit.Internal;
 
 namespace Octokit
 {
@@ -16,9 +17,9 @@ namespace Octokit
         public string Path { get; set; }
 
         /// <summary>
-        /// String of the file mode - one of 100644 for file (blob), 
-        /// 100755 for executable (blob), 040000 for subdirectory (tree), 
-        /// 160000 for submodule (commit) or 
+        /// String of the file mode - one of 100644 for file (blob),
+        /// 100755 for executable (blob), 040000 for subdirectory (tree),
+        /// 160000 for submodule (commit) or
         /// 120000 for a blob that specifies the path of a symlink
         /// </summary>
         public string Mode { get; set; }
@@ -31,11 +32,12 @@ namespace Octokit
 
         /// <summary>
         /// The SHA for this Tree item.
+        /// If both this and Content is null it will delete the item.
         /// </summary>
-        public string Sha { get; set; }
+        [SerializeNull] public string Sha { get; set; }
 
         /// <summary>
-        /// Gets or sets the content you want this file to have. GitHub will write this blob out and use that SHA 
+        /// Gets or sets the content you want this file to have. GitHub will write this blob out and use that SHA
         /// for this entry. Use either this, or tree.sha.
         /// </summary>
         /// <value>


### PR DESCRIPTION
Fixes #2836

----

### Before the change?

* When creating a tree with a null content & sha, we got this error from github: `Must supply either tree.sha or tree.content. Request will be rejected if both are present`
* Since `null` are not serialized, gh received neither a `sha` nor a `content` value in the tree and that caused the error.

### After the change?

* Actually serialize the `null` value of the `sha` to allow deletion of tree items.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

I made an integration test but running it is a bit of a pain, I noticed there's no CI on my fork and i am opening this PR to get CI runs x)

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
