### PR TITLE
Add Digest to ReleaseAsset.cs

### DIFF
--- a/Octokit/Models/Response/ReleaseAsset.cs
+++ b/Octokit/Models/Response/ReleaseAsset.cs
@@ -9,7 +9,7 @@ namespace Octokit
     {
         public ReleaseAsset() { }
 
-        public ReleaseAsset(string url, int id, string nodeId, string name, string label, string state, string contentType, int size, int downloadCount, DateTimeOffset createdAt, DateTimeOffset updatedAt, string browserDownloadUrl, Author uploader)
+        public ReleaseAsset(string url, int id, string nodeId, string name, string label, string state, string contentType, int size, string digest, int downloadCount, DateTimeOffset createdAt, DateTimeOffset updatedAt, string browserDownloadUrl, Author uploader)
         {
             Url = url;
             Id = id;
@@ -19,6 +19,7 @@ namespace Octokit
             State = state;
             ContentType = contentType;
             Size = size;
+            Digest = digest;
             DownloadCount = downloadCount;
             CreatedAt = createdAt;
             UpdatedAt = updatedAt;
@@ -44,6 +45,8 @@ namespace Octokit
         public string ContentType { get; private set; }
 
         public int Size { get; private set; }
+
+        public string Digest { get; private set; }
 
         public int DownloadCount { get; private set; }
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #3052

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

The current API does not expose the new [digest field that was added not so long ago](https://github.blog/changelog/2025-06-03-releases-now-expose-digests-for-release-assets/)

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Digest is available as a string property as shown on the GitHub API docs page

### Pull request checklist
- [X] Tests for the changes have been added (for bug fixes / features)
N/A no changes were required for the new property
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
N/A no relevant docs was found regarding ReleaseAssets properties

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes
- [X] No

According to the docs this does not introduce a breaking change as I'm modifying an SDK model, but technically the public constructor was modified and if someone was using this type in their project they might be impacted.
Please advise if the new digest parameter should be added as a last parameter with a default value so it doesn't break existing (albeit a weird) use case.

----
