### PR TITLE
BREAKING CHANGE: `Actions.Workflows.CreateDispatch` returns the workflow run details

### DIFF
--- a/Octokit.Reactive/Clients/IObservableActionsWorkflowsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableActionsWorkflowsClient.cs
@@ -21,7 +21,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository.</param>
         /// <param name="workflowFileName">The workflow file name.</param>
         /// <param name="createDispatch">The parameters to use to trigger the workflow run.</param>
-        IObservable<Unit> CreateDispatch(string owner, string name, string workflowFileName, CreateWorkflowDispatch createDispatch);
+        IObservable<WorkflowDispatch> CreateDispatch(string owner, string name, string workflowFileName, CreateWorkflowDispatch createDispatch);
 
         /// <summary>
         /// Manually triggers a GitHub Actions workflow run in a repository by slug.
@@ -33,7 +33,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository.</param>
         /// <param name="workflowId">The Id of the workflow.</param>
         /// <param name="createDispatch">The parameters to use to trigger the workflow run.</param>
-        IObservable<Unit> CreateDispatch(string owner, string name, long workflowId, CreateWorkflowDispatch createDispatch);
+        IObservable<WorkflowDispatch> CreateDispatch(string owner, string name, long workflowId, CreateWorkflowDispatch createDispatch);
 
         /// <summary>
         /// Manually triggers a GitHub Actions workflow run in a repository by Id.
@@ -44,7 +44,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="workflowFileName">The workflow file name.</param>
         /// <param name="createDispatch">The parameters to use to trigger the workflow run.</param>
-        IObservable<Unit> CreateDispatch(long repositoryId, string workflowFileName, CreateWorkflowDispatch createDispatch);
+        IObservable<WorkflowDispatch> CreateDispatch(long repositoryId, string workflowFileName, CreateWorkflowDispatch createDispatch);
 
         /// <summary>
         /// Manually triggers a GitHub Actions workflow run in a repository by Id.
@@ -55,7 +55,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="workflowId">The Id of the workflow.</param>
         /// <param name="createDispatch">The parameters to use to trigger the workflow run.</param>
-        IObservable<Unit> CreateDispatch(long repositoryId, long workflowId, CreateWorkflowDispatch createDispatch);
+        IObservable<WorkflowDispatch> CreateDispatch(long repositoryId, long workflowId, CreateWorkflowDispatch createDispatch);
         /// <summary>
         /// Disables a specific workflow in a repository by Id.
         /// </summary>

--- a/Octokit.Reactive/Clients/ObservableActionsWorkflowsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableActionsWorkflowsClient.cs
@@ -32,7 +32,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository.</param>
         /// <param name="workflowFileName">The workflow file name.</param>
         /// <param name="createDispatch">The parameters to use to trigger the workflow run.</param>
