### PR TITLE
Add Signature property to NewCommit as per documented API

### DIFF
--- a/Octokit/Models/Request/NewCommit.cs
+++ b/Octokit/Models/Request/NewCommit.cs
@@ -96,6 +96,15 @@ namespace Octokit
         /// </value>
         public Committer Committer { get; set; }
 
+        /// <summary>
+        /// Gets or sets the PGP signature of the commit.
+        /// If provided, the commit will be created with this signature.
+        /// </summary>
+        /// <value>
+        /// The signature.
+        /// </value>
+        public string Signature { get; set; }
+
         internal string DebuggerDisplay
         {
             get


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves [#3074](https://github.com/octokit/octokit.net/issues/3074)

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Signing Signatures required manually posting code, e.g.

```c#
  var endpoint = ApiUrls.CreateCommit(identity.OrganisationName, identity.RepositoryName);
        var request = new
        {
            Message = description,
            Tree = treeSha,
            Parents = parents,
            Committer = committer,
            Signature = signature
        };

        var response = await client.Connection.Post<Commit>(endpoint, request, "application/json", "application/json", (IDictionary<string, string>?)null, cancellationToken);
```

### After the change?

* We can use the existing NewCommit payload and api call.

e.g.

```c#
   var commit = new NewCommit(description, treeSha, parents)
        {
            Committer = committer,
            Signature = signature
        };
  var response = await client.Commit.Create(organisationName, repositoryName, commit);
```

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
