### PR TITLE
Fix CodespaceLocation locations and machine CPU cores metric

### DIFF
--- a/Octokit/Clients/Machine.cs
+++ b/Octokit/Clients/Machine.cs
@@ -11,16 +11,17 @@ namespace Octokit
         public string OperatingSystem { get; private set; }
         public long StorageInBytes { get; private set; }
         public long MemoryInBytes { get; private set; }
-        public long CpuCount { get; private set; }
+        public long CpuCount => Cpus;
+        public long Cpus { get; private set; }
 
-        public Machine(string name, string displayName, string operatingSystem, long storageInBytes, long memoryInBytes, long cpuCount)
+        public Machine(string name, string displayName, string operatingSystem, long storageInBytes, long memoryInBytes, long cpus)
         {
             Name = name;
             DisplayName = displayName;
             OperatingSystem = operatingSystem;
             StorageInBytes = storageInBytes;
             MemoryInBytes = memoryInBytes;
-            CpuCount = cpuCount;
+            Cpus = cpus;
         }
 
         public Machine() { }

--- a/Octokit/Models/Common/CodespaceLocation.cs
+++ b/Octokit/Models/Common/CodespaceLocation.cs
@@ -4,13 +4,13 @@ namespace Octokit
 {
     public enum CodespaceLocation
     {
-        [Parameter(Value = "EuropeWest")]
-        EuropeWest,
-        [Parameter(Value = "SoutheastAsia")]
-        SoutheastAsia,
-        [Parameter(Value = "UsEast")]
-        UsEast,
-        [Parameter(Value = "UsWest")]
-        UsWest
+        [Parameter(Value = "WestEurope")]
+        WestEurope,
+        [Parameter(Value = "SouthEastAsia")]
+        SouthEastAsia,
+        [Parameter(Value = "EastUs")]
+        EastUs,
+        [Parameter(Value = "WestUs2")]
+        WestUs2
     }
 }


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #3086

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

Machine.CpuCount does no longer propagate the correct value as the field was renamed to Cpus.

The CodespaceLocation enum is outdated.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Adds a new Machine.Cpus field and Machine.CpuCount stays as an alias.
* All the old CodespaceLocation values have been removed and were replaced with the current ones.

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [x] Yes
- [ ] No

----