-        public IObservable<Unit> CreateDispatch(string owner, string name, string workflowFileName, CreateWorkflowDispatch createDispatch)
+        public IObservable<WorkflowDispatch> CreateDispatch(string owner, string name, string workflowFileName, CreateWorkflowDispatch createDispatch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -52,7 +52,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository.</param>
         /// <param name="workflowId">The Id of the workflow.</param>
         /// <param name="createDispatch">The parameters to use to trigger the workflow run.</param>
-        public IObservable<Unit> CreateDispatch(string owner, string name, long workflowId, CreateWorkflowDispatch createDispatch)
+        public IObservable<WorkflowDispatch> CreateDispatch(string owner, string name, long workflowId, CreateWorkflowDispatch createDispatch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -70,7 +70,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="workflowFileName">The workflow file name.</param>
         /// <param name="createDispatch">The parameters to use to trigger the workflow run.</param>
-        public IObservable<Unit> CreateDispatch(long repositoryId, string workflowFileName, CreateWorkflowDispatch createDispatch)
+        public IObservable<WorkflowDispatch> CreateDispatch(long repositoryId, string workflowFileName, CreateWorkflowDispatch createDispatch)
         {
             Ensure.ArgumentNotNullOrEmptyString(workflowFileName, nameof(workflowFileName));
             Ensure.ArgumentNotNull(createDispatch, nameof(createDispatch));
@@ -87,7 +87,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="workflowId">The Id of the workflow.</param>
         /// <param name="createDispatch">The parameters to use to trigger the workflow run.</param>
-        public IObservable<Unit> CreateDispatch(long repositoryId, long workflowId, CreateWorkflowDispatch createDispatch)
+        public IObservable<WorkflowDispatch> CreateDispatch(long repositoryId, long workflowId, CreateWorkflowDispatch createDispatch)
         {
             Ensure.ArgumentNotNull(createDispatch, nameof(createDispatch));
 

--- a/Octokit.Tests/Clients/ActionsWorkflowsClientTests.cs
+++ b/Octokit.Tests/Clients/ActionsWorkflowsClientTests.cs
@@ -41,7 +41,7 @@ namespace Octokit.Tests.Clients
 
                 await client.CreateDispatch("fake", "repo", 123, createDispatch);
 
-                connection.Received().Post<object>(
+                connection.Received().Post<WorkflowDispatch>(
                     Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/actions/workflows/123/dispatches"),
                     createDispatch);
             }
@@ -56,7 +56,7 @@ namespace Octokit.Tests.Clients
 
                 await client.CreateDispatch("fake", "repo", "main.yaml", createDispatch);
 
-                connection.Received().Post<object>(
+                connection.Received().Post<WorkflowDispatch>(
                     Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/actions/workflows/main.yaml/dispatches"),
                     createDispatch);
             }
@@ -71,7 +71,7 @@ namespace Octokit.Tests.Clients
 
                 await client.CreateDispatch(321, 123, createDispatch);
 
-                connection.Received().Post<object>(
+                connection.Received().Post<WorkflowDispatch>(
                     Arg.Is<Uri>(u => u.ToString() == "repositories/321/actions/workflows/123/dispatches"),
                     createDispatch);
             }
@@ -86,7 +86,7 @@ namespace Octokit.Tests.Clients
 
                 await client.CreateDispatch(321, "main.yaml", createDispatch);
 
-                connection.Received().Post<object>(
+                connection.Received().Post<WorkflowDispatch>(
                     Arg.Is<Uri>(u => u.ToString() == "repositories/321/actions/workflows/main.yaml/dispatches"),
                     createDispatch);
             }

--- a/Octokit.Tests/Models/CreateWorkflowDispatchTests.cs
+++ b/Octokit.Tests/Models/CreateWorkflowDispatchTests.cs
@@ -31,7 +31,7 @@ namespace Octokit.Tests.Models
 
             var payload = serializer.Serialize(item);
 
-            Assert.Equal(@"{""ref"":""main""}", payload);
+            Assert.Equal(@"{""ref"":""main"",""return_run_details"":true}", payload);
         }
 
         [Fact]
@@ -49,7 +49,7 @@ namespace Octokit.Tests.Models
 
             var payload = serializer.Serialize(item);
 
-            Assert.Equal(@"{""ref"":""main"",""inputs"":{""foo"":1,""bar"":""qux""}}", payload);
+            Assert.Equal(@"{""ref"":""main"",""inputs"":{""foo"":1,""bar"":""qux""},""return_run_details"":true}", payload);
         }
     }
 }

--- a/Octokit.Tests/Models/WorkflowDispatchTests.cs
+++ b/Octokit.Tests/Models/WorkflowDispatchTests.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Octokit.Internal;
+using Xunit;
+
+namespace Octokit.Tests.Models
+{
+    public class WorkflowDispatchTests
+    {
+        [Fact]
+        public void CanBeDeserialized()
+        {
+            const string json = @"{
+  ""workflow_run_id"": 21217723379,
+  ""run_url"": ""https://api.github.com/repos/octo-org/octo-repo/actions/runs/21217723379"",
+  ""html_url"": ""https://github.com/octo-org/octo-repo/actions/runs/21217723379""
+}";
+
+            var serializer = new SimpleJsonSerializer();
+
+            var payload = serializer.Deserialize<WorkflowDispatch>(json);
+
+            Assert.NotNull(payload);
+            Assert.Equal(21217723379, payload.WorkflowRunId);
+            Assert.Equal("https://api.github.com/repos/octo-org/octo-repo/actions/runs/21217723379", payload.RunUrl);
+            Assert.Equal("https://github.com/octo-org/octo-repo/actions/runs/21217723379", payload.HtmlUrl);
+        }
+    }
+}

