### PR TITLE
Fix RepositoryFormatException for repository names that start with a hyphen

### DIFF
--- a/Octokit.Tests/Clients/SearchClientTests.cs
+++ b/Octokit.Tests/Clients/SearchClientTests.cs
@@ -1587,6 +1587,21 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public void TestingTheRepoQualifier_RepoNameStartingWithHyphen()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new SearchClient(connection);
+                var request = new SearchIssuesRequest("something");
+                request.Repos.Add("octokit", "-repo-starting-with-hyphen");
+
+                client.SearchIssues(request);
+
+                connection.Received().Get<SearchIssuesResult>(
+                    Arg.Is<Uri>(u => u.ToString() == "search/issues"),
+                    Arg.Is<Dictionary<string, string>>(d => d["q"] == "something+repo:octokit/-repo-starting-with-hyphen"));
+            }
+
+            [Fact]
             public async Task ErrorOccursWhenSpecifyingInvalidFormatForRepos()
             {
                 var connection = Substitute.For<IApiConnection>();

--- a/Octokit.Tests/Helpers/StringExtensionsTests.cs
+++ b/Octokit.Tests/Helpers/StringExtensionsTests.cs
@@ -32,6 +32,22 @@ namespace Octokit.Tests.Helpers
             }
         }
 
+        public class TheIsNameWithOwnerFormatMethod
+        {
+            [InlineData("octokit/octokit.net", true)]
+            [InlineData("owner/-repo-starting-with-hyphen", true)]
+            [InlineData("owner/_repo_starting_with_underscore", true)]
+            [InlineData("owner/.github", true)]
+            [InlineData("my-org/my.repo_name-1", true)]
+            [InlineData("haha-business", false)]
+            [InlineData("", false)]
+            [Theory]
+            public void ProperlyDetectsNameWithOwnerStrings(string data, bool expected)
+            {
+                Assert.Equal(expected, data.IsNameWithOwnerFormat());
+            }
+        }
+
         public class TheToRubyCaseMethod
         {
             [Theory]

--- a/Octokit/Helpers/StringExtensions.cs
+++ b/Octokit/Helpers/StringExtensions.cs
@@ -139,7 +139,7 @@ namespace Octokit
         // the rule:
         // Username may only contain alphanumeric characters or single hyphens
         // and cannot begin or end with a hyphen
-        static readonly Regex nameWithOwner = new Regex("[a-z0-9.-]{1,}/[a-z0-9.-_]{1,}",
+        static readonly Regex nameWithOwner = new Regex("[a-z0-9.-]{1,}/[a-z0-9_.-]{1,}",
 #if HAS_REGEX_COMPILED_OPTIONS
             RegexOptions.Compiled |
 #endif


### PR DESCRIPTION
Fixes #3082

## Problem

Search requests that use the `Repos` collection throw `RepositoryFormatException` client-side for repository names that start with a hyphen (e.g. `myorg/-my-repo`), even though such names are valid on GitHub and the server-side search API accepts the corresponding `repo:` qualifier.

## Root cause

In the `nameWithOwner` validation regex, the name-part character class `[a-z0-9.-_]` does not contain three literal punctuation characters — `.-_` is a character **range** (0x2E–0x5F). The literal `-` (0x2D) sits just below the range start, so it is not in the class, and any name whose *first* character is `-` fails to match right after the `/` (mid-name hyphens still pass only because the regex is unanchored).

This regressed in #1418 (the fix for #1406, leading-underscore names): appending `_` after the previously *trailing* literal `-` turned `.-` + `_` into the `.-_` range.

## Fix

Reorder the class so all three specials are literals — `.-_` → `_.-`:

```diff
-        static readonly Regex nameWithOwner = new Regex("[a-z0-9.-]{1,}/[a-z0-9.-_]{1,}",
+        static readonly Regex nameWithOwner = new Regex("[a-z0-9.-]{1,}/[a-z0-9_.-]{1,}",
```

Leading-hyphen names now validate; leading-underscore (#1406) and leading-dot (`.github`) names keep working. As a side effect the accidental range no longer admits characters that can never appear in a repository name (`/ : ; < = > ? @ [ \ ] ^`), so the validation also becomes slightly stricter in the correct direction.

## Tests

- `StringExtensionsTests.TheIsNameWithOwnerFormatMethod` — new theory covering leading-hyphen, leading-underscore, leading-dot, regular names, and invalid input.
- `SearchClientTests.TestingTheRepoQualifier_RepoNameStartingWithHyphen` — end-to-end: `SearchIssues` sends `repo:octokit/-repo-starting-with-hyphen` instead of throwing.
- Full `Octokit.Tests` unit suite: 4550 passed / 4 failed — the 4 failures are the `CanPopulateObjectFromSerializedData` (BinaryFormatter) tests, which fail identically on unmodified `main` under the .NET 10 runtime used locally (BinaryFormatter is disabled in .NET 9+); they are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
