### PR TITLE
Support duplicate issue state reason

### DIFF
--- a/Octokit.Tests/Models/IssueTest.cs
+++ b/Octokit.Tests/Models/IssueTest.cs
@@ -308,5 +308,21 @@ public class IssueTest
             Assert.Equal("octocat", update.Assignees.FirstOrDefault());
             Assert.Equal(ItemStateReason.Reopened, update.StateReason.GetValueOrDefault());
         }
+
+        [Fact]
+        public void PreservesDuplicateStateReason()
+        {
+            const string json = @"{
+""state"": ""closed"",
+""state_reason"": ""duplicate""
+}";
+            var serializer = new SimpleJsonSerializer();
+            var issue = serializer.Deserialize<Issue>(json);
+
+            var update = issue.ToUpdate();
+
+            Assert.Equal(ItemStateReason.Duplicate, update.StateReason.GetValueOrDefault());
+            Assert.Contains(@"""state_reason"":""duplicate""", serializer.Serialize(update));
+        }
     }
 }

--- a/Octokit/Models/Request/IssueRequest.cs
+++ b/Octokit/Models/Request/IssueRequest.cs
@@ -188,7 +188,13 @@ namespace Octokit
       /// Item reopened.
       /// </summary>
       [Parameter(Value = "reopened")]
-      Reopened
+      Reopened,
+
+      /// <summary>
+      /// Item closed as a duplicate.
+      /// </summary>
+      [Parameter(Value = "duplicate")]
+      Duplicate
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Add `ItemStateReason.Duplicate` for the `duplicate` value now returned by GitHub's Issues API.

GitHub can return `state_reason: "duplicate"` for issues closed as duplicates. Because Octokit does not currently model that value, accessing `Issue.StateReason.Value` throws, and `Issue.ToUpdate()` cannot preserve the reason. Applications that fetch an issue and update another field can consequently resend a closed state without its reason, causing GitHub to change the close reason to `completed`.

The regression test verifies the complete response-to-request path: deserialize an issue with the duplicate reason, convert it with `ToUpdate()`, and serialize the update back to `state_reason: "duplicate"`.

Fixes #3045.

> [!NOTE]
> This pull request was prepared with GitHub Copilot.