--- a/Octokit/Clients/ActionsWorkflowsClient.cs
+++ b/Octokit/Clients/ActionsWorkflowsClient.cs
@@ -32,14 +32,14 @@ namespace Octokit
         /// <param name="workflowFileName">The workflow file name.</param>
         /// <param name="createDispatch">The parameters to use to trigger the workflow run.</param>
         [ManualRoute("POST", "/repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches")]
-        public Task CreateDispatch(string owner, string name, string workflowFileName, CreateWorkflowDispatch createDispatch)
+        public Task<WorkflowDispatch> CreateDispatch(string owner, string name, string workflowFileName, CreateWorkflowDispatch createDispatch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNullOrEmptyString(workflowFileName, nameof(workflowFileName));
             Ensure.ArgumentNotNull(createDispatch, nameof(createDispatch));
 
-            return ApiConnection.Post<object>(ApiUrls.ActionsDispatchWorkflow(owner, name, workflowFileName), createDispatch);
+            return ApiConnection.Post<WorkflowDispatch>(ApiUrls.ActionsDispatchWorkflow(owner, name, workflowFileName), createDispatch);
         }
 
         /// <summary>
@@ -53,13 +53,13 @@ namespace Octokit
         /// <param name="workflowId">The Id of the workflow.</param>
         /// <param name="createDispatch">The parameters to use to trigger the workflow run.</param>
         [ManualRoute("POST", "/repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches")]
-        public Task CreateDispatch(string owner, string name, long workflowId, CreateWorkflowDispatch createDispatch)
+        public Task<WorkflowDispatch> CreateDispatch(string owner, string name, long workflowId, CreateWorkflowDispatch createDispatch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(createDispatch, nameof(createDispatch));
 
-            return ApiConnection.Post<object>(ApiUrls.ActionsDispatchWorkflow(owner, name, workflowId), createDispatch);
+            return ApiConnection.Post<WorkflowDispatch>(ApiUrls.ActionsDispatchWorkflow(owner, name, workflowId), createDispatch);
         }
 
         /// <summary>
@@ -72,12 +72,12 @@ namespace Octokit
         /// <param name="workflowFileName">The workflow file name.</param>
         /// <param name="createDispatch">The parameters to use to trigger the workflow run.</param>
         [ManualRoute("POST", "/repositories/{id}/actions/workflows/{workflow_id}/dispatches")]
-        public Task CreateDispatch(long repositoryId, string workflowFileName, CreateWorkflowDispatch createDispatch)
+        public Task<WorkflowDispatch> CreateDispatch(long repositoryId, string workflowFileName, CreateWorkflowDispatch createDispatch)
         {
             Ensure.ArgumentNotNullOrEmptyString(workflowFileName, nameof(workflowFileName));
             Ensure.ArgumentNotNull(createDispatch, nameof(createDispatch));
 
-            return ApiConnection.Post<object>(ApiUrls.ActionsDispatchWorkflow(repositoryId, workflowFileName), createDispatch);
+            return ApiConnection.Post<WorkflowDispatch>(ApiUrls.ActionsDispatchWorkflow(repositoryId, workflowFileName), createDispatch);
         }
 
         /// <summary>
@@ -90,11 +90,11 @@ namespace Octokit
         /// <param name="workflowId">The Id of the workflow.</param>
         /// <param name="createDispatch">The parameters to use to trigger the workflow run.</param>
         [ManualRoute("POST", "/repositories/{id}/actions/workflows/{workflow_id}/dispatches")]
-        public Task CreateDispatch(long repositoryId, long workflowId, CreateWorkflowDispatch createDispatch)
+        public Task<WorkflowDispatch> CreateDispatch(long repositoryId, long workflowId, CreateWorkflowDispatch createDispatch)
         {
             Ensure.ArgumentNotNull(createDispatch, nameof(createDispatch));
 
-            return ApiConnection.Post<object>(ApiUrls.ActionsDispatchWorkflow(repositoryId, workflowId), createDispatch);
+            return ApiConnection.Post<WorkflowDispatch>(ApiUrls.ActionsDispatchWorkflow(repositoryId, workflowId), createDispatch);
         }
 
         /// <summary>

