### PR TITLE
fix: add Enterprise account type to AccountType enum

### DIFF
--- a/Octokit.Tests/SimpleJsonSerializerTests.cs
+++ b/Octokit.Tests/SimpleJsonSerializerTests.cs
@@ -283,6 +283,22 @@ namespace Octokit.Tests
                 Assert.Equal(new DateTimeOffset(2014, 07, 07, 00, 12, 56, TimeSpan.Zero), result.UpdatedAt);
             }
 
+            [Theory]
+            [InlineData("Enterprise")]
+            [InlineData("enterprise")]
+            public void CanDeserializeEnterpriseOwnedAccount(string type)
+            {
+                var json = "{" +
+                  "\"login\": \"acme-enterprise\"," +
+                  "\"id\": 12345," +
+                  "\"type\": \"" + type + "\"" +
+                "}";
+
+                var result = new SimpleJsonSerializer().Deserialize<User>(json);
+
+                Assert.Equal(AccountType.Enterprise, result.Type);
+            }
+
             [Fact]
             public void DeserializesInheritedProperties()
             {

--- a/Octokit/Models/Response/AccountType.cs
+++ b/Octokit/Models/Response/AccountType.cs
@@ -22,11 +22,17 @@ namespace Octokit
         [Parameter(Value = "Bot")]
         Bot,
 
-	/// <summary>
-	/// Mannequin account - all user activity in the migrated repository (except Git commits) 
-	/// 			is attributed to placeholder identities called mannequins.
-	/// </summary>
-	[Parameter(Value = "Mannequin")]
-	Mannequin
+        /// <summary>
+        /// Mannequin account - all user activity in the migrated repository (except Git commits)
+        /// 			is attributed to placeholder identities called mannequins.
+        /// </summary>
+        [Parameter(Value = "Mannequin")]
+        Mannequin,
+
+        /// <summary>
+        /// Enterprise account
+        /// </summary>
+        [Parameter(Value = "Enterprise")]
+        Enterprise
     }
 }


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #3081

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

Deserializing an account with `type = "enterprise"` (returned by enterprise-owned GitHub Apps, GA'd 2025-03-10) throws `System.ArgumentException: Requested value 'enterprise' was not found`, because `AccountType` has no
`Enterprise` member and `Account.Type` is a raw enum that parses strictly.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Added `Enterprise` to the `AccountType` enum. Accounts with `type = "enterprise"` now deserialize to `AccountType.Enterprise`. Both `"Enterprise"` (exact `[Parameter]` match) and `"enterprise"` (case-insensitive `Enum.Parse` fallback) resolve correctly.

Related prior art: #2998 (bug), #2999 (earlier fix, auto-closed by the stale bot before merge).

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