--- a/Octokit/Clients/IActionsWorkflowsClient.cs
+++ b/Octokit/Clients/IActionsWorkflowsClient.cs
@@ -20,7 +20,7 @@ namespace Octokit
         /// <param name="name">The name of the repository.</param>
         /// <param name="workflowFileName">The workflow file name.</param>
         /// <param name="createDispatch">The parameters to use to trigger the workflow run.</param>
-        Task CreateDispatch(string owner, string name, string workflowFileName, CreateWorkflowDispatch createDispatch);
+        Task<WorkflowDispatch> CreateDispatch(string owner, string name, string workflowFileName, CreateWorkflowDispatch createDispatch);
 
         /// <summary>
         /// Manually triggers a GitHub Actions workflow run in a repository by slug.
@@ -32,7 +32,7 @@ namespace Octokit
         /// <param name="name">The name of the repository.</param>
         /// <param name="workflowId">The Id of the workflow.</param>
         /// <param name="createDispatch">The parameters to use to trigger the workflow run.</param>
-        Task CreateDispatch(string owner, string name, long workflowId, CreateWorkflowDispatch createDispatch);
+        Task<WorkflowDispatch> CreateDispatch(string owner, string name, long workflowId, CreateWorkflowDispatch createDispatch);
 
         /// <summary>
         /// Manually triggers a GitHub Actions workflow run in a repository by Id.
@@ -43,7 +43,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="workflowFileName">The workflow file name.</param>
         /// <param name="createDispatch">The parameters to use to trigger the workflow run.</param>
-        Task CreateDispatch(long repositoryId, string workflowFileName, CreateWorkflowDispatch createDispatch);
+        Task<WorkflowDispatch> CreateDispatch(long repositoryId, string workflowFileName, CreateWorkflowDispatch createDispatch);
 
         /// <summary>
         /// Manually triggers a GitHub Actions workflow run in a repository by Id.
@@ -54,7 +54,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="workflowId">The Id of the workflow.</param>
         /// <param name="createDispatch">The parameters to use to trigger the workflow run.</param>
-        Task CreateDispatch(long repositoryId, long workflowId, CreateWorkflowDispatch createDispatch);
+        Task<WorkflowDispatch> CreateDispatch(long repositoryId, long workflowId, CreateWorkflowDispatch createDispatch);
 
         /// <summary>
         /// Disables a specific workflow in a repository by Id.

--- a/Octokit/Models/Request/CreateWorkflowDispatch.cs
+++ b/Octokit/Models/Request/CreateWorkflowDispatch.cs
@@ -30,6 +30,11 @@ namespace Octokit
         /// </summary>
         public IDictionary<string, object> Inputs { get; set; }
 
+        /// <summary>
+        /// Indicates that the details of the workflow run should be returned in the response.
+        /// </summary>
+        public bool ReturnRunDetails => true;
+
         internal string DebuggerDisplay
         {
             get

--- a/Octokit/Models/Response/WorkflowDispatch.cs
+++ b/Octokit/Models/Response/WorkflowDispatch.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace Octokit
+{
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class WorkflowDispatch
+    {
+        public WorkflowDispatch() { }
+
+        public WorkflowDispatch(long workflowRunId, string runUrl, string htmlUrl)
+        {
+            WorkflowRunId = workflowRunId;
+            RunUrl = runUrl;
+            HtmlUrl = htmlUrl;
+        }
+
+        /// <summary>
+        /// The Id for the dispatched workflow run.
+        /// </summary>
+        public long WorkflowRunId { get; private set; }
+
+        /// <summary>
+        /// The API URL for this dispatched workflow.
+        /// </summary>
+        public string RunUrl { get; private set; }
+
+        /// <summary>
+        /// The URL for the HTML view of this dispatched workflow.
+        /// </summary>
+        public string HtmlUrl { get; private set; }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format(CultureInfo.InvariantCulture, "WorkflowRunId: {0}", WorkflowRunId);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- https://github.blog/changelog/2026-02-19-workflow-dispatch-api-now-returns-run-ids/
- https://docs.github.com/en/rest/actions/workflows?apiVersion=2026-03-10#create-a-workflow-dispatch-event

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #3062

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* `Actions.Workflows.CreateDispatch` would not return anything (besides a `Task`).

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* `Actions.Workflows.CreateDispatch` will return the details of the workflow run. The details include the ID, an API URL and a HTML URL.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [x] Yes
- [ ] No

----
